### PR TITLE
[STEP S02] Supabase client & SSR auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Supabase configuration
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"
+# Optional server-side keys (used in later steps)
+SUPABASE_SERVICE_ROLE_KEY=""
+SUPABASE_JWT_SECRET=""

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -51,10 +51,15 @@ feat(step {id}): {title}
     * Introduced a TypeScript snapshot runner with a JSON baseline under `tests/snapshots`.
     * Exposed snapshot verify/update scripts via `npm test`.
   * PR: https://github.com/Hamernick/coach-house-lms/pull/2
-* [ ] **S02** — Supabase client & SSR auth
+* [x] **S02** — Supabase client & SSR auth
 
   * SSR cookie wiring; typed client in `src/lib/supabase`; envs; helper hooks.
   * **Accept**: server and client examples reading user session.
+  * **Changelog**:
+    * Added Supabase env validation and typed client factories for server, browser, and route handlers.
+    * Dashboard now fetches the session server-side and hydrates a `SessionPreview` client widget.
+    * Documented required Supabase env vars in `.env.example`.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/3
 * [ ] **S03** — DB schema & RLS (migrations)
 
   * Create tables per AGENTS §4; indexes; uniques; RLS policies; profiles with roles.

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -2,7 +2,9 @@ import { AppSidebar } from "@/components/app-sidebar"
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 import { DataTable } from "@/components/data-table"
 import { SectionCards } from "@/components/section-cards"
+import { SessionPreview } from "@/components/session-preview"
 import { SiteHeader } from "@/components/site-header"
