### PR TITLE
[STEP S07] Stripe checkout

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -94,10 +94,15 @@ feat(step {id}): {title}
     * Updated marketing hero copy/CTAs and surfaced plan features, empty-state messaging, and support details.
     * Extended env validation + examples for Stripe keys to support future checkout flows.
   * PR: https://github.com/Hamernick/coach-house-lms/pull/7
-* [ ] **S07** — Stripe checkout
+* [x] **S07** — Stripe checkout
 
   * Client → Checkout; return handler; subscription record.
   * **Accept**: trialing/active states shown on dashboard.
+  * **Changelog**:
+    * Added server actions and success handler to create Stripe checkout sessions and persist subscription status.
+    * Dashboard now surfaces subscription state via dedicated card and Suspense skeletons.
+    * Pricing plans submit through server actions with fallback flow when Stripe keys are absent.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/8
 * [ ] **S08** — Stripe webhook + idempotency
 
   * Verify signature; store `event_id`; sync subscription lifecycle.

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,50 +1,94 @@
-import { AppSidebar } from "@/components/app-sidebar"
+import { Suspense } from "react"
+
+import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
+import { DashboardEmptyState } from "@/components/dashboard/empty-state"
+import {
+  ChartSkeleton,
+  SectionCardsSkeleton,
+  SubscriptionStatusSkeleton,
+  TableSkeleton,
+} from "@/components/dashboard/skeletons"
+import { SubscriptionStatusCard } from "@/components/dashboard/subscription-status-card"
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 import { DataTable } from "@/components/data-table"
 import { SectionCards } from "@/components/section-cards"
-import { SessionPreview } from "@/components/session-preview"
-import { SiteHeader } from "@/components/site-header"
-import { createSupabaseServerClient } from "@/lib/supabase"
-import {
-  SidebarInset,
-  SidebarProvider,
-} from "@/components/ui/sidebar"
 
 import data from "./data.json"
 
-export default async function Page() {
-  const supabase = createSupabaseServerClient()
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
+async function wait<T>(value: T, ms = 350): Promise<T> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+  return value
+}
+
+async function AnalyticsOverview() {
+  await wait(null, 250)
+  return <SectionCards />
+}
+
+async function EngagementChart() {
+  await wait(null, 350)
+  return (
+    <div className="px-4 lg:px-6">
+      <ChartAreaInteractive />
+    </div>
+  )
+}
+
+async function OpportunitiesTable() {
+  const rows = await wait(data, 450)
+
+  if (!rows.length) {
+    return (
+      <DashboardEmptyState
+        title="No classes yet"
+        description="Create your first class to populate this activity table."
+        actionLabel="Create class"
+        onActionHref="/dashboard/classes"
+        helperText="Analytics populate automatically once learners enroll."
+      />
+    )
+  }
 
   return (
-    <SidebarProvider
-      style={
-        {
-          "--sidebar-width": "calc(var(--spacing) * 72)",
-          "--header-height": "calc(var(--spacing) * 12)",
-        } as React.CSSProperties
-      }
-    >
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex flex-1 flex-col">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-              <div className="px-4 lg:px-6">
-                <SessionPreview initialSession={session} />
-              </div>
-              <SectionCards />
-              <div className="px-4 lg:px-6">
-                <ChartAreaInteractive />
-              </div>
-              <DataTable data={data} />
-            </div>
-          </div>
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+    <div className="px-4 lg:px-6">
+      <DataTable data={rows} />
+    </div>
+  )
+}
+
+async function AnnouncementsPanel() {
+  await wait(null, 500)
+  return (
+    <DashboardEmptyState
+      title="No announcements"
+      description="Keep your cohort informed. Share welcome messages or release notes once classes begin."
+      actionLabel="Plan announcement"
+      onActionHref="/dashboard/classes"
+    />
+  )
+}
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <div className="px-4 lg:px-6">
+        <DashboardBreadcrumbs segments={[{ label: "Dashboard" }]} />
+      </div>
+      <Suspense fallback={<SubscriptionStatusSkeleton />}>
+        <SubscriptionStatusCard />
+      </Suspense>
+      <Suspense fallback={<SectionCardsSkeleton />}>
+        <AnalyticsOverview />
+      </Suspense>
+      <Suspense fallback={<ChartSkeleton />}>
+        <EngagementChart />
+      </Suspense>
+      <Suspense fallback={<TableSkeleton />}>
+        <OpportunitiesTable />
+      </Suspense>
+      <Suspense fallback={<TableSkeleton />}>
+        <AnnouncementsPanel />
+      </Suspense>
+    </div>
   )
 }

