### PR TITLE
[STEP S12] Admin classes/modules CRUD

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -134,10 +134,15 @@ feat(step {id}): {title}
 
   * Canonical route `/class/[slug]/module/[index]`; video embed; markdown render; form inputs; Prev/Next.
   * **Accept**: completing module 1 unlocks 2.
-* [ ] **S12** — Admin: classes/modules CRUD
+* [x] **S12** — Admin: classes/modules CRUD
 
   * `/admin/classes`, `/admin/classes/[id]`, `/admin/modules/[id]`; drag‑reorder; publish/unpublish.
   * **Accept**: reorder persists; publish toggles visibility.
+  * **Changelog**:
+    * Added admin layout plus classes table with create/delete and publish toggles.
+    * Built class detail editor with metadata form, module reorder drag-and-drop, and module creation flow.
+    * Implemented module editor with markdown preview, video metadata, and delete controls.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/14
 * [ ] **S13** — PDF storage (signed URLs)
 
   * Supabase Storage `decks` private; server‑generated signed URLs; upload UI.

--- a/src/app/(admin)/admin/classes/[id]/_components/module-list-manager.tsx
+++ b/src/app/(admin)/admin/classes/[id]/_components/module-list-manager.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import Link from "next/link"
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { IconGripVertical } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+
+import { deleteModuleAction, reorderModulesAction } from "../actions"
+import { ModulePublishedToggle } from "./module-published-toggle"
+
+type ModuleItem = {
+  id: string
+  title: string
+  slug: string
+  idx: number
+  published: boolean
+}
+
+export function ModuleListManager({
+  classId,
+  modules,
+}: {
+  classId: string
+  modules: ModuleItem[]
+}) {
+  const sorted = useMemo(() => [...modules].sort((a, b) => a.idx - b.idx), [modules])
+  const [items, setItems] = useState(sorted)
+  const [isPending, startTransition] = useTransition()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor)
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) {
+      return
+    }
+
+    setItems((current) => {
+      const oldIndex = current.findIndex((module) => module.id === active.id)
+      const newIndex = current.findIndex((module) => module.id === over.id)
+      const next = arrayMove(current, oldIndex, newIndex).map((module, index) => ({
+        ...module,
+        idx: index + 1,
+      }))
+
+      startTransition(async () => {
+        await reorderModulesAction(
+          classId,
+          next.map((module) => module.id)
+        )
+      })
+
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-3">
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={items.map((item) => item.id)} strategy={verticalListSortingStrategy}>
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <SortableModuleRow
+                key={item.id}
+                module={item}
+                classId={classId}
+                disabled={isPending}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+      {isPending ? <p className="text-xs text-muted-foreground">Saving new order…</p> : null}
+    </div>
+  )
+}
+
+function SortableModuleRow({
+  module,
+  classId,
+  disabled,
+}: {
+  module: ModuleItem
+  classId: string
+  disabled: boolean
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: module.id,
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="rounded-xl border bg-card/60 p-4 shadow-sm"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-1 items-start gap-3">
+          <button
+            type="button"
+            className="mt-1 text-muted-foreground transition hover:text-foreground"
+            aria-label="Reorder module"
+            {...attributes}
+            {...listeners}
+            disabled={disabled}
+          >
+            <IconGripVertical className="size-4" />
+          </button>
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold">Module {module.idx}</span>
+              <Badge variant={module.published ? "default" : "outline"}>
+                {module.published ? "Published" : "Draft"}
+              </Badge>
+            </div>
+            <span className="text-sm text-muted-foreground">{module.title}</span>
+            <span className="text-xs text-muted-foreground">Slug: {module.slug}</span>
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center">
+          <ModulePublishedToggle
+            moduleId={module.id}
+            classId={classId}
+            published={module.published}
+          />
+          <div className="flex gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/admin/modules/${module.id}`}>Edit</Link>
+            </Button>
+            <form action={deleteModuleAction} className="inline">
+              <input type="hidden" name="moduleId" value={module.id} />
+              <input type="hidden" name="classId" value={classId} />
+              <Button size="sm" variant="destructive">
+                Delete
+              </Button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/src/app/(admin)/admin/classes/[id]/_components/module-published-toggle.tsx
+++ b/src/app/(admin)/admin/classes/[id]/_components/module-published-toggle.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+
+import { Switch } from "@/components/ui/switch"
+
+import { setModulePublishedAction } from "../actions"
+
+export function ModulePublishedToggle({
+  moduleId,
+  classId,
+  published,
+}: {
+  moduleId: string
+  classId: string
+  published: boolean
+}) {
+  const [checked, setChecked] = useState(published)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    setChecked(published)
+  }, [published])
+
+  return (
+    <Switch
+      checked={checked}
+      onCheckedChange={(next) => {
+        setChecked(next)
+        startTransition(async () => {
+          await setModulePublishedAction(moduleId, classId, next)
+        })
+      }}
+      disabled={isPending}
+    />
+  )
+}

