### PR TITLE
[STEP S03] DB schema & RLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Supabase configuration
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"
+# Optional server-side keys (used for scripts/tests)
+SUPABASE_SERVICE_ROLE_KEY=""
+SUPABASE_JWT_SECRET=""

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -55,10 +55,15 @@ feat(step {id}): {title}
 
   * SSR cookie wiring; typed client in `src/lib/supabase`; envs; helper hooks.
   * **Accept**: server and client examples reading user session.
-* [ ] **S03** — DB schema & RLS (migrations)
+* [x] **S03** — DB schema & RLS (migrations)
 
   * Create tables per AGENTS §4; indexes; uniques; RLS policies; profiles with roles.
   * **Accept**: migration up/down; RLS tests; seed script.
+  * **Changelog**:
+    * Added canonical migrations with triggers, enums, and RLS policies for profiles, classes, modules, enrollments, module progress, and subscriptions.
+    * Seeded sample curriculum data and published Supabase typings plus RLS verification script.
+    * Wired `npm run test:rls` to exercise policies (skips when Supabase credentials are absent).
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/4
 * [ ] **S04** — Auth flows
 
   * Signup/verify/signin/reset; guards; route middleware.

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -1,0 +1,31 @@
+# Database schema overview
+
+This repository uses Supabase (Postgres) for persistence. The canonical migration
+lives in `supabase/migrations/20250108150000_bootstrap_schema.sql` and creates the
+following entities:
+
+- `profiles`: 1:1 with `auth.users` and augmented with role metadata
+- `classes`: course container with publish state and Stripe linkage
+- `modules`: ordered lessons linked to `classes`
+- `enrollments`: join table mapping learners to classes
+- `module_progress`: per-module learner progress with completion metadata
+- `subscriptions`: billing and entitlement state mirrored from Stripe
+
+All tables have RLS enabled. Helper function `public.is_admin()` powers admin
+policies. Students (default role) can only access their own records and published
+content; admins (role `admin`) can manage everything.
+
+## Local workflow
+
+1. Apply migrations: `supabase db push` (or run the SQL manually against your
+   Postgres instance).
+2. Seed sample data: `psql $DATABASE_URL -f supabase/seed.sql`.
+3. Run RLS tests (requires a live Supabase project or local stack):
+   ```bash
+   SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... \\
+   SUPABASE_SERVICE_ROLE_KEY=... npm run test:rls
+   ```
+   The script provisions temporary users, verifies policies, and cleans up.
+
+Update `src/lib/supabase/types.ts` whenever the schema changes so TypeScript infers
+end-to-end types.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "snapshots:verify": "npm run snapshots:build && node -r ./dist-snapshots/scripts/register-alias.js dist-snapshots/scripts/generate-snapshots.js",
     "snapshots:update": "npm run snapshots:build && node -r ./dist-snapshots/scripts/register-alias.js dist-snapshots/scripts/generate-snapshots.js --update",
     "test:snapshots": "npm run snapshots:verify",