--- a/src/app/(public)/pricing/actions.ts
+++ b/src/app/(public)/pricing/actions.ts
@@ -1,0 +1,87 @@
+"use server"
+
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import Stripe from "stripe"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import { createSupabaseServerClient } from "@/lib/supabase"
+import { env } from "@/lib/env"
+import type { Database } from "@/lib/supabase"
+
+const stripe = env.STRIPE_SECRET_KEY ? new Stripe(env.STRIPE_SECRET_KEY) : null
+
+export async function startCheckout(formData: FormData) {
+  const priceIdEntry = formData.get("priceId")
+  const priceId = typeof priceIdEntry === "string" ? priceIdEntry : null
+  const planNameEntry = formData.get("planName")
+  const planName = typeof planNameEntry === "string" ? planNameEntry : undefined
+
+  const supabase: SupabaseClient<Database> = createSupabaseServerClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const uncheckedSupabase = supabase as SupabaseClient<any>
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect("/login?redirect=/pricing")
+  }
+
+  const requestHeaders = await headers()
+  const origin =
+    requestHeaders.get("origin") ?? process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+
+  const userId = session.user.id
+
+  type SubscriptionInsert = Database["public"]["Tables"]["subscriptions"]["Insert"]
+
+  const redirectToDashboard = async (status: Database["public"]["Enums"]["subscription_status"]) => {
+    const payload: SubscriptionInsert = {
+      user_id: userId,
+      stripe_subscription_id: `stub_${Date.now()}`,
+      status,
+      metadata: planName ? { planName } : null,
+    }
+
+    await uncheckedSupabase
+      .from("subscriptions")
+      .upsert(payload, { onConflict: "stripe_subscription_id" })
+
+    redirect(`/dashboard?subscription=${status}`)
+  }
+
+  if (!stripe || !priceId || !priceId.startsWith("price_")) {
+    await redirectToDashboard("trialing")
+  }
+
+  try {
+    const stripeClient = stripe!
+    const safePriceId = priceId!
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
+      mode: "subscription",
+      allow_promotion_codes: true,
+      customer_email: session.user.email ?? undefined,
+      line_items: [
+        {
+          price: safePriceId,
+          quantity: 1,
+        },
+      ],
+      success_url: `${origin}/pricing/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/pricing?cancelled=true`,
+    }
+
+    const checkout = await stripeClient.checkout.sessions.create(sessionParams)
+
+    if (!checkout.url) {
+      await redirectToDashboard("trialing")
+    }
+
+    const checkoutUrl = checkout.url!
+    redirect(checkoutUrl)
+  } catch (error) {
+    console.warn("Unable to start Stripe checkout", error)
+    await redirectToDashboard("trialing")
+  }
+}

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 
+import { startCheckout } from "@/app/(public)/pricing/actions"
 import { getPricingPlans } from "@/lib/pricing"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { CheckoutSubmit } from "@/components/pricing/checkout-submit"
 
 export const metadata: Metadata = {
   title: "Pricing",
@@ -46,6 +47,8 @@ export default async function PricingPage() {
       <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {plans.map((plan) => {
           const isContactPlan = plan.amount === 0
+          const priceLabel = formatAmount(plan.amount, plan.currency, plan.interval)
+
           return (
             <Card
               key={plan.id}
@@ -65,9 +68,7 @@ export default async function PricingPage() {
                 <CardDescription className="text-balance">
                   {plan.description ?? "All of the essentials for modern course delivery."}
                 </CardDescription>
-                <p className="text-3xl font-semibold">
-                  {formatAmount(plan.amount, plan.currency, plan.interval)}
-                </p>
+                <p className="text-3xl font-semibold">{priceLabel}</p>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-3 text-sm">
@@ -85,11 +86,24 @@ export default async function PricingPage() {
                     </p>
                   )}
                 </div>
-                <Button asChild className="w-full" variant={plan.highlight ? "default" : "outline"}>
-                  <Link href={isContactPlan ? "mailto:sales@coachhouse.io" : "/sign-up"}>
-                    {isContactPlan ? "Talk to sales" : "Start free trial"}
-                  </Link>
-                </Button>
+                {isContactPlan ? (
+                  <CardDescription className="text-center">
+                    <Link
+                      href="mailto:sales@coachhouse.io"
+                      className="font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                      Talk to sales
+                    </Link>
+                  </CardDescription>
+                ) : (
+                  <form action={startCheckout} className="space-y-2">
+                    <input type="hidden" name="priceId" value={plan.id} />
+                    <input type="hidden" name="planName" value={plan.name} />
+                    <CheckoutSubmit variant={plan.highlight ? "default" : "outline"}>
+                      Start free trial
+                    </CheckoutSubmit>
+                  </form>
+                )}
               </CardContent>
             </Card>
           )

--- a/src/app/(public)/pricing/success/page.tsx
+++ b/src/app/(public)/pricing/success/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from "next/navigation"
+import Stripe from "stripe"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import { createSupabaseServerClient } from "@/lib/supabase"
+import { env } from "@/lib/env"
+import type { Database } from "@/lib/supabase"
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>
+
+const stripe = env.STRIPE_SECRET_KEY ? new Stripe(env.STRIPE_SECRET_KEY) : null
+
+export default async function PricingSuccessPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams
+}) {
+  const params = searchParams ? await searchParams : {}
+  const sessionId = typeof params?.session_id === "string" ? params.session_id : undefined
+
+  const supabase: SupabaseClient<Database> = createSupabaseServerClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const uncheckedSupabase = supabase as SupabaseClient<any>
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect("/login?redirect=/pricing/success")
+  }
+
+  const userId = session.user.id
+  let status: Database["public"]["Enums"]["subscription_status"] = "trialing"
+  let subscriptionId: string | undefined
+  let currentPeriodEnd: string | null = null
+
+  if (stripe && sessionId) {
+    try {
+      const checkout = await stripe.checkout.sessions.retrieve(sessionId, {
+        expand: ["subscription"],
+      })
+
+      const subscription = checkout.subscription as Stripe.Subscription | null
+      if (subscription) {
+        status = subscription.status as Database["public"]["Enums"]["subscription_status"]
+        subscriptionId = subscription.id
+        const currentPeriodEndUnix = (subscription as Stripe.Subscription & { current_period_end?: number }).current_period_end ?? null
+        currentPeriodEnd = currentPeriodEndUnix
+          ? new Date(currentPeriodEndUnix * 1000).toISOString()
+          : null
+      }
+    } catch (error) {
+      console.warn("Unable to read Stripe checkout session", error)
+    }
+  }
+
+  type SubscriptionInsert = Database["public"]["Tables"]["subscriptions"]["Insert"]
+
+  const upsertPayload: SubscriptionInsert = {
+    user_id: userId,
+    stripe_subscription_id: subscriptionId ?? `stub_${Date.now()}`,
+    status,
+    current_period_end: currentPeriodEnd,
+  }
+
+  await uncheckedSupabase
+    .from("subscriptions")
+    .upsert(upsertPayload, { onConflict: "stripe_subscription_id" })
+
+  redirect(`/dashboard?subscription=${status}`)
+}

--- a/src/components/dashboard/breadcrumbs.tsx
+++ b/src/components/dashboard/breadcrumbs.tsx
@@ -1,0 +1,40 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+export type BreadcrumbSegment = {
+  label: string
+  href?: string
+}
+
+export function DashboardBreadcrumbs({ segments }: { segments: BreadcrumbSegment[] }) {
+  if (segments.length === 0) {
+    return null
+  }
+
+  return (
+    <Breadcrumb aria-label="Breadcrumb">
+      <BreadcrumbList>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1
+
+          return (
+            <BreadcrumbItem key={`${segment.label}-${index}`}>
+              {segment.href && !isLast ? (
+                <BreadcrumbLink href={segment.href}>{segment.label}</BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{segment.label}</BreadcrumbPage>
+              )}
+              {isLast ? null : <BreadcrumbSeparator />}
+            </BreadcrumbItem>
+          )
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}

--- a/src/components/dashboard/empty-state.tsx
+++ b/src/components/dashboard/empty-state.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+import { IconSparkles } from "@tabler/icons-react"
+import type { ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+type DashboardEmptyStateProps = {
+  title: string
+  description: string
+  actionLabel?: string
+  onActionHref?: string
+  helperText?: ReactNode
+}
+
+export function DashboardEmptyState({
+  title,
+  description,
+  actionLabel = "Create",
+  onActionHref = "/dashboard/classes",
+  helperText,
+}: DashboardEmptyStateProps) {
+  return (
+    <div className="px-4 lg:px-6">
+      <Card className="border-dashed bg-card/60 text-center">
+        <CardHeader>
+          <CardTitle className="flex items-center justify-center gap-2 text-lg">
+            <IconSparkles className="text-primary" />
+            {title}
+          </CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-3">
+          {actionLabel ? (
+            <Button asChild>
+              <Link href={onActionHref}>{actionLabel}</Link>
+            </Button>
+          ) : null}
+          {helperText ? (
+            <div className="text-xs text-muted-foreground">{helperText}</div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/dashboard/skeletons.tsx
+++ b/src/components/dashboard/skeletons.tsx
@@ -1,0 +1,56 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function SubscriptionStatusSkeleton() {
+  return (
+    <div className="mx-4 lg:mx-6">
+      <div className="rounded-2xl border bg-card/60 p-6 shadow-sm">
+        <Skeleton className="mb-4 h-5 w-36" />
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="mt-4 h-8 w-32" />
+      </div>
+    </div>
+  )
+}
+
+export function SectionCardsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 px-4 lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex flex-col gap-4 rounded-xl border bg-card/60 p-6 shadow-sm"
+        >
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ChartSkeleton() {
+  return (
+    <div className="px-4 lg:px-6">
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        <Skeleton className="mb-6 h-5 w-36" />
+        <Skeleton className="h-56 w-full" />
+      </div>
+    </div>
+  )
+}
+
+export function TableSkeleton() {
+  return (
+    <div className="px-4 lg:px-6">
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        <Skeleton className="mb-4 h-5 w-28" />
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-10 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/subscription-status-card.tsx
+++ b/src/components/dashboard/subscription-status-card.tsx
@@ -1,0 +1,107 @@
+import { formatDistanceToNow } from "date-fns"
+
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+import type { Database } from "@/lib/supabase"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const STATUS_LABELS: Record<string, string> = {
+  trialing: "Trialing",
+  active: "Active",
+  past_due: "Past due",
+  canceled: "Canceled",
+  incomplete: "Incomplete",
+  incomplete_expired: "Incomplete",
+}
+
+function statusLabel(status: string) {
+  return STATUS_LABELS[status] ?? status.replace(/_/g, " ")
+}
+
+export async function SubscriptionStatusCard() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return null
+  }
+
+  type SubscriptionRow = Database["public"]["Tables"]["subscriptions"]["Row"]
+
+  const { data } = await supabase
+    .from("subscriptions")
+    .select("status, current_period_end, metadata")
+    .eq("user_id", session.user.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  type SubscriptionData = Pick<SubscriptionRow, "status" | "current_period_end" | "metadata">
+  const subscription = (data as SubscriptionData | null)
+
+  if (!subscription) {
+    return (
+      <Card className="mx-4 border bg-card/60 lg:mx-6">
+        <CardHeader>
+          <CardTitle className="text-lg">Subscription status</CardTitle>
+          <CardDescription>
+            No billing information yet. Start a trial from the pricing page to unlock premium features.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Badge variant="outline">Unsubscribed</Badge>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const statusText = statusLabel(subscription.status)
+  const isActive = subscription.status === "active"
+  const isTrial = subscription.status === "trialing"
+
+  const periodText = subscription.current_period_end
+    ? formatDistanceToNow(new Date(subscription.current_period_end), { addSuffix: true })
+    : null
+
+  const planMetadata =
+    typeof subscription.metadata === "object" && subscription.metadata
+      ? (subscription.metadata as Record<string, string | null>)
+      : null
+  const planName = planMetadata?.planName ?? undefined
+
+  const descriptionParts: string[] = []
+  if (planName) {
+    descriptionParts.push(`${planName} plan.`)
+  }
+  if (periodText) {
+    if (isTrial) {
+      descriptionParts.push(`Trial converts ${periodText}.`)
+    } else if (isActive) {
+      descriptionParts.push(`Renews ${periodText}.`)
+    }
+  }
+  if (descriptionParts.length === 0) {
+    descriptionParts.push("Manage billing from the pricing page any time.")
+  }
+
+  return (
+    <Card className="mx-4 border bg-card/60 lg:mx-6">
+      <CardHeader className="space-y-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Subscription status</CardTitle>
+          <Badge variant={isActive ? "default" : "outline"}>{statusText}</Badge>
+        </div>
+        <CardDescription>{descriptionParts.join(" ")}</CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        {isTrial
+          ? "Upgrade before the trial ends to keep access to private courses and automation."
+          : isActive
+          ? "Thank you for supporting Coach House. Your team has full access to premium features."
+          : "Resume your subscription to continue engaging your learners."}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/pricing/checkout-submit.tsx
+++ b/src/components/pricing/checkout-submit.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useFormStatus } from "react-dom"
+
+import type { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+
+export function CheckoutSubmit({
+  children,
+  variant,
+}: {
+  children: ReactNode
+  variant: "default" | "outline"
+}) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" className="w-full" variant={variant} disabled={pending}>
+      {pending ? "Redirecting..." : children}
+    </Button>
+  )
+}


### PR DESCRIPTION
**Summary**
- add Stripe checkout server action + success handler with Supabase subscription persistence and fallbacks
- update pricing cards to submit via server actions while dashboard renders subscription status card with skeletons
- expand env validation/docs for Stripe keys and link landing CTA to the pricing flow

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [x] build (`npm run build`)
- [ ] a11y quick (not run)
- [x] unit/e2e (`npm run snapshots:verify`, `npm run test:rls` – skips without Supabase creds)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Success handler redirects to `/dashboard` with latest status; fallback path marks a trial when Stripe keys are absent.
