### PR TITLE
[STEP S09] Billing placeholder

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -115,11 +115,16 @@ feat(step {id}): {title}
     * Pricing checkout and dashboard reflect subscription status end-to-end with fallbacks when Stripe keys are absent.
 
   * PR: https://github.com/Hamernick/coach-house-lms/pull/8
-* [ ] **S09** — Billing management - We're going to placeholder this. We don't have stripe set up yet so we'll set this up so our flows are created/demonstrated but we'll set it up with functionality later. 
+* [x] **S09** — Billing management - We're going to placeholder this. We don't have stripe set up yet so we'll set this up so our flows are created/demonstrated but we'll set it up with functionality later. 
 
 
   * Stripe Customer Portal link; invoices; cancel/resubscribe.
   * **Accept**: portal opens; state reflects after return.
+  * **Changelog**:
+    * Added billing portal server action/button that redirects when Stripe credentials are set.
+    * Surfaced fallback messaging and support link when Stripe is not configured.
+    * Documented placeholder expectations for follow-up implementation.
+  * PR: TODO
 
 * [x] **S10** — Classes model & list
 

--- a/src/app/(dashboard)/billing/actions.ts
+++ b/src/app/(dashboard)/billing/actions.ts
@@ -1,0 +1,59 @@
+"use server"
+
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+import Stripe from "stripe"
+
+import { env } from "@/lib/env"
+import { logger } from "@/lib/logger"
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+
+export async function createBillingPortalSession() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect("/login?redirect=/billing")
+  }
+
+  if (!env.STRIPE_SECRET_KEY) {
+    return { error: "Billing portal not available yet." }
+  }
+
+  const { data: subscription, error } = await supabase
+    .from("subscriptions")
+    .select("stripe_customer_id")
+    .eq("user_id", session.user.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    logger.error("billing_portal_subscription_lookup_failed", error, { userId: session.user.id })
+    return { error: "Unable to locate your subscription." }
+  }
+
+  const customerId = subscription?.stripe_customer_id
+  if (!customerId) {
+    return { error: "No Stripe customer linked to this account yet." }
+  }
+
+  const stripe = new Stripe(env.STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" })
+  const origin = headers().get("origin") ?? "https://coachhouse.local"
+
+  try {
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${origin}/billing`,
+    })
+
+    logger.info("billing_portal_session_created", { userId: session.user.id })
+
+    return { url: portalSession.url }
+  } catch (portalError) {
+    logger.error("billing_portal_session_failed", portalError, { userId: session.user.id })
+    return { error: "We couldn't open the billing portal. Contact support." }
+  }
+}

--- a/src/app/(dashboard)/billing/billing-portal-button.tsx
+++ b/src/app/(dashboard)/billing/billing-portal-button.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTransition } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+
+import { createBillingPortalSession } from "./actions"
+
+export function BillingPortalButton() {
+  const [isPending, startTransition] = useTransition()
+
+  function handleOpenPortal() {
+    startTransition(async () => {
+      const result = await createBillingPortalSession()
+      if (result?.url) {
+        window.location.href = result.url
+      } else if (result?.error) {
+        toast.error(result.error)
+      } else {
+        toast.error("Billing portal is currently unavailable.")
+      }
+    })
+  }
+
+  return (
+    <Button onClick={handleOpenPortal} disabled={isPending} variant="outline">
+      {isPending ? "Opening portal..." : "Open billing portal"}
+    </Button>
+  )
+}

--- a/src/app/(dashboard)/billing/page.tsx
+++ b/src/app/(dashboard)/billing/page.tsx
@@ -1,31 +1,46 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 
+import { env } from "@/lib/env"
+
+import { BillingPortalButton } from "./billing-portal-button"
+
+const PORTAL_READY = Boolean(env.STRIPE_SECRET_KEY)
+
 export default function BillingPlaceholderPage() {
   return (
     <div className="space-y-6 px-4 py-6 lg:px-6">
       <Card className="border-dashed bg-card/70">
         <CardHeader>
-          <CardTitle>Billing management coming soon</CardTitle>
+          <CardTitle>Billing management</CardTitle>
           <CardDescription>
-            Stripe customer portal integration ships in a later step. For now, reach out and our
-            team will adjust your subscription manually.
+            {PORTAL_READY
+              ? "Manage your subscription through the Stripe customer portal."
+              : "Stripe customer portal integration ships in a later step. For now, reach out and our team will adjust your subscription manually."}
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-3">
           <div className="text-sm text-muted-foreground">
-            Need to upgrade, downgrade, or change payment methods? Email
+            {PORTAL_READY ? (
+              <>Open the portal to update payment methods, change plan, or cancel/resume your subscription.</>
+            ) : (
+              <>Need to upgrade, downgrade, or change payment methods? Email</>
+            )}
             <a
               href="mailto:support@coachhouse.io"
               className="font-medium text-primary underline-offset-4 hover:underline"
             >
               {" "}support@coachhouse.io
             </a>
-            and include your workspace name.
+            {PORTAL_READY ? " if you need additional help." : " and include your workspace name."}
           </div>
-          <Button asChild variant="outline" className="self-start">
-            <a href="/pricing">View plans</a>
-          </Button>
+          {PORTAL_READY ? (
+            <BillingPortalButton />
+          ) : (
+            <Button asChild variant="outline" className="self-start">
+              <a href="/pricing">View plans</a>
+            </Button>
+          )}
         </CardContent>
       </Card>
       <Card>
@@ -33,7 +48,11 @@ export default function BillingPlaceholderPage() {
           <CardTitle>What to expect next</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-muted-foreground">
-          <p>• Stripe customer portal link will appear here once credentials are connected.</p>
+          <p>
+            • {PORTAL_READY
+              ? "Stripe customer portal is now available for self-serve management."
+              : "Stripe customer portal link will appear here once credentials are connected."}
+          </p>
           <p>• Subscription status on the dashboard already reflects the latest webhook data.</p>
           <p>• Webhook events are stored in Supabase for replay-safe processing.</p>
         </CardContent>


### PR DESCRIPTION
## Summary
- Added billing portal server action/button to redirect to Stripe when credentials exist.
- Surface fallback messaging and support contact when Stripe keys or customer IDs are missing.
- Documented placeholder expectations in the runbook.

## Risks
- Low: portal depends on Stripe env vars; caller receives friendly error otherwise.

## Checks
- `npm run lint`

## Screens
- n/a

## Notes
- No migrations.
