### PR TITLE
[STEP S04] Auth flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 next-env.d.ts
 
 dist-snapshots/
+supabase/.temp/

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -72,10 +72,15 @@ feat(step {id}): {title}
     * Seeded sample curriculum data and published Supabase typings plus RLS verification script.
     * Wired `npm run test:rls` to exercise policies (skips when Supabase credentials are absent).
   * PR: https://github.com/Hamernick/coach-house-lms/pull/4
-* [ ] **S04** — Auth flows
+* [x] **S04** — Auth flows
 
   * Signup/verify/signin/reset; guards; route middleware.
   * **Accept**: e2e happy paths; screenshots.
+  * **Changelog**:
+    * Implemented Supabase email/password flows (sign in, sign up, password reset/update) with server-side callbacks.
+    * Added shared auth UI, protected route middleware, and sign-out control for the dashboard shell.
+    * Linked verification/reset redirects through `/auth/callback` and surfaced helpful form states.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/5
 * [ ] **S05** — Shell & navigation
 
   * Sidebar/header shell; breadcrumbs; skeletons; empty states.

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
+
+function getSafeRedirect(path?: string | null) {
+  if (!path) return null
+  if (!path.startsWith("/")) return null
+  return path
+}
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url)
+  const code = requestUrl.searchParams.get("code")
+  const type = requestUrl.searchParams.get("type")
+  const redirectParam = getSafeRedirect(requestUrl.searchParams.get("redirect"))
+
+  const fallback = type === "recovery" ? "/auth/update-password" : "/dashboard"
+  const destination = new URL(redirectParam ?? fallback, requestUrl.origin)
+
+  if (!code) {
+    const errorUrl = new URL("/login", requestUrl.origin)
+    errorUrl.searchParams.set("error", "Missing verification code")
+    return NextResponse.redirect(errorUrl)
+  }
+
+  const response = NextResponse.redirect(destination)
+  const supabase = createSupabaseRouteHandlerClient(request, response)
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    const errorUrl = new URL("/login", requestUrl.origin)
+    errorUrl.searchParams.set("error", error.message)
+    return NextResponse.redirect(errorUrl)
+  }
+
+  return response
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,22 @@
+import { AuthCard } from "@/components/auth/auth-card"
+import { ForgotPasswordForm } from "@/components/auth/forgot-password-form"
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+type ForgotPasswordPageProps = {
+  searchParams?: Promise<SearchParams>
+}
+
+export default async function ForgotPasswordPage({ searchParams }: ForgotPasswordPageProps) {
+  const resolved = searchParams ? await searchParams : {}
+  const redirect = typeof resolved.redirect === "string" ? resolved.redirect : undefined
+
+  return (
+    <AuthCard
+      title="Reset your password"
+      description="Enter your email and we'll send a secure link to choose a new password."
+    >
+      <ForgotPasswordForm redirectTo={redirect} />
+    </AuthCard>
+  )
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react"
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background via-background to-secondary/40 px-6 py-16">
+      <div className="w-full max-w-md space-y-6">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,13 +1,24 @@
-export default function LoginPage() {
+import { AuthCard } from "@/components/auth/auth-card"
+import { LoginForm } from "@/components/auth/login-form"
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+type LoginPageProps = {
+  searchParams?: Promise<SearchParams>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const resolved = searchParams ? await searchParams : {}
+
+  const redirect = typeof resolved.redirect === "string" ? resolved.redirect : undefined
+  const error = typeof resolved.error === "string" ? resolved.error : null
+
   return (
-    <div className="flex min-h-screen items-center justify-center px-6 py-16">
-      <div className="max-w-md space-y-4 text-center">
-        <h1 className="text-3xl font-semibold tracking-tight">Sign in</h1>
-        <p className="text-muted-foreground">
-          Authentication flows will arrive in later steps. This placeholder keeps the
-          route group wired and ready.
-        </p>
-      </div>
-    </div>
+    <AuthCard
+      title="Sign in"
+      description="Access your courses and continue where you left off."
+    >
+      <LoginForm redirectTo={redirect} initialError={error} />
+    </AuthCard>
   )
 }

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,22 @@
+import { AuthCard } from "@/components/auth/auth-card"
+import { SignUpForm } from "@/components/auth/sign-up-form"
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+type SignUpPageProps = {
+  searchParams?: Promise<SearchParams>
+}
+
+export default async function SignUpPage({ searchParams }: SignUpPageProps) {
+  const resolved = searchParams ? await searchParams : {}
+  const redirect = typeof resolved.redirect === "string" ? resolved.redirect : undefined
+
+  return (
+    <AuthCard
+      title="Create your account"
+      description="Join Coach House to access premium learning paths."
+    >
+      <SignUpForm redirectTo={redirect} />
+    </AuthCard>
+  )
+}

--- a/src/app/(auth)/update-password/page.tsx
+++ b/src/app/(auth)/update-password/page.tsx
@@ -1,0 +1,22 @@
+import { AuthCard } from "@/components/auth/auth-card"
+import { UpdatePasswordForm } from "@/components/auth/update-password-form"
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+type UpdatePasswordPageProps = {
+  searchParams?: Promise<SearchParams>
+}
+
+export default async function UpdatePasswordPage({ searchParams }: UpdatePasswordPageProps) {
+  const resolved = searchParams ? await searchParams : {}
+  const redirect = typeof resolved.redirect === "string" ? resolved.redirect : undefined
+
+  return (
+    <AuthCard
+      title="Choose a new password"
+      description="Passwords must be at least 8 characters."
+    >
+      <UpdatePasswordForm redirectTo={redirect ?? "/dashboard"} />
+    </AuthCard>
+  )
+}

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+type AuthCardProps = {
+  title: string
+  description?: string
+  children: ReactNode
+}
+
+export function AuthCard({ title, description, children }: AuthCardProps) {
+  return (
+    <Card className="border-border/80 shadow-lg">
+      <CardHeader className="space-y-2 text-center">
+        <CardTitle className="text-2xl font-semibold tracking-tight">{title}</CardTitle>
+        {description ? (
+          <CardDescription className="text-balance text-sm text-muted-foreground">
+            {description}
+          </CardDescription>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-4">{children}</CardContent>
+    </Card>
+  )
+}

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const schema = z.object({
+  email: z.string().email("Enter a valid email"),
+})
+
+type ForgotPasswordValues = z.infer<typeof schema>
+
+type ForgotPasswordFormProps = {
+  redirectTo?: string
+}
+
+export function ForgotPasswordForm({ redirectTo = "/auth/update-password" }: ForgotPasswordFormProps) {
+  const supabase = useSupabaseClient()
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle")
+  const [message, setMessage] = useState<string>("")
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<ForgotPasswordValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: "",
+    },
+  })
+
+  async function onSubmit(values: ForgotPasswordValues) {
+    setStatus("idle")
+    setMessage("")
+    startTransition(async () => {
+      const origin = typeof window === "undefined" ? undefined : window.location.origin
+      const emailRedirectTo = origin
+        ? `${origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`
+        : undefined
+
+      const { error } = await supabase.auth.resetPasswordForEmail(values.email, {
+        redirectTo: emailRedirectTo,
+      })
+
+      if (error) {
+        setStatus("error")
+        setMessage(error.message)
+        return
+      }
+
+      setStatus("success")
+      setMessage("If that email is registered, a reset link is on its way.")
+      form.reset()
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input {...field} type="email" autoComplete="email" placeholder="you@example.com" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {status !== "idle" ? (
+            <p
+              className={`text-sm ${status === "success" ? "text-emerald-600" : "text-destructive"}`}
+              role="status"
+            >
+              {message}
+            </p>
+          ) : null}
+          <Button className="w-full" type="submit" disabled={isPending}>
+            {isPending ? "Sending email..." : "Send reset link"}
+          </Button>
+        </form>
+      </Form>
+      <div className="text-center text-sm text-muted-foreground">
+        Remembered it? {" "}
+        <Link href="/login" className="hover:text-foreground">
+          Back to sign in
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const schema = z.object({
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+})
+
+type LoginFormValues = z.infer<typeof schema>
+
+type LoginFormProps = {
+  redirectTo?: string
+  initialError?: string | null
+}
+
+export function LoginForm({ redirectTo, initialError }: LoginFormProps) {
+  const supabase = useSupabaseClient()
+  const router = useRouter()
+  const [errorMessage, setErrorMessage] = useState<string | null>(initialError ?? null)
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  })
+
+  async function onSubmit(values: LoginFormValues) {
+    setErrorMessage(null)
+    startTransition(async () => {
+      const { error } = await supabase.auth.signInWithPassword({
+        email: values.email,
+        password: values.password,
+      })
+
+      if (error) {
+        setErrorMessage(error.message)
+        return
+      }
+
+      form.reset()
+      router.replace(redirectTo ?? "/dashboard")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input {...field} type="email" autoComplete="email" placeholder="you@example.com" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input {...field} type="password" autoComplete="current-password" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {errorMessage ? (
+            <p className="text-sm text-destructive" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+          <Button className="w-full" type="submit" disabled={isPending}>
+            {isPending ? "Signing in..." : "Sign in"}
+          </Button>
+        </form>
+      </Form>
+      <div className="flex justify-between text-sm text-muted-foreground">
+        <Link href="/sign-up" className="hover:text-foreground">
+          Need an account? Sign up
+        </Link>
+        <Link href="/forgot-password" className="hover:text-foreground">
+          Forgot password?
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const schema = z.object({
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+})
+
+type SignUpValues = z.infer<typeof schema>
+
+type SignUpFormProps = {
+  redirectTo?: string
+}
+
+export function SignUpForm({ redirectTo = "/dashboard" }: SignUpFormProps) {
+  const supabase = useSupabaseClient()
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle")
+  const [message, setMessage] = useState<string>("")
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<SignUpValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  })
+
+  async function onSubmit(values: SignUpValues) {
+    setStatus("idle")
+    setMessage("")
+    startTransition(async () => {
+      const origin = typeof window === "undefined" ? undefined : window.location.origin
+      const emailRedirectTo = origin
+        ? `${origin}/auth/callback?redirect=${encodeURIComponent(redirectTo)}`
+        : undefined
+
+      const { error } = await supabase.auth.signUp({
+        email: values.email,
+        password: values.password,
+        options: {
+          emailRedirectTo,
+        },
+      })
+
+      if (error) {
+        setStatus("error")
+        setMessage(error.message)
+        return
+      }
+
+      setStatus("success")
+      setMessage(
+        "Check your inbox for a verification link. After confirming, you'll be redirected automatically."
+      )
+      form.reset()
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input {...field} type="email" autoComplete="email" placeholder="you@example.com" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input {...field} type="password" autoComplete="new-password" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {status !== "idle" ? (
+            <p
+              className={`text-sm ${status === "success" ? "text-emerald-600" : "text-destructive"}`}
+              role="status"
+            >
+              {message}
+            </p>
+          ) : null}
+          <Button className="w-full" type="submit" disabled={isPending}>
+            {isPending ? "Creating account..." : "Create account"}
+          </Button>
+        </form>
+      </Form>
+      <div className="text-center text-sm text-muted-foreground">
+        Already have an account? {" "}
+        <Link href="/login" className="hover:text-foreground">
+          Sign in
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/update-password-form.tsx
+++ b/src/components/auth/update-password-form.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+const schema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "Passwords must match",
+  })
+
+type UpdatePasswordValues = z.infer<typeof schema>
+
+type UpdatePasswordFormProps = {
+  redirectTo?: string
+}
+
+export function UpdatePasswordForm({ redirectTo = "/dashboard" }: UpdatePasswordFormProps) {
+  const supabase = useSupabaseClient()
+  const router = useRouter()
+  const [status, setStatus] = useState<"checking" | "ready" | "no-session">("checking")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const form = useForm<UpdatePasswordValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    supabase.auth.getSession().then(({ data }) => {
+      if (cancelled) return
+      if (data.session) {
+        setStatus("ready")
+      } else {
+        setStatus("no-session")
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [supabase])
+
+  async function onSubmit(values: UpdatePasswordValues) {
+    setErrorMessage(null)
+    startTransition(async () => {
+      const { error } = await supabase.auth.updateUser({ password: values.password })
+      if (error) {
+        setErrorMessage(error.message)
+        return
+      }
+      form.reset()
+      router.replace(redirectTo)
+      router.refresh()
+    })
+  }
+
+  if (status === "checking") {
+    return <p className="text-sm text-muted-foreground">Verifying session...</p>
+  }
+
+  if (status === "no-session") {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Reset links are single-use. Request a new reset email to update your password.
+      </p>
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New password</FormLabel>
+              <FormControl>
+                <Input {...field} type="password" autoComplete="new-password" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm password</FormLabel>
+              <FormControl>
+                <Input {...field} type="password" autoComplete="new-password" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {errorMessage ? (
+          <p className="text-sm text-destructive" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+        <Button className="w-full" type="submit" disabled={isPending}>
+          {isPending ? "Updating..." : "Update password"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/sign-out-button.tsx
+++ b/src/components/sign-out-button.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useTransition, type ComponentProps } from "react"
+import { useRouter } from "next/navigation"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+
+type SignOutButtonProps = ComponentProps<typeof Button>
+
+export function SignOutButton({ children = "Sign out", ...props }: SignOutButtonProps) {
+  const supabase = useSupabaseClient()
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function handleSignOut() {
+    startTransition(async () => {
+      await supabase.auth.signOut()
+      router.replace("/login")
+      router.refresh()
+    })
+  }
+
+  return (
+    <Button onClick={handleSignOut} disabled={isPending} {...props}>
+      {isPending ? "Signing out..." : children}
+    </Button>
+  )
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,3 +1,4 @@
+import { SignOutButton } from "@/components/sign-out-button"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
@@ -11,7 +12,7 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">Documents</h1>
+        <h1 className="text-base font-medium">Dashboard</h1>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
             <a
@@ -23,6 +24,7 @@ export function SiteHeader() {
               GitHub
             </a>
           </Button>
+          <SignOutButton variant="outline" size="sm" />
         </div>
       </div>
     </header>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+const PROTECTED_PREFIXES = ["/dashboard", "/billing", "/class", "/admin"]
+const AUTH_ROUTES = new Set(["/login", "/sign-up", "/forgot-password"])
+
+export function middleware(request: NextRequest) {
+  const accessToken = request.cookies.get("sb-access-token")?.value
+  const refreshToken = request.cookies.get("sb-refresh-token")?.value
+  const hasSession = Boolean(accessToken && refreshToken)
+
+  const pathname = request.nextUrl.pathname
+  const isProtected = PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  const isAuthRoute = AUTH_ROUTES.has(pathname)
+
+  if (!hasSession && isProtected) {
+    const redirectUrl = new URL("/login", request.url)
+    redirectUrl.searchParams.set("redirect", pathname + request.nextUrl.search)
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  if (hasSession && isAuthRoute) {
+    return NextResponse.redirect(new URL("/dashboard", request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ["/((?!_next|.*\\..*|api/auth).*)"],
+}


### PR DESCRIPTION
**Summary**
- implement Supabase-driven auth flows for sign in, sign up, password reset/update, and verification callbacks
- add shared auth layout, UI forms, and session-aware dashboard sign out; enforce access via middleware guards
- document success/error states and keep runbook synced for step S04

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`, `npm run test:rls` – skips without Supabase creds)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Email verification and password recovery links target `/auth/callback`, which exchanges the session and redirects accordingly.
