### PR TITLE
[STEP S21] App shell polish

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -208,6 +208,35 @@ feat(step {id}): {title}
     * Exposed module progress helpers for sequential unlock validation and wired the suite into CI.
   * PR: https://github.com/Hamernick/coach-house-lms/pull/29
 
+* [x] **S21** — App shell polish
+
+  * Remove locale/GitHub controls; surface `Support` mailto (contact@coachhousesolutions.org); show accurate user name/email with working sign-out.
+  * **Accept**: header actions match spec across dashboard/admin layouts; sign-out verified.
+  * **Changelog**:
+    * Replaced header controls with Support mailto and Supabase-backed user menu displaying name/email.
+    * Added client dropdown with settings shortcut and sign-out action driven by Supabase.
+  * PR: https://github.com/Hamernick/coach-house-lms/pull/30
+
+* [ ] **S22** — Dashboard duplication fix
+
+  * Ensure `/dashboard` and `/admin` render a single shell instance (no nested dashboards).
+  * **Accept**: visual inspection/screenshots confirm single layout; regression covered with acceptance test update.
+
+* [ ] **S23** — Student navigation pages
+
+  * Implement `/classes`, `/schedule`, `/settings` with responsive layouts, placeholder data (fetch stubs), and links from sidebar.
+  * **Accept**: routes accessible; empty/loading states present; settings surfaces marketing/newsletter toggles.
+
+* [ ] **S24** — Admin overview content
+
+  * Flesh out `/admin` landing (KPIs + recent activity) using existing data services.
+  * **Accept**: admin homepage populated with cards/table/skeletons.
+
+* [ ] **S25** — Onboarding flow
+
+  * Build first-login onboarding stepper (name, role, goals, marketing/newsletter opt-ins) patterned after shadcn example; persist completion flag.
+  * **Accept**: onboarding runs once per user, stores preferences, and redirects to dashboard.
+
 ## Controller prompt (for “Proceed” runs)
 
 > Read `CODEX_RUNBOOK.md`. Identify the first unchecked step. Execute only that step. Produce a PR with the prescribed template. Update the checkbox to checked, add a short **Changelog** section under the step with what changed, and append a link to the PR. End with `DONE`.

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { CircleUser, LogOut } from "lucide-react"
+
+import { useSupabaseClient } from "@/hooks/use-supabase-client"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+type UserMenuProps = {
+  name?: string | null
+  email?: string | null
+}
+
+export function UserMenu({ name, email }: UserMenuProps) {
+  const supabase = useSupabaseClient()
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function signOut() {
+    startTransition(async () => {
+      await supabase.auth.signOut()
+      router.replace("/login")
+      router.refresh()
+    })
+  }
+
+  const displayName = name && name.trim().length > 0 ? name : email ?? "Account"
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="flex items-center gap-2">
+          <CircleUser className="h-4 w-4" aria-hidden />
+          <span className="max-w-[140px] truncate text-sm font-medium">{displayName}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel>
+          <div>
+            <p className="text-sm font-medium leading-tight">{displayName}</p>
+            {email ? (
+              <p className="text-xs text-muted-foreground leading-tight">{email}</p>
+            ) : null}
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <a href="/settings" className="w-full cursor-pointer">
+            Settings
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="flex items-center gap-2 text-destructive focus:text-destructive"
+          onSelect={(event) => {
+            event.preventDefault()
+            if (!isPending) {
+              signOut()
+            }
+          }}
+        >
+          <LogOut className="h-4 w-4" aria-hidden />
+          {isPending ? "Signing out..." : "Sign out"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary
- replace locale/github header controls with a Support mailto and authenticated user menu
- fetch Supabase profile/session server-side and surface name/email in a dropdown
- add a client user menu component with settings link and working sign-out action

## Checks
- [x] typecheck (npm run build)
- [x] lint (npm run build)
- [x] build
- [x] unit / acceptance (npm run test:acceptance)
- [ ] a11y quick

## Notes
- no migrations