### PR TITLE
[STEP S05] Shell & navigation

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -81,10 +81,15 @@ feat(step {id}): {title}
     * Added shared auth UI, protected route middleware, and sign-out control for the dashboard shell.
     * Linked verification/reset redirects through `/auth/callback` and surfaced helpful form states.
   * PR: https://github.com/Hamernick/coach-house-lms/pull/5
-* [ ] **S05** — Shell & navigation
+* [x] **S05** — Shell & navigation
 
   * Sidebar/header shell; breadcrumbs; skeletons; empty states.
   * **Accept**: `/dashboard` loads with skeletons; a11y landmarks.
+  * **Changelog**:
+    * Added shared dashboard layout with persistent sidebar/header landmarks and breadcrumb support.
+    * Refreshed navigation links, resources, and support actions; includes sign-out in header.
+    * Introduced Suspense-driven skeletons and empty states for analytics, charts, and announcements.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/6
 * [ ] **S06** — Pricing page
 
   * Public `/pricing` with plans pulled from Stripe (test keys placeholder).

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,50 +1,89 @@
-import { AppSidebar } from "@/components/app-sidebar"
+import { Suspense } from "react"
+
+import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
+import { DashboardEmptyState } from "@/components/dashboard/empty-state"
+import {
+  ChartSkeleton,
+  SectionCardsSkeleton,
+  TableSkeleton,
+} from "@/components/dashboard/skeletons"
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 import { DataTable } from "@/components/data-table"
 import { SectionCards } from "@/components/section-cards"
-import { SessionPreview } from "@/components/session-preview"
-import { SiteHeader } from "@/components/site-header"
-import { createSupabaseServerClient } from "@/lib/supabase"
-import {
-  SidebarInset,
-  SidebarProvider,
-} from "@/components/ui/sidebar"
 
 import data from "./data.json"
 
-export default async function Page() {
-  const supabase = createSupabaseServerClient()
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
+async function wait<T>(value: T, ms = 350): Promise<T> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+  return value
+}
+
+async function AnalyticsOverview() {
+  await wait(null, 250)
+  return <SectionCards />
+}
+
+async function EngagementChart() {
+  await wait(null, 350)
+  return (
+    <div className="px-4 lg:px-6">
+      <ChartAreaInteractive />
+    </div>
+  )
+}
+
+async function OpportunitiesTable() {
+  const rows = await wait(data, 450)
+
+  if (!rows.length) {
+    return (
+      <DashboardEmptyState
+        title="No classes yet"
+        description="Create your first class to populate this activity table."
+        actionLabel="Create class"
+        onActionHref="/dashboard/classes"
+        helperText="Analytics populate automatically once learners enroll."
+      />
+    )
+  }
 
   return (
-    <SidebarProvider
-      style={
-        {
-          "--sidebar-width": "calc(var(--spacing) * 72)",
-          "--header-height": "calc(var(--spacing) * 12)",
-        } as React.CSSProperties
-      }
-    >
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex flex-1 flex-col">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-              <div className="px-4 lg:px-6">
-                <SessionPreview initialSession={session} />
-              </div>
-              <SectionCards />
-              <div className="px-4 lg:px-6">
-                <ChartAreaInteractive />
-              </div>
-              <DataTable data={data} />
-            </div>
-          </div>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <div className="px-4 lg:px-6">
+      <DataTable data={rows} />
+    </div>
+  )
+}
+
+async function AnnouncementsPanel() {
+  await wait(null, 500)
+  return (
+    <DashboardEmptyState
+      title="No announcements"
+      description="Keep your cohort informed. Share welcome messages or release notes once classes begin."
+      actionLabel="Plan announcement"
+      onActionHref="/dashboard/classes"
+    />
+  )
+}
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <div className="px-4 lg:px-6">
+        <DashboardBreadcrumbs segments={[{ label: "Dashboard" }]} />
+      </div>
+      <Suspense fallback={<SectionCardsSkeleton />}>
+        <AnalyticsOverview />
+      </Suspense>
+      <Suspense fallback={<ChartSkeleton />}>
+        <EngagementChart />
+      </Suspense>
+      <Suspense fallback={<TableSkeleton />}>
+        <OpportunitiesTable />
+      </Suspense>
+      <Suspense fallback={<TableSkeleton />}>
+        <AnnouncementsPanel />
+      </Suspense>
+    </div>
   )
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react"
+
+import { AppSidebar } from "@/components/app-sidebar"
+import { SiteHeader } from "@/components/site-header"
+import {
+  SidebarInset,
+  SidebarProvider,
+} from "@/components/ui/sidebar"
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <SidebarProvider
+      style={
+        {
+          "--sidebar-width": "calc(var(--spacing) * 72)",
+          "--header-height": "calc(var(--spacing) * 12)",
+        } as React.CSSProperties
+      }
+    >
+      <AppSidebar variant="inset" />
+      <SidebarInset>
+        <SiteHeader />
+        <main className="flex flex-1 flex-col" role="main">
+          <div className="@container/main flex flex-1 flex-col gap-2">
+            <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+              {children}
+            </div>
+          </div>
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,21 +2,15 @@
 
 import * as React from "react"
 import {
-  IconCamera,
-  IconChartBar,
-  IconDashboard,
-  IconDatabase,
-  IconFileAi,
-  IconFileDescription,
-  IconFileWord,
-  IconFolder,
+  IconBook,
+  IconCalendarTime,
+  IconCreditCard,
   IconHelp,
-  IconInnerShadowTop,
-  IconListDetails,
-  IconReport,
-  IconSearch,
+  IconLayoutDashboard,
+  IconLifebuoy,
+  IconNotebook,
   IconSettings,
-  IconUsers,
+  IconShieldLock,
 } from "@tabler/icons-react"
 
 import { NavDocuments } from "@/components/nav-documents"
