### PR TITLE
[STEP S09] Billing management placeholder

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -97,10 +97,14 @@ feat(step {id}): {title}
 
   * Verify signature; store `event_id`; sync subscription lifecycle.
   * **Accept**: replay safe; logs; tests for states.
-* [ ] **S09** — Billing management - We're going to placeholder this. We don't have stripe set up yet so we'll set this up so our flows are created/demonstrated but we'll set it up with functionality later. 
+* [x] **S09** — Billing management - placeholder
 
   * Stripe Customer Portal link; invoices; cancel/resubscribe.
   * **Accept**: portal opens; state reflects after return.
+  * **Changelog**:
+    * Added `/billing` placeholder page outlining upcoming management features and temporary support path.
+    * Surfaced contact CTA in dashboard navigation via visible billing entry.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/10
 * [ ] **S10** — Classes model & list
 
   * CRUD API + RSC queries; `/dashboard` cards with progress stub.

--- a/src/app/(dashboard)/billing/page.tsx
+++ b/src/app/(dashboard)/billing/page.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+export default function BillingPlaceholderPage() {
+  return (
+    <div className="space-y-6 px-4 py-6 lg:px-6">
+      <Card className="border-dashed bg-card/70">
+        <CardHeader>
+          <CardTitle>Billing management coming soon</CardTitle>
+          <CardDescription>
+            Stripe customer portal integration ships in a later step. For now, reach out and our
+            team will adjust your subscription manually.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="text-sm text-muted-foreground">
+            Need to upgrade, downgrade, or change payment methods? Email
+            <a
+              href="mailto:support@coachhouse.io"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              {" "}support@coachhouse.io
+            </a>
+            and include your workspace name.
+          </div>
+          <Button asChild variant="outline" className="self-start">
+            <a href="/pricing">View plans</a>
+          </Button>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>What to expect next</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>• Stripe customer portal link will appear here once credentials are connected.</p>
+          <p>• Subscription status on the dashboard already reflects the latest webhook data.</p>
+          <p>• Webhook events are stored in Supabase for replay-safe processing.</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
**Summary**
- add `/billing` placeholder page that explains manual plan changes while Stripe portal work is pending
- keep dashboard navigation functional so users can reach the messaging, linking back to pricing/support
- update the runbook with S09 completion and PR reference

**Checks**
- [ ] typecheck (not run)
- [ ] lint (not run)
- [ ] build (not run)
- [ ] a11y quick (not run)
- [ ] unit/e2e (not run)

**Screens**
- [ ] light
- [ ] dark
- [ ] mobile

**Notes**
- Messaging mirrors the S09 scope (“placeholder”) and points to support@coachhouse.io.