--- a/src/app/(admin)/admin/classes/[id]/actions.ts
+++ b/src/app/(admin)/admin/classes/[id]/actions.ts
@@ -1,0 +1,136 @@
+"use server"
+
+import { randomUUID } from "node:crypto"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireAdmin } from "@/lib/admin/auth"
+
+export async function updateClassDetailsAction(formData: FormData) {
+  const classId = formData.get("classId")
+  const title = formData.get("title")
+  const slug = formData.get("slug")
+  const description = formData.get("description")
+  const stripeProductId = formData.get("stripeProductId")
+  const stripePriceId = formData.get("stripePriceId")
+
+  if (typeof classId !== "string" || typeof title !== "string" || typeof slug !== "string") {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase
+    .from("classes")
+    .update({
+      title: title.trim(),
+      slug: slug.trim(),
+      description: typeof description === "string" ? description : null,
+      stripe_product_id: typeof stripeProductId === "string" && stripeProductId.length > 0 ? stripeProductId : null,
+      stripe_price_id: typeof stripePriceId === "string" && stripePriceId.length > 0 ? stripePriceId : null,
+    })
+    .eq("id", classId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+  revalidatePath("/admin/classes")
+}
+
+export async function createModuleAction(formData: FormData) {
+  const classId = formData.get("classId")
+
+  if (typeof classId !== "string") {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const { data: maxIdxData, error: idxError } = await supabase
+    .from("modules")
+    .select("idx")
+    .eq("class_id", classId)
+    .order("idx", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (idxError) {
+    throw idxError
+  }
+
+  const nextIdx = maxIdxData ? maxIdxData.idx + 1 : 1
+  const slug = `module-${randomUUID().slice(0, 8)}`
+
+  const { data, error } = await supabase
+    .from("modules")
+    .insert({
+      class_id: classId,
+      idx: nextIdx,
+      slug,
+      title: "Untitled Module",
+      content_md: "",
+      published: false,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+
+  redirect(`/admin/modules/${data.id}`)
+}
+
+export async function reorderModulesAction(classId: string, orderedIds: string[]) {
+  const { supabase } = await requireAdmin()
+
+  const updates = orderedIds.map((id, index) => ({ id, idx: index + 1 }))
+
+  const { error } = await supabase.from("modules").upsert(updates, { onConflict: "id" })
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+}
+
+export async function deleteModuleAction(formData: FormData) {
+  const moduleId = formData.get("moduleId")
+  const classId = formData.get("classId")
+
+  if (typeof moduleId !== "string" || typeof classId !== "string") {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase.from("modules").delete().eq("id", moduleId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+}
+
+export async function setModulePublishedAction(moduleId: string, classId: string, published: boolean) {
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase
+    .from("modules")
+    .update({ published })
+    .eq("id", moduleId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+  revalidatePath(`/admin/modules/${moduleId}`)
+}

--- a/src/app/(admin)/admin/classes/[id]/page.tsx
+++ b/src/app/(admin)/admin/classes/[id]/page.tsx
@@ -1,0 +1,124 @@
+import { notFound } from "next/navigation"
+
+import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { getClassById } from "@/lib/classes"
+
+import { ClassPublishedToggle } from "../../_components/class-published-toggle"
+import {
+  createModuleAction,
+  updateClassDetailsAction,
+} from "./actions"
+import { ModuleListManager } from "./_components/module-list-manager"
+
+export default async function AdminClassDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const classData = await getClassById(params.id)
+
+  if (!classData) {
+    notFound()
+  }
+
+  const modules = (classData.modules ?? []).map((module) => ({
+    id: module.id,
+    title: module.title,
+    slug: module.slug,
+    idx: module.idx,
+    published: module.published,
+  }))
+
+  return (
+    <div className="space-y-6">
+      <DashboardBreadcrumbs
+        segments={[
+          { label: "Admin", href: "/admin/classes" },
+          { label: classData.title },
+        ]}
+      />
+      <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+        <Card className="bg-card/60">
+          <CardHeader>
+            <CardTitle>Class details</CardTitle>
+            <CardDescription>Update metadata and publication state.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form action={updateClassDetailsAction} className="space-y-4">
+              <input type="hidden" name="classId" value={classData.id} />
+              <div className="space-y-2">
+                <Label htmlFor="title">Title</Label>
+                <Input id="title" name="title" defaultValue={classData.title} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="slug">Slug</Label>
+                <Input id="slug" name="slug" defaultValue={classData.slug} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  name="description"
+                  defaultValue={classData.description ?? ""}
+                  className="min-h-32"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stripeProductId">Stripe product ID</Label>
+                <Input
+                  id="stripeProductId"
+                  name="stripeProductId"
+                  defaultValue={classData.stripe_product_id ?? ""}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="stripePriceId">Stripe price ID</Label>
+                <Input
+                  id="stripePriceId"
+                  name="stripePriceId"
+                  defaultValue={classData.stripe_price_id ?? ""}
+                />
+              </div>
+              <div className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <p className="text-sm font-medium">Published</p>
+                  <p className="text-xs text-muted-foreground">
+                    Toggle visibility for students. Draft classes stay hidden.
+                  </p>
+                </div>
+                <ClassPublishedToggle classId={classData.id} published={classData.published} />
+              </div>
+              <Button type="submit">Save changes</Button>
+            </form>
+          </CardContent>
+        </Card>
+        <Card className="bg-card/60">
+          <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>Modules</CardTitle>
+              <CardDescription>Reorder modules or manage publication status.</CardDescription>
+            </div>
+            <form action={createModuleAction}>
+              <input type="hidden" name="classId" value={classData.id} />
+              <Button type="submit">Add module</Button>
+            </form>
+          </CardHeader>
+          <CardContent>
+            {modules.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No modules yet. Create one to start building your class.
+              </p>
+            ) : (
+              <ModuleListManager classId={classData.id} modules={modules} />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/classes/_components/class-published-toggle.tsx
+++ b/src/app/(admin)/admin/classes/_components/class-published-toggle.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+
+import { Switch } from "@/components/ui/switch"
+
+import { setClassPublishedAction } from "../actions"
+
+export function ClassPublishedToggle({
+  classId,
+  published,
+}: {
+  classId: string
+  published: boolean
+}) {
+  const [checked, setChecked] = useState(published)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    setChecked(published)
+  }, [published])
+
+  return (
+    <Switch
+      checked={checked}
+      onCheckedChange={(next) => {
+        setChecked(next)
+        startTransition(async () => {
+          await setClassPublishedAction(classId, next)
+        })
+      }}
+      disabled={isPending}
+    />
+  )
+}

--- a/src/app/(admin)/admin/classes/actions.ts
+++ b/src/app/(admin)/admin/classes/actions.ts
@@ -1,0 +1,65 @@
+"use server"
+
+import { randomUUID } from "node:crypto"
+
+import { redirect } from "next/navigation"
+import { revalidatePath } from "next/cache"
+
+import { requireAdmin } from "@/lib/admin/auth"
+
+export async function createClassAction() {
+  const { supabase } = await requireAdmin()
+
+  const slug = `class-${randomUUID().slice(0, 8)}`
+
+  const { data, error } = await supabase
+    .from("classes")
+    .insert({
+      title: "Untitled Class",
+      slug,
+      description: "",
+      published: false,
+    })
+    .select("id")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  redirect(`/admin/classes/${data.id}`)
+}
+
+export async function deleteClassAction(formData: FormData) {
+  const classId = formData.get("classId")
+
+  if (typeof classId !== "string") {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase.from("classes").delete().eq("id", classId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath("/admin/classes")
+}
+
+export async function setClassPublishedAction(classId: string, published: boolean) {
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase
+    .from("classes")
+    .update({ published })
+    .eq("id", classId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath("/admin/classes")
+  revalidatePath(`/admin/classes/${classId}`)
+}

--- a/src/app/(admin)/admin/classes/page.tsx
+++ b/src/app/(admin)/admin/classes/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link"
+
+import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { listClasses } from "@/lib/classes"
+
+import { ClassPublishedToggle } from "./_components/class-published-toggle"
+import { createClassAction, deleteClassAction } from "./actions"
+
+export default async function AdminClassesPage() {
+  const { items } = await listClasses({ pageSize: 100 })
+
+  return (
+    <div className="space-y-6">
+      <DashboardBreadcrumbs segments={[{ label: "Admin" }, { label: "Classes" }]} />
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Classes</h1>
+          <p className="text-sm text-muted-foreground">
+            Manage class content, publication state, and modules.
+          </p>
+        </div>
+        <form action={createClassAction}>
+          <Button type="submit">New Class</Button>
+        </form>
+      </div>
+      <div className="overflow-hidden rounded-xl border">
+        <Table>
+          <TableHeader className="bg-muted/40">
+            <TableRow>
+              <TableHead className="w-[30%]">Title</TableHead>
+              <TableHead>Slug</TableHead>
+              <TableHead>Modules</TableHead>
+              <TableHead>Published</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-12 text-center text-sm text-muted-foreground">
+                  No classes yet. Create one to get started.
+                </TableCell>
+              </TableRow>
+            ) : null}
+            {items.map((item) => (
+              <TableRow key={item.id} className="hover:bg-muted/20">
+                <TableCell className="font-medium">{item.title}</TableCell>
+                <TableCell className="text-sm text-muted-foreground">{item.slug}</TableCell>
+                <TableCell className="text-sm">{item.moduleCount}</TableCell>
+                <TableCell>
+                  <ClassPublishedToggle classId={item.id} published={item.published} />
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end gap-2">
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/admin/classes/${item.id}`}>Edit</Link>
+                    </Button>
+                    <form action={deleteClassAction} className="inline">
+                      <input type="hidden" name="classId" value={item.id} />
+                      <Button size="sm" variant="destructive">
+                        Delete
+                      </Button>
+                    </form>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/modules/[id]/_components/markdown-editor.tsx
+++ b/src/app/(admin)/admin/modules/[id]/_components/markdown-editor.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useState } from "react"
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+import { Textarea } from "@/components/ui/textarea"
+
+export function MarkdownEditor({
+  name,
+  defaultValue = "",
+}: {
+  name: string
+  defaultValue?: string
+}) {
+  const [value, setValue] = useState(defaultValue)
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium" htmlFor={name}>
+          Markdown content
+        </label>
+        <Textarea
+          id={name}
+          name={name}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          className="min-h-[300px]"
+        />
+      </div>
+      <div className="rounded-lg border bg-card/40 p-4">
+        <p className="text-sm font-medium text-muted-foreground">Preview</p>
+        <article className="prose prose-sm prose-invert mt-3 max-w-none">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{value || "_No content yet._"}</ReactMarkdown>
+        </article>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/modules/[id]/actions.ts
+++ b/src/app/(admin)/admin/modules/[id]/actions.ts
@@ -1,0 +1,72 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireAdmin } from "@/lib/admin/auth"
+
+export async function updateModuleDetailsAction(formData: FormData) {
+  const moduleId = formData.get("moduleId")
+  const classId = formData.get("classId")
+  const title = formData.get("title")
+  const slug = formData.get("slug")
+  const description = formData.get("description")
+  const videoUrl = formData.get("videoUrl")
+  const duration = formData.get("durationMinutes")
+  const content = formData.get("contentMd")
+
+  if (
+    typeof moduleId !== "string" ||
+    typeof classId !== "string" ||
+    typeof title !== "string" ||
+    typeof slug !== "string"
+  ) {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const durationValue =
+    typeof duration === "string" && duration.length > 0
+      ? Number.parseInt(duration, 10)
+      : null
+
+  const { error } = await supabase
+    .from("modules")
+    .update({
+      title: title.trim(),
+      slug: slug.trim(),
+      description: typeof description === "string" ? description : null,
+      video_url: typeof videoUrl === "string" && videoUrl.length > 0 ? videoUrl : null,
+      duration_minutes: Number.isFinite(durationValue) ? durationValue : null,
+      content_md: typeof content === "string" ? content : null,
+    })
+    .eq("id", moduleId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+  revalidatePath(`/admin/modules/${moduleId}`)
+}
+
+export async function deleteModuleFromDetailAction(formData: FormData) {
+  const moduleId = formData.get("moduleId")
+  const classId = formData.get("classId")
+
+  if (typeof moduleId !== "string" || typeof classId !== "string") {
+    return
+  }
+
+  const { supabase } = await requireAdmin()
+
+  const { error } = await supabase.from("modules").delete().eq("id", moduleId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath(`/admin/classes/${classId}`)
+  redirect(`/admin/classes/${classId}`)
+}

--- a/src/app/(admin)/admin/modules/[id]/page.tsx
+++ b/src/app/(admin)/admin/modules/[id]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation"
+
+import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { requireAdmin } from "@/lib/admin/auth"
+
+import { ModulePublishedToggle } from "../../classes/[id]/_components/module-published-toggle"
+import { MarkdownEditor } from "./_components/markdown-editor"
+import { deleteModuleFromDetailAction, updateModuleDetailsAction } from "./actions"
+
+export default async function AdminModuleDetailPage({
+  params,
+}: {
+  params: { id: string }
+}) {
+  const { supabase } = await requireAdmin()
+
+  const { data, error } = await supabase
+    .from("modules")
+    .select(
+      "id, class_id, idx, slug, title, description, video_url, content_md, duration_minutes, published, classes ( id, title, slug )"
+    )
+    .eq("id", params.id)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data || !data.classes) {
+    notFound()
+  }
+
+  const parentClass = data.classes
+
+  return (
+    <div className="space-y-6">
+      <DashboardBreadcrumbs
+        segments={[
+          { label: "Admin", href: "/admin/classes" },
+          { label: parentClass.title, href: `/admin/classes/${parentClass.id}` },
+          { label: data.title },
+        ]}
+      />
+      <Card className="bg-card/60">
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>{data.title}</CardTitle>
+            <CardDescription>Update module content and metadata.</CardDescription>
+          </div>
+          <div className="flex items-center gap-2 rounded-lg border p-3">
+            <span className="text-sm font-medium">Published</span>
+            <ModulePublishedToggle moduleId={data.id} classId={data.class_id} published={data.published} />
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <form action={updateModuleDetailsAction} className="space-y-5">
+            <input type="hidden" name="moduleId" value={data.id} />
+            <input type="hidden" name="classId" value={data.class_id} />
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="title">Title</Label>
+                <Input id="title" name="title" defaultValue={data.title} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="slug">Slug</Label>
+                <Input id="slug" name="slug" defaultValue={data.slug} required />
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  name="description"
+                  defaultValue={data.description ?? ""}
+                  className="min-h-24"
+                />
+              </div>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="videoUrl">Video URL</Label>
+                  <Input id="videoUrl" name="videoUrl" defaultValue={data.video_url ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="durationMinutes">Duration (minutes)</Label>
+                  <Input
+                    id="durationMinutes"
+                    name="durationMinutes"
+                    type="number"
+                    min={0}
+                    defaultValue={data.duration_minutes ?? ""}
+                  />
+                </div>
+              </div>
+            </div>
+            <MarkdownEditor name="contentMd" defaultValue={data.content_md ?? ""} />
+            <Button type="submit">Save changes</Button>
+          </form>
+          <form action={deleteModuleFromDetailAction} className="inline-flex">
+            <input type="hidden" name="moduleId" value={data.id} />
+            <input type="hidden" name="classId" value={data.class_id} />
+            <Button type="submit" variant="destructive">
+              Delete module
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+import type { ReactNode } from "react"
+
+import { requireAdmin } from "@/lib/admin/auth"
+import { cn } from "@/lib/utils"
+
+const NAV_ITEMS = [{ href: "/admin/classes", label: "Classes" }]
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  await requireAdmin()
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b bg-card/40 backdrop-blur">
+        <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4">
+          <Link href="/dashboard" className="text-base font-semibold">
+            Coach House Admin
+          </Link>
+          <nav className="flex items-center gap-3 text-sm text-muted-foreground">
+            {NAV_ITEMS.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "rounded-md px-3 py-2 font-medium hover:bg-accent hover:text-accent-foreground"
+                )}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-6xl px-4 py-8">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -50,8 +50,6 @@ export default async function DashboardPage() {
   const {
     data: { session },
   } = await supabase.auth.getSession()
-
-export default function DashboardPage() {
   return (
     <SidebarProvider
       style={

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -1,0 +1,38 @@
+import { redirect } from "next/navigation"
+import { cache } from "react"
+
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+
+type AdminContext = {
+  supabase: ReturnType<typeof createSupabaseServerClient>
+  userId: string
+}
+
+async function requireAdminInternal(): Promise<AdminContext> {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", session.user.id)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!profile || profile.role !== "admin") {
+    redirect("/dashboard")
+  }
+
+  return { supabase, userId: session.user.id }
+}
+
+export const requireAdmin = cache(requireAdminInternal)


### PR DESCRIPTION
## Summary
- Add admin layout and role guard plus  table with create/delete/publish controls.
- Build class detail editor with metadata form, module reorder drag-and-drop, and module creation flow.
- Implement module detail editor with markdown preview, video metadata, and delete actions.

## Risks
- Medium: reordering modules and publish toggles rely on Supabase admin RLS paths; ensure admin role is seeded.

## Checks
- `npm run lint`

## Screens
- n/a

## Notes
- No migrations.