-    "test": "npm run test:snapshots"
+    "test": "npm run test:snapshots && npm run test:rls",
+    "test:rls": "node supabase/tests/rls.test.cjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,241 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string
+          full_name: string | null
+          avatar_url: string | null
+          headline: string | null
+          timezone: string | null
+          role: Database["public"]["Enums"]["user_role"]
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id: string
+          full_name?: string | null
+          avatar_url?: string | null
+          headline?: string | null
+          timezone?: string | null
+          role?: Database["public"]["Enums"]["user_role"]
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          full_name?: string | null
+          avatar_url?: string | null
+          headline?: string | null
+          timezone?: string | null
+          role?: Database["public"]["Enums"]["user_role"]
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      classes: {
+        Row: {
+          id: string
+          title: string
+          slug: string
+          description: string | null
+          stripe_product_id: string | null
+          stripe_price_id: string | null
+          published: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          title: string
+          slug: string
+          description?: string | null
+          stripe_product_id?: string | null
+          stripe_price_id?: string | null
+          published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          title?: string
+          slug?: string
+          description?: string | null
+          stripe_product_id?: string | null
+          stripe_price_id?: string | null
+          published?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      modules: {
+        Row: {
+          id: string
+          class_id: string
+          idx: number
+          slug: string
+          title: string
+          description: string | null
+          video_url: string | null
+          content_md: string | null
+          duration_minutes: number | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          class_id: string
+          idx: number
+          slug: string
+          title: string
+          description?: string | null
+          video_url?: string | null
+          content_md?: string | null
+          duration_minutes?: number | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          class_id?: string
+          idx?: number
+          slug?: string
+          title?: string
+          description?: string | null
+          video_url?: string | null
+          content_md?: string | null
+          duration_minutes?: number | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      enrollments: {
+        Row: {
+          id: string
+          user_id: string
+          class_id: string
+          status: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          class_id: string
+          status?: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          class_id?: string
+          status?: string
+          created_at?: string
+        }
+      }
+      module_progress: {
+        Row: {
+          id: string
+          user_id: string
+          module_id: string
+          status: Database["public"]["Enums"]["module_progress_status"]
+          completed_at: string | null
+          notes: Json | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          module_id: string
+          status?: Database["public"]["Enums"]["module_progress_status"]
+          completed_at?: string | null
+          notes?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          module_id?: string
+          status?: Database["public"]["Enums"]["module_progress_status"]
+          completed_at?: string | null
+          notes?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      subscriptions: {
+        Row: {
+          id: string
+          user_id: string
+          stripe_customer_id: string | null
+          stripe_subscription_id: string
+          status: Database["public"]["Enums"]["subscription_status"]
+          current_period_end: string | null
+          cancel_at: string | null
+          canceled_at: string | null
+          created_at: string
+          updated_at: string
+          metadata: Json | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id: string
+          status?: Database["public"]["Enums"]["subscription_status"]
+          current_period_end?: string | null
+          cancel_at?: string | null
+          canceled_at?: string | null
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string
+          status?: Database["public"]["Enums"]["subscription_status"]
+          current_period_end?: string | null
+          cancel_at?: string | null
+          canceled_at?: string | null
+          created_at?: string
+          updated_at?: string
+          metadata?: Json | null
+        }
+      }
+    }
+    Views: Record<string, never>
+    Functions: {
+      is_admin: {
+        Args: Record<string, never>
+        Returns: boolean
+      }
+      handle_updated_at: {
+        Args: Record<string, never>
+        Returns: unknown
+      }
+    }
+    Enums: {
+      user_role: "student" | "admin"
+      module_progress_status: "not_started" | "in_progress" | "completed"
+      subscription_status:
+        | "trialing"
+        | "active"
+        | "past_due"
+        | "canceled"
+        | "incomplete"
+        | "incomplete_expired"
+    }
+    CompositeTypes: Record<string, never>
+  }
+}

--- a/supabase/migrations/20250108150000_bootstrap_schema.down.sql
+++ b/supabase/migrations/20250108150000_bootstrap_schema.down.sql
@@ -1,0 +1,54 @@
+set search_path = public;
+
+DROP POLICY IF EXISTS "subscriptions_admin_manage" ON subscriptions;
+DROP POLICY IF EXISTS "subscriptions_self_update" ON subscriptions;
+DROP POLICY IF EXISTS "subscriptions_self_read" ON subscriptions;
+DROP POLICY IF EXISTS "progress_admin_manage" ON module_progress;
+DROP POLICY IF EXISTS "progress_self_update" ON module_progress;
+DROP POLICY IF EXISTS "progress_self_upsert" ON module_progress;
+DROP POLICY IF EXISTS "progress_self_access" ON module_progress;
+DROP POLICY IF EXISTS "enrollments_admin_manage" ON enrollments;
+DROP POLICY IF EXISTS "enrollments_self_insert" ON enrollments;
+DROP POLICY IF EXISTS "enrollments_self_read" ON enrollments;
+DROP POLICY IF EXISTS "modules_admin_manage" ON modules;
+DROP POLICY IF EXISTS "modules_view_published" ON modules;
+DROP POLICY IF EXISTS "classes_admin_manage" ON classes;
+DROP POLICY IF EXISTS "classes_view_enrolled" ON classes;
+DROP POLICY IF EXISTS "classes_view_published" ON classes;
+DROP POLICY IF EXISTS "profiles_admin_manage" ON profiles;
+DROP POLICY IF EXISTS "profiles_self_insert" ON profiles;
+DROP POLICY IF EXISTS "profiles_self_update" ON profiles;
+DROP POLICY IF EXISTS "profiles_self_manage" ON profiles;
+
+ALTER TABLE subscriptions DISABLE ROW LEVEL SECURITY;
+ALTER TABLE module_progress DISABLE ROW LEVEL SECURITY;
+ALTER TABLE enrollments DISABLE ROW LEVEL SECURITY;
+ALTER TABLE modules DISABLE ROW LEVEL SECURITY;
+ALTER TABLE classes DISABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS public.is_admin();
+DROP TRIGGER IF EXISTS set_updated_at_subscriptions ON subscriptions;
+DROP TRIGGER IF EXISTS set_updated_at_module_progress ON module_progress;
+DROP TRIGGER IF EXISTS set_updated_at_modules ON modules;
+DROP TRIGGER IF EXISTS set_updated_at_classes ON classes;
+DROP TRIGGER IF EXISTS set_updated_at_profiles ON profiles;
+DROP FUNCTION IF EXISTS public.handle_updated_at();
+
+DROP INDEX IF EXISTS subscriptions_user_id_idx;
+DROP INDEX IF EXISTS module_progress_module_id_idx;
+DROP INDEX IF EXISTS module_progress_user_id_idx;
+DROP INDEX IF EXISTS enrollments_class_id_idx;
+DROP INDEX IF EXISTS enrollments_user_id_idx;
+DROP INDEX IF EXISTS modules_class_id_idx;
+
+DROP TABLE IF EXISTS subscriptions;
+DROP TABLE IF EXISTS module_progress;
+DROP TABLE IF EXISTS enrollments;
+DROP TABLE IF EXISTS modules;
+DROP TABLE IF EXISTS classes;
+DROP TABLE IF EXISTS profiles;
+
+DROP TYPE IF EXISTS subscription_status;
+DROP TYPE IF EXISTS module_progress_status;
+DROP TYPE IF EXISTS user_role;

--- a/supabase/migrations/20250108150000_bootstrap_schema.sql
+++ b/supabase/migrations/20250108150000_bootstrap_schema.sql
@@ -1,0 +1,261 @@
+-- Bootstrap domain schema, constraints, and RLS policies for Coach House LMS.
+set check_function_bodies = off;
+set search_path = public;
+
+create extension if not exists "pgcrypto";
+
+create type user_role as enum ('student', 'admin');
+create type module_progress_status as enum ('not_started', 'in_progress', 'completed');
+create type subscription_status as enum (
+  'trialing',
+  'active',
+  'past_due',
+  'canceled',
+  'incomplete',
+  'incomplete_expired'
+);
+
+create table profiles (
+  id uuid primary key references auth.users on delete cascade,
+  full_name text,
+  avatar_url text,
+  headline text,
+  timezone text,
+  role user_role not null default 'student',
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table classes (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  slug text not null unique,
+  description text,
+  stripe_product_id text,
+  stripe_price_id text,
+  published boolean not null default false,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table modules (
+  id uuid primary key default gen_random_uuid(),
+  class_id uuid not null references classes on delete cascade,
+  idx integer not null,
+  slug text not null,
+  title text not null,
+  description text,
+  video_url text,
+  content_md text,
+  duration_minutes integer,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (class_id, idx),
+  unique (class_id, slug)
+);
+
+create table enrollments (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users on delete cascade,
+  class_id uuid not null references classes on delete cascade,
+  status text not null default 'active',
+  created_at timestamptz not null default timezone('utc', now()),
+  unique (user_id, class_id)
+);
+
+create table module_progress (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users on delete cascade,
+  module_id uuid not null references modules on delete cascade,
+  status module_progress_status not null default 'not_started',
+  completed_at timestamptz,
+  notes jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (user_id, module_id)
+);
+
+create table subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users on delete cascade,
+  stripe_customer_id text,
+  stripe_subscription_id text not null,
+  status subscription_status not null default 'trialing',
+  current_period_end timestamptz,
+  cancel_at timestamptz,
+  canceled_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  metadata jsonb,
+  unique (user_id, stripe_subscription_id)
+);
+
+create index enrollments_user_id_idx on enrollments (user_id);
+create index enrollments_class_id_idx on enrollments (class_id);
+create index module_progress_user_id_idx on module_progress (user_id);
+create index module_progress_module_id_idx on module_progress (module_id);
+create index modules_class_id_idx on modules (class_id);
+create index subscriptions_user_id_idx on subscriptions (user_id);
+
+create or replace function public.handle_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+create trigger set_updated_at_profiles
+before update on profiles
+for each row execute procedure public.handle_updated_at();
+
+create trigger set_updated_at_classes
+before update on classes
+for each row execute procedure public.handle_updated_at();
+
+create trigger set_updated_at_modules
+before update on modules
+for each row execute procedure public.handle_updated_at();
+
+create trigger set_updated_at_module_progress
+before update on module_progress
+for each row execute procedure public.handle_updated_at();
+
+create trigger set_updated_at_subscriptions
+before update on subscriptions
+for each row execute procedure public.handle_updated_at();
+
+create or replace function public.is_admin()
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_role user_role;
+begin
+  select role into current_role from profiles where id = auth.uid();
+  return current_role = 'admin';
+exception when others then
+  return false;
+end;
+$$;
+
+
+revoke all on function public.is_admin() from public;
+grant execute on function public.is_admin() to authenticated;
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE classes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE modules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE enrollments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE module_progress ENABLE ROW LEVEL SECURITY;
+ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE profiles FORCE ROW LEVEL SECURITY;
+ALTER TABLE classes FORCE ROW LEVEL SECURITY;
+ALTER TABLE modules FORCE ROW LEVEL SECURITY;
+ALTER TABLE enrollments FORCE ROW LEVEL SECURITY;
+ALTER TABLE module_progress FORCE ROW LEVEL SECURITY;
+ALTER TABLE subscriptions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "profiles_self_manage" ON profiles
+  FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "profiles_self_update" ON profiles
+  FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "profiles_self_insert" ON profiles
+  FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "profiles_admin_manage" ON profiles
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "classes_view_published" ON classes
+  FOR SELECT
+  USING (published);
+
+CREATE POLICY "classes_view_enrolled" ON classes
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM enrollments e
+      WHERE e.class_id = classes.id
+        AND e.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "classes_admin_manage" ON classes
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "modules_view_published" ON modules
+  FOR SELECT
+  USING (
+    public.is_admin()
+    OR EXISTS (
+      SELECT 1 FROM classes c
+      WHERE c.id = modules.class_id
+        AND c.published
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM enrollments e
+      WHERE e.class_id = modules.class_id
+        AND e.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "modules_admin_manage" ON modules
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "enrollments_self_read" ON enrollments
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "enrollments_self_insert" ON enrollments
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "enrollments_admin_manage" ON enrollments
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "progress_self_access" ON module_progress
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "progress_self_upsert" ON module_progress
+  FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "progress_self_update" ON module_progress
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "progress_admin_manage" ON module_progress
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "subscriptions_self_read" ON subscriptions
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "subscriptions_self_update" ON subscriptions
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "subscriptions_admin_manage" ON subscriptions
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,44 @@
+-- Seed baseline data for Coach House LMS local development.
+set search_path = public;
+
+insert into classes (id, title, slug, description, stripe_product_id, stripe_price_id, published)
+values
+  (
+    gen_random_uuid(),
+    'Coach House Foundations',
+    'coach-house-foundations',
+    'Orientation modules to help new students ramp quickly.',
+    null,
+    null,
+    true
+  ),
+  (
+    gen_random_uuid(),
+    'Advanced Facilitation',
+    'advanced-facilitation',
+    'Deep dives into live session delivery and engagement tactics.',
+    null,
+    null,
+    false
+  )
+  on conflict do nothing;
+
+with class_lookup as (
+  select id from classes where slug = 'coach-house-foundations' limit 1
+)
+insert into modules (class_id, idx, slug, title, description, video_url, content_md, duration_minutes)
+select
+  class_lookup.id,
+  data.idx,
+  data.slug,
+  data.title,
+  data.description,
+  data.video_url,
+  data.content_md,
+  data.duration_minutes
+from class_lookup,
+  (values
+    (1, 'welcome', 'Welcome to Coach House', 'Quick orientation for first-time learners.', 'https://youtu.be/dQw4w9WgXcQ', '# Welcome!\nThis is where your journey starts.', 5),
+    (2, 'setup', 'Platform Setup', 'Steps to get your account configured and ready.', null, '# Setup\nFollow these steps to get started.', 8)
+  ) as data(idx, slug, title, description, video_url, content_md, duration_minutes)
+on conflict (class_id, slug) do nothing;

--- a/supabase/tests/rls.test.cjs
+++ b/supabase/tests/rls.test.cjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+const crypto = require("node:crypto")
+const { createClient } = require("@supabase/supabase-js")
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!url || !anonKey || !serviceRole) {
+  console.log("[supabase] Skipping RLS tests – set SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY.")
+  process.exit(0)
+}
+
+const adminClient = createClient(url, serviceRole, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+const suffix = crypto.randomUUID().slice(0, 8)
+const studentEmail = `student-${suffix}@example.com`
+const adminEmail = `admin-${suffix}@example.com`
+const password = `TempPass!${suffix}`
+
+async function ensureProfile(id, role, fullName) {
+  const { error } = await adminClient.from("profiles").upsert(
+    {
+      id,
+      role,
+      full_name: fullName,
+    },
+    { onConflict: "id" }
+  )
+  if (error) throw error
+}
+
+async function createUsers() {
+  const {
+    data: { user: student },
+    error: studentError,
+  } = await adminClient.auth.admin.createUser({
+    email: studentEmail,
+    password,
+    email_confirm: true,
+  })
+  if (studentError) throw studentError
+
+  const {
+    data: { user: admin },
+    error: adminError,
+  } = await adminClient.auth.admin.createUser({
+    email: adminEmail,
+    password,
+    email_confirm: true,
+  })
+  if (adminError) throw adminError
+
+  await ensureProfile(student.id, "student", "Test Student")
+  await ensureProfile(admin.id, "admin", "Test Admin")
+
+  return { student, admin }
+}
+
+async function createDemoContent(studentId) {
+  const publishedClassId = crypto.randomUUID()
+  const unpublishedClassId = crypto.randomUUID()
+  const moduleId = crypto.randomUUID()
+  const hiddenModuleId = crypto.randomUUID()
+
+  const { error: classErr } = await adminClient.from("classes").insert([
+    {
+      id: publishedClassId,
+      title: "Published Class",
+      slug: `published-${suffix}`,
+      description: "Visible to students",
+      published: true,
+    },
+    {
+      id: unpublishedClassId,
+      title: "Draft Class",
+      slug: `draft-${suffix}`,
+      description: "Hidden from students",
+      published: false,
+    },
+  ])
+  if (classErr) throw classErr
+
+  const { error: moduleErr } = await adminClient.from("modules").insert([
+    {
+      id: moduleId,
+      class_id: publishedClassId,
+      idx: 1,
+      slug: `module-${suffix}`,
+      title: "Kick-off",
+      content_md: "# Kick-off",
+    },
+    {
+      id: hiddenModuleId,
+      class_id: unpublishedClassId,
+      idx: 1,
+      slug: `draft-module-${suffix}`,
+      title: "Draft",
+      content_md: "Hidden",
+    },
+  ])
+  if (moduleErr) throw moduleErr
+
+  const { error: enrollmentErr } = await adminClient.from("enrollments").insert({
+    user_id: studentId,
+    class_id: publishedClassId,
+  })
+  if (enrollmentErr) throw enrollmentErr
+
+  return { publishedClassId, unpublishedClassId, moduleId, hiddenModuleId }
+}
+
+async function run() {
+  const { student, admin } = await createUsers()
+  const assets = await createDemoContent(student.id)
+
+  const studentClient = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+  const adminSessionClient = createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+
+  await studentClient.auth.signInWithPassword({ email: studentEmail, password })
+  await adminSessionClient.auth.signInWithPassword({ email: adminEmail, password })
+
+  const results = []
+
+  // Profile visibility
+  {
+    const { data, error } = await studentClient.from("profiles").select("id").eq("id", student.id).maybeSingle()
+    results.push({ name: "student reads own profile", passed: !!data && !error })
+
+    const { data: otherProfile, error: otherError } = await studentClient
+      .from("profiles")
+      .select("id")
+      .eq("id", admin.id)
+      .maybeSingle()
+    results.push({ name: "student cannot read other profile", passed: !otherProfile })
+  }
+
+  // Class visibility
+  {
+    const { data, error } = await studentClient.from("classes").select("id, published").order("published", { ascending: false })
+    const publishedVisible = Array.isArray(data) && data.some((row) => row.id === assets.publishedClassId)
+    const draftHidden = Array.isArray(data) && !data.some((row) => row.id === assets.unpublishedClassId)
+    results.push({ name: "student sees published class", passed: publishedVisible && !error })
+    results.push({ name: "student does not see draft class", passed: draftHidden })
+  }
+
+  // Class insertion RLS
+  {
+    const { error } = await studentClient.from("classes").insert({
+      title: "Forbidden",
+      slug: `forbidden-${suffix}`,
+      published: true,
+    })
+    results.push({ name: "student cannot insert classes", passed: !!error })
+  }
+
+  // Admin update allowed
+  {
+    const { error } = await adminSessionClient.from("classes").update({ title: "Published Class Updated" }).eq("id", assets.publishedClassId)
+    results.push({ name: "admin can update classes", passed: !error })
+  }
+
+  // Module access + progress updates
+  {
+    const { data, error } = await studentClient.from("modules").select("id, class_id")
+    const moduleVisible = Array.isArray(data) && data.some((row) => row.id === assets.moduleId)
+    const draftHidden = Array.isArray(data) && !data.some((row) => row.id === assets.hiddenModuleId)
+    results.push({ name: "student sees module for published class", passed: moduleVisible && !error })
+    results.push({ name: "student does not see draft module", passed: draftHidden })
+
+    const { error: progressErr } = await studentClient.from("module_progress").upsert({
+      user_id: student.id,
+      module_id: assets.moduleId,
+      status: "in_progress",
+    })
+    results.push({ name: "student can upsert own module progress", passed: !progressErr })
+  }
+
+  // Subscription visibility
+  {
+    const subId = crypto.randomUUID()
+    const { error } = await adminClient.from("subscriptions").insert({
+      id: subId,
+      user_id: student.id,
+      stripe_subscription_id: `sub_${suffix}`,
+      status: "active",
+    })
+    if (error) throw error
+
+    const { data, error: subscriptionError } = await studentClient.from("subscriptions").select("id").maybeSingle()
+    results.push({ name: "student can read own subscription", passed: !!data && !subscriptionError })
+
+    const { error: updateError } = await studentClient
+      .from("subscriptions")
+      .update({ metadata: { source: "rls-test" } })
+      .eq("id", subId)
+    results.push({ name: "student can update own subscription metadata", passed: !updateError })
+  }
+
+  const failed = results.filter((result) => !result.passed)
+  results.forEach((result) => {
+    console.log(`${result.passed ? "✓" : "✗"} ${result.name}`)
+  })
+
+  await adminClient.from('module_progress').delete().eq('user_id', student.id)
+  await adminClient.from('enrollments').delete().eq('user_id', student.id)
+  await adminClient.from('modules').delete().in('id', [assets.moduleId, assets.hiddenModuleId])
+  await adminClient.from('classes').delete().in('id', [assets.publishedClassId, assets.unpublishedClassId])
+  await adminClient.from('subscriptions').delete().eq('user_id', student.id)
+  await adminClient.auth.admin.deleteUser(student.id)
+  await adminClient.auth.admin.deleteUser(admin.id)
+
+  if (failed.length > 0) {
+    console.error(`RLS tests failed (${failed.length}).`)
+    process.exit(1)
+  }
+
+  console.log("RLS tests passed.")
+}
+
+run().catch((error) => {
+  console.error("RLS test runner error:", error)
+  process.exit(1)
+})


### PR DESCRIPTION
**Summary**
- add normalized tables for profiles, classes, modules, enrollments, module_progress, and subscriptions with constraints + triggers
- enable strict RLS policies backed by `is_admin()` helper so students only see their data and published content
- seed sample curriculum data, expose Supabase typings, and wire npm scripts for schema tests + RLS verification

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`, `npm run test:rls`)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- `npm run test:rls` requires SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY; it auto-skips when unset.