@@ -33,119 +27,61 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 
-const data = {
+const navigation = {
   user: {
-    name: "shadcn",
-    email: "m@example.com",
+    name: "Alex Morgan",
+    email: "alex@coachhouse.io",
     avatar: "/avatars/shadcn.jpg",
   },
-  navMain: [
+  main: [
     {
       title: "Dashboard",
-      url: "#",
-      icon: IconDashboard,
+      href: "/dashboard",
+      icon: IconLayoutDashboard,
     },
     {
-      title: "Lifecycle",
-      url: "#",
-      icon: IconListDetails,
+      title: "Classes",
+      href: "/dashboard/classes",
+      icon: IconBook,
     },
     {
-      title: "Analytics",
-      url: "#",
-      icon: IconChartBar,
+      title: "Schedule",
+      href: "/dashboard/schedule",
+      icon: IconCalendarTime,
     },
     {
-      title: "Projects",
-      url: "#",
-      icon: IconFolder,
+      title: "Billing",
+      href: "/billing",
+      icon: IconCreditCard,
     },
     {
-      title: "Team",
-      url: "#",
-      icon: IconUsers,
+      title: "Admin",
+      href: "/admin",
+      icon: IconShieldLock,
     },
   ],
-  navClouds: [
+  resources: [
     {
-      title: "Capture",
-      icon: IconCamera,
-      isActive: true,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
+      name: "Knowledge base",
+      url: "https://coachhouse.example.com/docs",
+      icon: IconNotebook,
     },
     {
-      title: "Proposal",
-      icon: IconFileDescription,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Prompts",
-      icon: IconFileAi,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
+      name: "Community",
+      url: "https://coachhouse.example.com/community",
+      icon: IconLifebuoy,
     },
   ],
-  navSecondary: [
+  secondary: [
     {
       title: "Settings",
-      url: "#",
+      url: "/settings",
       icon: IconSettings,
     },
     {
-      title: "Get Help",
-      url: "#",
+      title: "Support",
+      url: "mailto:support@coachhouse.io",
       icon: IconHelp,
-    },
-    {
-      title: "Search",
-      url: "#",
-      icon: IconSearch,
-    },
-  ],
-  documents: [
-    {
-      name: "Data Library",
-      url: "#",
-      icon: IconDatabase,
-    },
-    {
-      name: "Reports",
-      url: "#",
-      icon: IconReport,
-    },
-    {
-      name: "Word Assistant",
-      url: "#",
-      icon: IconFileWord,
     },
   ],
 }
@@ -156,25 +92,23 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              className="data-[slot=sidebar-menu-button]:!p-1.5"
-            >
-              <a href="#">
-                <IconInnerShadowTop className="!size-5" />
-                <span className="text-base font-semibold">Acme Inc.</span>
+            <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
+              <a href="/dashboard">
+                <span className="text-base font-semibold tracking-tight">
+                  Coach House LMS
+                </span>
               </a>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
-        <NavDocuments items={data.documents} />
-        <NavSecondary items={data.navSecondary} className="mt-auto" />
+        <NavMain items={navigation.main} label="Platform" />
+        <NavDocuments items={navigation.resources} label="Resources" />
+        <NavSecondary items={navigation.secondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        <NavUser user={navigation.user} />
       </SidebarFooter>
     </Sidebar>
   )

--- a/src/components/dashboard/breadcrumbs.tsx
+++ b/src/components/dashboard/breadcrumbs.tsx
@@ -1,0 +1,40 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+export type BreadcrumbSegment = {
+  label: string
+  href?: string
+}
+
+export function DashboardBreadcrumbs({ segments }: { segments: BreadcrumbSegment[] }) {
+  if (segments.length === 0) {
+    return null
+  }
+
+  return (
+    <Breadcrumb aria-label="Breadcrumb">
+      <BreadcrumbList>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1
+
+          return (
+            <BreadcrumbItem key={`${segment.label}-${index}`}>
+              {segment.href && !isLast ? (
+                <BreadcrumbLink href={segment.href}>{segment.label}</BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{segment.label}</BreadcrumbPage>
+              )}
+              {isLast ? null : <BreadcrumbSeparator />}
+            </BreadcrumbItem>
+          )
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/src/components/dashboard/empty-state.tsx
+++ b/src/components/dashboard/empty-state.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+import { IconSparkles } from "@tabler/icons-react"
+import type { ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+type DashboardEmptyStateProps = {
+  title: string
+  description: string
+  actionLabel?: string
+  onActionHref?: string
+  helperText?: ReactNode
+}
+
+export function DashboardEmptyState({
+  title,
+  description,
+  actionLabel = "Create",
+  onActionHref = "/dashboard/classes",
+  helperText,
+}: DashboardEmptyStateProps) {
+  return (
+    <div className="px-4 lg:px-6">
+      <Card className="border-dashed bg-card/60 text-center">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-center gap-2 text-lg">
+            <IconSparkles className="text-primary" />
+            {title}
+          </CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-3">
+          {actionLabel ? (
+            <Button asChild>
+              <Link href={onActionHref}>{actionLabel}</Link>
+            </Button>
+          ) : null}
+          {helperText ? (
+            <div className="text-xs text-muted-foreground">{helperText}</div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/dashboard/skeletons.tsx
+++ b/src/components/dashboard/skeletons.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function SectionCardsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 px-4 lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex flex-col gap-4 rounded-xl border bg-card/60 p-6 shadow-sm"
+        >
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ChartSkeleton() {
+  return (
+    <div className="px-4 lg:px-6">
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        <Skeleton className="mb-6 h-5 w-36" />
+        <Skeleton className="h-56 w-full" />
+      </div>
+    </div>
+  )
+}
+
+export function TableSkeleton() {
+  return (
+    <div className="px-4 lg:px-6">
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        <Skeleton className="mb-4 h-5 w-28" />
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/nav-documents.tsx
+++ b/src/components/nav-documents.tsx
@@ -27,18 +27,24 @@ import {
 
 export function NavDocuments({
   items,
+  label = "Resources",
 }: {
   items: {
     name: string
     url: string
     icon: Icon
   }[]
+  label?: string
 }) {
   const { isMobile } = useSidebar()
 
+  if (items.length === 0) {
+    return null
+  }
+
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-      <SidebarGroupLabel>Documents</SidebarGroupLabel>
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarMenu>
         {items.map((item) => (
           <SidebarMenuItem key={item.name}>
@@ -59,7 +65,7 @@ export function NavDocuments({
                 </SidebarMenuAction>
               </DropdownMenuTrigger>
               <DropdownMenuContent
-                className="w-24 rounded-lg"
+                className="w-32 rounded-lg"
                 side={isMobile ? "bottom" : "right"}
                 align={isMobile ? "end" : "start"}
               >
@@ -80,12 +86,6 @@ export function NavDocuments({
             </DropdownMenu>
           </SidebarMenuItem>
         ))}
-        <SidebarMenuItem>
-          <SidebarMenuButton className="text-sidebar-foreground/70">
-            <IconDots className="text-sidebar-foreground/70" />
-            <span>More</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { IconCirclePlusFilled, IconMail, type Icon } from "@tabler/icons-react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import type { Icon } from "@tabler/icons-react"
 
-import { Button } from "@/components/ui/button"
 import {
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -13,44 +15,36 @@ import {
 
 export function NavMain({
   items,
+  label = "Navigation",
 }: {
   items: {
     title: string
-    url: string
+    href: string
     icon?: Icon
   }[]
+  label?: string
 }) {
+  const pathname = usePathname()
+
   return (
     <SidebarGroup>
-      <SidebarGroupContent className="flex flex-col gap-2">
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
+      <SidebarGroupContent>
         <SidebarMenu>
-          <SidebarMenuItem className="flex items-center gap-2">
-            <SidebarMenuButton
-              tooltip="Quick Create"
-              className="bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground active:bg-primary/90 active:text-primary-foreground min-w-8 duration-200 ease-linear"
-            >
-              <IconCirclePlusFilled />
-              <span>Quick Create</span>
-            </SidebarMenuButton>
-            <Button
-              size="icon"
-              className="size-8 group-data-[collapsible=icon]:opacity-0"
-              variant="outline"
-            >
-              <IconMail />
-              <span className="sr-only">Inbox</span>
-            </Button>
-          </SidebarMenuItem>
-        </SidebarMenu>
-        <SidebarMenu>
-          {items.map((item) => (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton tooltip={item.title}>
-                {item.icon && <item.icon />}
-                <span>{item.title}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
+          {items.map((item) => {
+            const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild tooltip={item.title} isActive={isActive}>
+                  <Link href={item.href}>
+                    {item.icon ? <item.icon /> : null}
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -6,6 +6,7 @@ import { type Icon } from "@tabler/icons-react"
 import {
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -13,6 +14,7 @@ import {
 
 export function NavSecondary({
   items,
+  label = "Support",
   ...props
 }: {
   items: {
@@ -20,9 +22,15 @@ export function NavSecondary({
     url: string
     icon: Icon
   }[]
+  label?: string
 } & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
+  if (items.length === 0) {
+    return null
+  }
+
   return (
     <SidebarGroup {...props}>
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
           {items.map((item) => (


### PR DESCRIPTION
**Summary**
- add a shared dashboard layout with persistent sidebar/header landmarks and breadcrumb support
- refresh navigation data for real routes and add skeleton + empty state panels powered by Suspense
- introduce dashboard helpers (breadcrumbs, skeletons, empty state) while keeping build/test coverage

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`, `npm run test:rls` — skips without Supabase creds)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Skeletons drive the `/dashboard` loading experience; announcements panel shows the empty state.
