### PR TITLE
[STEP S06] Pricing page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ SUPABASE_JWT_SECRET=""
 
 # App
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
+
+# Stripe configuration
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_123"
+STRIPE_SECRET_KEY="sk_test_123"

--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -85,10 +85,15 @@ feat(step {id}): {title}
 
   * Sidebar/header shell; breadcrumbs; skeletons; empty states.
   * **Accept**: `/dashboard` loads with skeletons; a11y landmarks.
-* [ ] **S06** — Pricing page
+* [x] **S06** — Pricing page
 
   * Public `/pricing` with plans pulled from Stripe (test keys placeholder).
   * **Accept**: LCP budget met on mid‑range mobile.
+  * **Changelog**:
+    * Added `/pricing` with Stripe-backed plan retrieval and graceful fallbacks when keys are absent.
+    * Updated marketing hero copy/CTAs and surfaced plan features, empty-state messaging, and support details.
+    * Extended env validation + examples for Stripe keys to support future checkout flows.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/7
 * [ ] **S07** — Stripe checkout
 
   * Client → Checkout; return handler; subscription record.

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -11,9 +11,8 @@ export default function LandingPage() {
           Ship courses faster with an opinionated learning platform
         </h1>
         <p className="mx-auto max-w-2xl text-balance text-muted-foreground">
-          This placeholder page anchors the public route group while we build the
-          full marketing experience. Future steps will flesh out pricing, feature
-          highlights, and capture forms.
+          Launch an LMS with Supabase auth, Stripe billing, and production-ready
+          dashboard components. Pricing stays simple as you add more cohorts.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-4">
           <Link
@@ -21,6 +20,12 @@ export default function LandingPage() {
             className="rounded-full bg-primary px-6 py-2 text-primary-foreground transition hover:bg-primary/90"
           >
             Sign in
+          </Link>
+          <Link
+            href="/pricing"
+            className="rounded-full border border-border px-6 py-2 text-sm font-medium text-foreground transition hover:bg-secondary"
+          >
+            View pricing
           </Link>
           <Link
             href="/dashboard"
@@ -38,7 +43,7 @@ export default function LandingPage() {
           ✓ Authentication routes staged
         </p>
         <p className="text-left text-muted-foreground">
-          ✓ Dashboard foundation ready for data
+          ✓ Dashboard + pricing experiences ready for real data
         </p>
       </div>
     </main>

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { getPricingPlans } from "@/lib/pricing"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+
+export const metadata: Metadata = {
+  title: "Pricing",
+  description:
+    "Choose a Coach House LMS plan that fits your cohort. Upgrade any time as your classrooms grow.",
+}
+
+function formatAmount(amount: number, currency: string, interval: string) {
+  if (!amount) {
+    return "Contact us"
+  }
+
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: amount % 100 === 0 ? 0 : 2,
+  })
+
+  return `${formatter.format(amount / 100)}/${interval}`
+}
+
+export default async function PricingPage() {
+  const plans = await getPricingPlans()
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-16 px-6 py-16 lg:py-24">
+      <section className="mx-auto max-w-3xl text-center">
+        <Badge variant="outline" className="mb-4">Simple, usage-based pricing</Badge>
+        <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+          Launch courses without hidden fees
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Start with the essentials, then unlock advanced automation, billing, and analytics as your
+          cohort scales.
+        </p>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {plans.map((plan) => {
+          const isContactPlan = plan.amount === 0
+          return (
+            <Card
+              key={plan.id}
+              className={
+                plan.highlight
+                  ? "border-primary/30 bg-primary/5 shadow-lg"
+                  : "bg-card/80"
+              }
+            >
+              <CardHeader className="space-y-3 text-center">
+                <div className="flex items-center justify-center gap-2">
+                  <CardTitle className="text-2xl font-semibold">{plan.name}</CardTitle>
+                  {plan.highlight ? (
+                    <Badge variant="default">Most popular</Badge>
+                  ) : null}
+                </div>
+                <CardDescription className="text-balance">
+                  {plan.description ?? "All of the essentials for modern course delivery."}
+                </CardDescription>
+                <p className="text-3xl font-semibold">
+                  {formatAmount(plan.amount, plan.currency, plan.interval)}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-3 text-sm">
+                  {plan.features.length > 0 ? (
+                    plan.features.map((feature) => (
+                      <div key={feature} className="flex items-start gap-2 text-left">
+                        <span className="mt-1 size-1.5 rounded-full bg-primary" aria-hidden />
+                        <span className="text-muted-foreground">{feature}</span>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-muted-foreground">
+                      Includes full access to Coach House dashboards, Supabase auth, and Stripe
+                      billing integration.
+                    </p>
+                  )}
+                </div>
+                <Button asChild className="w-full" variant={plan.highlight ? "default" : "outline"}>
+                  <Link href={isContactPlan ? "mailto:sales@coachhouse.io" : "/sign-up"}>
+                    {isContactPlan ? "Talk to sales" : "Start free trial"}
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </section>
+
+      <section className="grid gap-4 rounded-3xl border bg-card/60 p-8 md:grid-cols-3">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Everything you need to ship courses</h2>
+          <p className="text-sm text-muted-foreground">
+            Every plan includes enterprise-grade authentication, RLS-ready database migrations, and
+            modern React components built with shadcn/ui.
+          </p>
+        </div>
+        <Separator className="hidden md:block" orientation="vertical" />
+        <div className="grid gap-3 text-sm text-muted-foreground">
+          <div>
+            <span className="font-medium text-foreground">• Transparent billing.</span> Usage maps
+            directly to Stripe subscriptions so finance teams can reconcile quickly.
+          </div>
+          <div>
+            <span className="font-medium text-foreground">• Fast onboarding.</span> Use the included
+            Supabase and Stripe scripts to stand up staging in minutes.
+          </div>
+          <div>
+            <span className="font-medium text-foreground">• Human support.</span> Email us at {" "}
+            <a
+              href="mailto:support@coachhouse.io"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              support@coachhouse.io
+            </a>{" "}
+            to plan your rollout.
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,11 +5,14 @@ const serverEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
   SUPABASE_JWT_SECRET: z.string().min(1).optional(),
+  STRIPE_SECRET_KEY: z.string().min(1).optional(),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1).optional(),
 })
 
 const clientEnvSchema = serverEnvSchema.pick({
   NEXT_PUBLIC_SUPABASE_URL: true,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: true,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: true,
 })
 
 type ServerEnv = z.infer<typeof serverEnvSchema>
@@ -34,9 +37,12 @@ export const env: ServerEnv = assertEnv(serverEnvSchema, {
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
   SUPABASE_JWT_SECRET: process.env.SUPABASE_JWT_SECRET,
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 })
 
 export const clientEnv: ClientEnv = assertEnv(clientEnvSchema, {
   NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
   NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 })

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,107 @@
+import Stripe from "stripe"
+
+import { env } from "@/lib/env"
+
+export type PricingPlan = {
+  id: string
+  name: string
+  amount: number
+  currency: string
+  interval: string
+  description?: string | null
+  features: string[]
+  highlight?: boolean
+}
+
+const FALLBACK_PLANS: PricingPlan[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    amount: 2900,
+    currency: "usd",
+    interval: "month",
+    description: "Launch your first cohort with up to 50 learners.",
+    features: [
+      "Unlimited public lessons",
+      "Email-based support",
+      "Stripe test mode",
+    ],
+  },
+  {
+    id: "growth",
+    name: "Growth",
+    amount: 7900,
+    currency: "usd",
+    interval: "month",
+    description: "Everything you need to scale classes and automate billing.",
+    features: [
+      "Automated enrollment rules",
+      "Supabase row-level security presets",
+      "Priority support & onboarding",
+    ],
+    highlight: true,
+  },
+  {
+    id: "enterprise",
+    name: "Enterprise",
+    amount: 0,
+    currency: "usd",
+    interval: "month",
+    description: "Dedicated success manager, custom SLAs, and enterprise compliance.",
+    features: [
+      "Single sign-on (SSO)",
+      "Enterprise-grade observability",
+      "Custom rollout & migrations",
+    ],
+  },
+]
+
+const stripeClient = env.STRIPE_SECRET_KEY
+  ? new Stripe(env.STRIPE_SECRET_KEY)
+  : null
+
+export async function getPricingPlans(): Promise<PricingPlan[]> {
+  if (!stripeClient) {
+    return FALLBACK_PLANS
+  }
+
+  try {
+    const prices = await stripeClient.prices.list({
+      active: true,
+      type: "recurring",
+      expand: ["data.product"],
+      limit: 10,
+    })
+
+    const plans: PricingPlan[] = prices.data
+      .filter((price) => price.unit_amount && price.currency && price.recurring)
+      .map((price) => {
+        const product = price.product as Stripe.Product | null
+        const featureMetadata = product?.metadata?.features ?? ""
+        const features = featureMetadata
+          ? featureMetadata.split("|").map((entry) => entry.trim()).filter(Boolean)
+          : []
+
+        return {
+          id: price.id,
+          name: price.nickname || product?.name || "Monthly",
+          amount: price.unit_amount ?? 0,
+          currency: price.currency,
+          interval: price.recurring?.interval ?? "month",
+          description: product?.description ?? null,
+          features,
+          highlight: product?.metadata?.highlight === "true",
+        }
+      })
+      .sort((a, b) => a.amount - b.amount)
+
+    if (plans.length === 0) {
+      return FALLBACK_PLANS
+    }
+
+    return plans
+  } catch (error) {
+    console.warn("Failed to load Stripe pricing, falling back to defaults", error)
+    return FALLBACK_PLANS
+  }
+}


### PR DESCRIPTION
**Summary**
- add `/pricing` server component that fetches Stripe prices when credentials exist and falls back to curated tiers otherwise
- wire stripe env validation + sample values, and refresh the landing hero CTA to highlight pricing
- introduce reusable pricing helpers so plan metadata renders with badges, features, and support messaging

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`, `npm run test:rls` – skips without Supabase creds)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Stripe metadata `features` pipe-delimited string populates bullet lists when present; otherwise defaults are shown.
