### PR TITLE
[STEP S23] Student navigation pages

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -226,10 +226,17 @@ feat(step {id}): {title}
   * PR: https://github.com/Hamernick/coach-house-lms/pull/31
 
 
-* [ ] **S23** — Student navigation pages
+* [x] **S23** — Student navigation pages
 
   * Implement `/classes`, `/schedule`, `/settings` with responsive layouts, placeholder data (fetch stubs), and links from sidebar.
   * **Accept**: routes accessible; empty/loading states present; settings surfaces marketing/newsletter toggles.
+  * **Changelog**:
+    * Added student navigation routes under `(dashboard)`: `/classes`, `/schedule`, and `/settings`, each protected by SSR auth.
+    * `/classes`: paginated grid of enrolled classes via Supabase RSC fetch with empty state and breadcrumb; links into canonical module route.
+    * `/schedule`: responsive card list showing placeholder upcoming events with types and formatted times.
+    * `/settings`: profile form (full name) plus marketing/newsletter opt-in checkboxes backed by Supabase user metadata; server actions with revalidation and success notice.
+    * Sidebar updated to include Classes, Schedule, and Settings entries.
+  * PR: (pending)
 
 * [ ] **S24** — Admin overview content
 


### PR DESCRIPTION
## Summary
Adds student navigation pages and links:
- `/classes`: paginated grid with empty state and breadcrumb; links to canonical module route.
- `/schedule`: responsive list of upcoming events (placeholder data, server rendered).
- `/settings`: profile name update and marketing/newsletter opt-ins via Supabase user metadata with server actions, revalidation, and success notice.
- Sidebar includes Classes, Schedule, and Settings entries.

All pages are SSR-auth protected and match the dashboard shell patterns.

## Checks
- [x] typecheck
- [x] lint
- [x] build
- [x] unit
- [x] e2e
- [ ] a11y quick

## Notes
- No schema changes. No migrations required.
- Backwards compatible; routes are additive within the dashboard group.

## Links
- Runbook step: docs/CODEX_RUNBOOK.md (S23)
