### PR TITLE
Make Supabase server client async

### DIFF
--- a/src/app/(admin)/admin/classes/[id]/actions.ts
+++ b/src/app/(admin)/admin/classes/[id]/actions.ts
@@ -22,7 +22,7 @@ export async function updateClassDetailsAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const updatePayload: Database["public"]["Tables"]["classes"]["Update"] = {
     title: title.trim(),
@@ -53,7 +53,7 @@ export async function createModuleAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data: maxIdxData, error: idxError } = await supabase
     .from("modules" satisfies keyof Database["public"]["Tables"])
@@ -100,7 +100,7 @@ export async function createModuleAction(formData: FormData) {
 
 export async function reorderModulesAction(classId: string, orderedIds: string[]) {
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const updateResponses = await Promise.all(
     orderedIds.map((id, index) =>
@@ -128,7 +128,7 @@ export async function deleteModuleAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { error } = await supabase
     .from("modules" satisfies keyof Database["public"]["Tables"])
@@ -144,7 +144,7 @@ export async function deleteModuleAction(formData: FormData) {
 
 export async function setModulePublishedAction(moduleId: string, classId: string, published: boolean) {
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const publishPayload: Database["public"]["Tables"]["modules"]["Update"] = { published }
 

--- a/src/app/(admin)/admin/classes/actions.ts
+++ b/src/app/(admin)/admin/classes/actions.ts
@@ -11,7 +11,7 @@ import type { Database } from "@/lib/supabase"
 
 export async function createClassAction() {
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const slug = `class-${randomUUID().slice(0, 8)}`
 
@@ -45,7 +45,7 @@ export async function deleteClassAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { error } = await supabase
     .from("classes" satisfies keyof Database["public"]["Tables"])
@@ -61,7 +61,7 @@ export async function deleteClassAction(formData: FormData) {
 
 export async function setClassPublishedAction(classId: string, published: boolean) {
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const updatePayload: Database["public"]["Tables"]["classes"]["Update"] = { published }
 

--- a/src/app/(admin)/admin/modules/[id]/actions.ts
+++ b/src/app/(admin)/admin/modules/[id]/actions.ts
@@ -28,7 +28,7 @@ export async function updateModuleDetailsAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const durationValue =
     typeof duration === "string" && duration.length > 0
@@ -69,7 +69,7 @@ export async function deleteModuleFromDetailAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { error } = await supabase
     .from("modules" satisfies keyof Database["public"]["Tables"])
@@ -106,7 +106,7 @@ export async function uploadModuleDeckAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data: moduleRow, error } = await supabase
     .from("modules" satisfies keyof Database["public"]["Tables"])
@@ -151,7 +151,7 @@ export async function removeModuleDeckAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data, error } = await supabase
     .from("modules" satisfies keyof Database["public"]["Tables"])

--- a/src/app/(admin)/admin/users/actions.ts
+++ b/src/app/(admin)/admin/users/actions.ts
@@ -19,7 +19,7 @@ export async function changeUserRoleAction(formData: FormData) {
   }
 
   await requireAdmin()
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const updatePayload: Database["public"]["Tables"]["profiles"]["Update"] = {
     role: nextRole,

--- a/src/app/(dashboard)/billing/actions.ts
+++ b/src/app/(dashboard)/billing/actions.ts
@@ -10,7 +10,7 @@ import { logger } from "@/lib/logger"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 
 export async function createBillingPortalSession() {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/(dashboard)/class/[slug]/module/[index]/page.tsx
+++ b/src/app/(dashboard)/class/[slug]/module/[index]/page.tsx
@@ -31,7 +31,7 @@ export default async function ModulePage({
     notFound()
   }
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()
@@ -313,7 +313,7 @@ async function completeModuleAction(formData: FormData) {
     return
   }
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -9,7 +9,7 @@ import {
 import { createSupabaseServerClient } from "@/lib/supabase"
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/(public)/pricing/actions.ts
+++ b/src/app/(public)/pricing/actions.ts
@@ -16,7 +16,7 @@ export async function startCheckout(formData: FormData) {
   const planNameEntry = formData.get("planName")
   const planName = typeof planNameEntry === "string" ? planNameEntry : undefined
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/(public)/pricing/success/page.tsx
+++ b/src/app/(public)/pricing/success/page.tsx
@@ -17,7 +17,7 @@ export default async function PricingSuccessPage({
   const params = searchParams ? await searchParams : {}
   const sessionId = typeof params?.session_id === "string" ? params.session_id : undefined
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/api/modules/[id]/deck/route.ts
+++ b/src/app/api/modules/[id]/deck/route.ts
@@ -6,7 +6,7 @@ import type { Database } from "@/lib/supabase"
 
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const { id: moduleId } = await context.params
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const {
     data: { session },

--- a/src/components/dashboard/subscription-status-card.tsx
+++ b/src/components/dashboard/subscription-status-card.tsx
@@ -20,7 +20,7 @@ function statusLabel(status: string) {
 }
 
 export async function SubscriptionStatusCard() {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -11,7 +11,7 @@ type RequireAdminResult = {
 }
 
 async function requireAdminInternal(): Promise<RequireAdminResult> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/lib/admin/kpis.ts
+++ b/src/lib/admin/kpis.ts
@@ -65,7 +65,7 @@ function extractAmount(metadata: unknown): { amount: number; currency: string } 
 }
 
 export async function fetchAdminKpis(): Promise<AdminKpis> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const [{ data: profileCount, error: profileError }, { data: subs, error: subsError }] = await Promise.all([
     supabase.from("profiles").select("id", { count: "exact", head: true }),
@@ -110,7 +110,7 @@ export async function fetchAdminKpis(): Promise<AdminKpis> {
 }
 
 export async function fetchRecentEnrollments(limit = 5): Promise<AdminRecentEnrollment[]> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data, error } = await supabase
     .from("enrollments")
@@ -134,7 +134,7 @@ export async function fetchRecentEnrollments(limit = 5): Promise<AdminRecentEnro
 }
 
 export async function fetchRecentPayments(limit = 5): Promise<AdminRecentPayment[]> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data, error } = await supabase
     .from("subscriptions")

--- a/src/lib/admin/users.ts
+++ b/src/lib/admin/users.ts
@@ -37,7 +37,7 @@ export async function listAdminUsers({
     return []
   }
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const userIds = users.map((user) => user.id)
 
   const { data: profiles, error: profilesError } = await supabase
@@ -134,7 +134,7 @@ export async function getAdminUserDetail(userId: string): Promise<AdminUserDetai
     return null
   }
 
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data: profile, error: profileError } = await supabase
     .from("profiles")

--- a/src/lib/classes.ts
+++ b/src/lib/classes.ts
@@ -37,7 +37,7 @@ export async function listClasses({
   page?: number
   pageSize?: number
 } = {}): Promise<ListClassesResult> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1
   const size = Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : DEFAULT_PAGE_SIZE
   const from = (safePage - 1) * size
@@ -77,7 +77,7 @@ export async function listClasses({
 }
 
 export async function getClassById(id: string) {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data, error } = await supabase
     .from("classes")
     .select("*, modules ( id, title, idx, slug, published, created_at, deck_path )")

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -42,7 +42,7 @@ export async function getClassModulesForUser({
   classSlug: string
   userId: string
 }): Promise<ClassModuleResult> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const { data: classRow, error } = await supabase
     .from("classes" satisfies keyof Database["public"]["Tables"])
@@ -126,7 +126,7 @@ export async function markModuleCompleted({
   userId: string
   notes?: ModuleProgressInsert["notes"]
 }) {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
 
   const upsertPayload: ModuleProgressInsert = {
     user_id: userId,

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -5,8 +5,10 @@ import { cookies } from "next/headers"
 import { env } from "@/lib/env"
 import type { Database } from "./types"
 
-export function createSupabaseServerClient(): SupabaseClient<Database, "public"> {
-  const cookieStore = cookies() as unknown as {
+export async function createSupabaseServerClient(): Promise<
+  SupabaseClient<Database, "public">
+> {
+  const cookieStore = (await cookies()) as unknown as {
     get: (name: string) => { value: string } | undefined
     set?: (options: { name: string; value: string } & CookieOptions) => void
     delete?: (name: string) => void

--- a/tests/acceptance/module-progress.test.ts
+++ b/tests/acceptance/module-progress.test.ts
@@ -14,6 +14,7 @@ describe("module unlocking", () => {
     contentMd: null,
     durationMinutes: null,
     published: true,
+    hasDeck: false,
     ...overrides,
   })
 

--- a/tests/acceptance/test-utils.ts
+++ b/tests/acceptance/test-utils.ts
@@ -13,7 +13,7 @@ export const redirectMock = vi.fn((destination: string) => {
 export const revalidatePathMock = vi.fn()
 
 export const headersMock = vi.fn(async () => ({
-  get: (name: string) => {
+  get: (name: string): string | undefined => {
     if (name.toLowerCase() === "origin") {
       return "https://example.test"
     }


### PR DESCRIPTION
## Summary
- make `createSupabaseServerClient` asynchronous so cookies can be awaited before instantiating the client
- await the async server client across server utilities, actions, API routes, and components that depend on it
- update acceptance tests to reflect the stricter module shape and relaxed header mock typing

## Testing
- npm run lint
- npx tsc --noEmit
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a8b942a483279d83b01a8babcd33