+import { createSupabaseServerClient } from "@/lib/supabase"
 import {
   SidebarInset,
   SidebarProvider,
@@ -10,7 +12,12 @@ import {
 
 import data from "./data.json"
 
-export default function Page() {
+export default async function Page() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
   return (
     <SidebarProvider
       style={
@@ -26,6 +33,9 @@ export default function Page() {
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">
             <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+              <div className="px-4 lg:px-6">
+                <SessionPreview initialSession={session} />
+              </div>
               <SectionCards />
               <div className="px-4 lg:px-6">
                 <ChartAreaInteractive />

--- a/src/components/session-preview.tsx
+++ b/src/components/session-preview.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type { Session } from "@supabase/supabase-js"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+type SessionPreviewProps = {
+  initialSession: Session | null
+}
+
+export function SessionPreview({ initialSession }: SessionPreviewProps) {
+  const supabase = useSupabaseClient()
+  const [session, setSession] = useState<Session | null>(initialSession)
+
+  useEffect(() => {
+    let active = true
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (active) {
+        setSession(data.session ?? null)
+      }
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (active) {
+        setSession(nextSession)
+      }
+    })
+
+    return () => {
+      active = false
+      subscription.unsubscribe()
+    }
+  }, [supabase])
+
+  const isSignedIn = Boolean(session)
+  const label = isSignedIn ? "Signed in" : "Signed out"
+  const description = isSignedIn
+    ? session?.user.email ?? session?.user.user_metadata?.full_name ?? session?.user.id
+    : "Authenticate to populate the session."
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="space-y-3">
+        <CardTitle>Supabase session</CardTitle>
+        <CardDescription>
+          Server components fetch the initial session; this widget stays in sync on
+          the client.
+        </CardDescription>
+        <Badge variant={isSignedIn ? "default" : "outline"}>{label}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <p className="text-muted-foreground">{description}</p>
+        {isSignedIn ? (
+          <pre className="max-h-40 overflow-auto rounded-lg bg-muted/40 p-3 text-xs">
+            {JSON.stringify(
+              {
+                id: session?.user.id,
+                email: session?.user.email,
+                expires_at: session?.expires_at,
+              },
+              null,
+              2
+            )}
+          </pre>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/hooks/use-supabase-client.ts
+++ b/src/hooks/use-supabase-client.ts
@@ -1,0 +1,9 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { createSupabaseBrowserClient } from "@/lib/supabase/client"
+
+export function useSupabaseClient() {
+  return useMemo(() => createSupabaseBrowserClient(), [])
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,42 @@
+import { z } from "zod"
+
+const serverEnvSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
+  SUPABASE_JWT_SECRET: z.string().min(1).optional(),
+})
+
+const clientEnvSchema = serverEnvSchema.pick({
+  NEXT_PUBLIC_SUPABASE_URL: true,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: true,
+})
+
+type ServerEnv = z.infer<typeof serverEnvSchema>
+type ClientEnv = z.infer<typeof clientEnvSchema>
+
+function assertEnv<TSchema extends z.ZodTypeAny>(schema: TSchema, input: unknown) {
+  const parsed = schema.safeParse(input)
+
+  if (!parsed.success) {
+    const formatted = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "unknown"}: ${issue.message}`)
+      .join("; ")
+
+    throw new Error(`Invalid environment variables: ${formatted}`)
+  }
+
+  return parsed.data
+}
+
+export const env: ServerEnv = assertEnv(serverEnvSchema, {
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  SUPABASE_JWT_SECRET: process.env.SUPABASE_JWT_SECRET,
+})
+
+export const clientEnv: ClientEnv = assertEnv(clientEnvSchema, {
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+})

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,17 @@
+import { createBrowserClient } from "@supabase/ssr"
+
+import { clientEnv } from "@/lib/env"
+import type { Database } from "./types"
+
+let browserClient: ReturnType<typeof createBrowserClient<Database>> | undefined
+
+export function createSupabaseBrowserClient() {
+  if (!browserClient) {
+    browserClient = createBrowserClient<Database>(
+      clientEnv.NEXT_PUBLIC_SUPABASE_URL,
+      clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    )
+  }
+
+  return browserClient
+}

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -1,0 +1,4 @@
+export type { Database, Json } from "./types"
+export { createSupabaseBrowserClient } from "./client"
+export { createSupabaseServerClient } from "./server"
+export { createSupabaseRouteHandlerClient } from "./route"

--- a/src/lib/supabase/route.ts
+++ b/src/lib/supabase/route.ts
@@ -1,0 +1,28 @@
+import { createServerClient } from "@supabase/ssr"
+import type { NextRequest, NextResponse } from "next/server"
+
+import { env } from "@/lib/env"
+import type { Database } from "./types"
+
+export function createSupabaseRouteHandlerClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  return createServerClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return request.cookies.get(name)?.value
+        },
+        set(name, value, options) {
+          response.cookies.set({ name, value, ...options })
+        },
+        remove(name, options) {
+          response.cookies.set({ name, value: "", ...options, maxAge: 0 })
+        },
+      },
+    }
+  )
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,31 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
+import { env } from "@/lib/env"
+import type { Database } from "./types"
+
+export function createSupabaseServerClient() {
+  const cookieStore = cookies() as unknown as {
+    get: (name: string) => { value: string } | undefined
+    set?: (options: { name: string; value: string } & CookieOptions) => void
+    delete?: (name: string) => void
+  }
+
+  return createServerClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(name) {
+          return cookieStore.get(name)?.value
+        },
+        set(name, value, options) {
+          cookieStore.set?.({ name, value, ...options })
+        },
+        remove(name) {
+          cookieStore.delete?.(name)
+        },
+      },
+    }
+  )
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,17 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: Record<string, never>
+    Views: Record<string, never>
+    Functions: Record<string, never>
+    Enums: Record<string, never>
+    CompositeTypes: Record<string, never>
+  }
+}


### PR DESCRIPTION
**Summary**
- add typed Supabase client factories for server components, route handlers, and browser usage with env validation
- hydrate the dashboard with a server-fetched session feeding a `SessionPreview` client widget and helper hook
- document required Supabase secrets in `.env.example`

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Session display uses static placeholder data until real auth lands.
