### PR TITLE
Switch server auth to Supabase getUser before relying on session

### DIFF
--- a/src/app/(dashboard)/billing/actions.ts
+++ b/src/app/(dashboard)/billing/actions.ts
@@ -12,10 +12,15 @@ import { createSupabaseServerClient } from "@/lib/supabase/server"
 export async function createBillingPortalSession() {
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/billing")
   }
 
@@ -27,13 +32,13 @@ export async function createBillingPortalSession() {
   const { data: subscription, error } = await supabase
     .from("subscriptions")
     .select("stripe_customer_id")
-    .eq("user_id", session.user.id)
+    .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle()
 
   if (error) {
-    logger.error("billing_portal_subscription_lookup_failed", error, { userId: session.user.id })
+    logger.error("billing_portal_subscription_lookup_failed", error, { userId: user.id })
     return { error: "Unable to locate your subscription." }
   }
 
@@ -54,11 +59,11 @@ export async function createBillingPortalSession() {
       return_url: `${origin}/billing`,
     })
 
-    logger.info("billing_portal_session_created", { userId: session.user.id })
+    logger.info("billing_portal_session_created", { userId: user.id })
 
     return { url: portalSession.url }
   } catch (portalError) {
-    logger.error("billing_portal_session_failed", portalError, { userId: session.user.id })
+    logger.error("billing_portal_session_failed", portalError, { userId: user.id })
     return { error: "We couldn't open the billing portal. Contact support." }
 
   }

--- a/src/app/(dashboard)/class/[slug]/module/[index]/page.tsx
+++ b/src/app/(dashboard)/class/[slug]/module/[index]/page.tsx
@@ -33,16 +33,21 @@ export default async function ModulePage({
 
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/auth/sign-in")
   }
 
   const classContext = await getClassModulesForUser({
     classSlug: slug,
-    userId: session.user.id,
+    userId: user.id,
   })
 
   if (classContext.modules.length === 0) {
@@ -315,10 +320,15 @@ async function completeModuleAction(formData: FormData) {
 
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/auth/sign-in")
   }
 
@@ -327,7 +337,7 @@ async function completeModuleAction(formData: FormData) {
       ? { reflection: reflection.trim() }
       : null
 
-  await markModuleCompleted({ moduleId, userId: session.user.id, notes })
+  await markModuleCompleted({ moduleId, userId: user.id, notes })
 
   if (typeof currentIndex === "string" && currentIndex.length > 0) {
     revalidatePath(`/class/${classSlug}/module/${currentIndex}`)

--- a/src/app/(dashboard)/classes/page.tsx
+++ b/src/app/(dashboard)/classes/page.tsx
@@ -20,10 +20,15 @@ export default async function ClassesPage({
   const params = searchParams ? await searchParams : {}
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/classes")
   }
 

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic"
 import { Suspense } from "react"
+import { redirect } from "next/navigation"
 
 import { DashboardBreadcrumbs } from "@/components/dashboard/breadcrumbs"
 import { ClassesHighlights } from "@/components/dashboard/classes-overview"
@@ -26,8 +27,26 @@ const DynamicSectionCards = dynamic(
 export default async function DashboardPage() {
   const supabase = await createSupabaseServerClient()
   const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
+    redirect("/login?redirect=/dashboard")
+  }
+
+  const {
     data: { session },
+    error: sessionError,
   } = await supabase.auth.getSession()
+
+  if (sessionError) {
+    throw sessionError
+  }
 
   return (
     <>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -11,28 +11,33 @@ import { createSupabaseServerClient } from "@/lib/supabase"
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
 
   let displayName: string | null = null
-  let email: string | null = session?.user.email ?? null
+  let email: string | null = user?.email ?? null
   let avatar: string | null = null
 
-  if (session) {
+  if (user) {
     const { data: profile } = await supabase
       .from("profiles")
       .select("full_name")
-      .eq("id", session.user.id)
+      .eq("id", user.id)
       .maybeSingle<{ full_name: string | null }>()
 
-    displayName = profile?.full_name ?? (session.user.user_metadata?.full_name as string | undefined) ?? null
+    displayName = profile?.full_name ?? (user.user_metadata?.full_name as string | undefined) ?? null
 
-    if (!email && typeof session.user.user_metadata?.email === "string") {
-      email = session.user.user_metadata.email as string
+    if (!email && typeof user.user_metadata?.email === "string") {
+      email = user.user_metadata.email as string
     }
 
-    if (typeof session.user.user_metadata?.avatar_url === "string") {
-      avatar = session.user.user_metadata.avatar_url as string
+    if (typeof user.user_metadata?.avatar_url === "string") {
+      avatar = user.user_metadata.avatar_url as string
     }
   }
 

--- a/src/app/(dashboard)/schedule/page.tsx
+++ b/src/app/(dashboard)/schedule/page.tsx
@@ -38,10 +38,15 @@ const UPCOMING_EVENTS = [
 export default async function SchedulePage() {
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/schedule")
   }
 

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -18,20 +18,25 @@ export default async function SettingsPage({
 }) {
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/settings")
   }
 
   const { data: profile } = await supabase
     .from("profiles")
     .select("full_name")
-    .eq("id", session.user.id)
+    .eq("id", user.id)
     .maybeSingle<{ full_name: string | null }>()
 
-  const metadata = session.user.user_metadata ?? {}
+  const metadata = user.user_metadata ?? {}
   const marketingOptIn = Boolean(metadata.marketing_opt_in ?? true)
   const newsletterOptIn = Boolean(metadata.newsletter_opt_in ?? true)
 
@@ -79,7 +84,7 @@ export default async function SettingsPage({
               </div>
               <div className="grid gap-2">
                 <Label htmlFor="email">Email</Label>
-                <Input id="email" value={session.user.email ?? ""} disabled />
+                <Input id="email" value={user.email ?? ""} disabled />
               </div>
               <div className="flex flex-wrap items-center gap-3">
                 <Button type="submit">
@@ -138,10 +143,15 @@ async function updateAccountAction(formData: FormData) {
 
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/settings")
   }
 
@@ -151,7 +161,7 @@ async function updateAccountAction(formData: FormData) {
   await supabase
     .from("profiles")
     .update({ full_name: typeof fullName === "string" && fullName.trim().length > 0 ? fullName.trim() : null })
-    .eq("id", session.user.id)
+    .eq("id", user.id)
 
   revalidatePath("/settings")
   redirect(redirectTo)
@@ -162,10 +172,15 @@ async function updatePreferencesAction(formData: FormData) {
 
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/settings")
   }
 

--- a/src/app/(public)/pricing/actions.ts
+++ b/src/app/(public)/pricing/actions.ts
@@ -18,10 +18,15 @@ export async function startCheckout(formData: FormData) {
 
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/pricing")
   }
 
@@ -29,7 +34,7 @@ export async function startCheckout(formData: FormData) {
   const origin =
     requestHeaders.get("origin") ?? process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
 
-  const userId = session.user.id
+  const userId = user.id
 
   type SubscriptionStatus = Database["public"]["Enums"]["subscription_status"]
   type SubscriptionInsert = Database["public"]["Tables"]["subscriptions"]["Insert"]
@@ -61,7 +66,7 @@ export async function startCheckout(formData: FormData) {
       mode: "subscription",
       allow_promotion_codes: true,
       client_reference_id: userId,
-      customer_email: session.user.email ?? undefined,
+      customer_email: user.email ?? undefined,
       line_items: [
         {
           price: safePriceId,

--- a/src/app/(public)/pricing/success/page.tsx
+++ b/src/app/(public)/pricing/success/page.tsx
@@ -19,14 +19,19 @@ export default async function PricingSuccessPage({
 
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/login?redirect=/pricing/success")
   }
 
-  const userId = session.user.id
+  const userId = user.id
   let status: Database["public"]["Enums"]["subscription_status"] = "trialing"
   let subscriptionId: string | undefined
   let currentPeriodEnd: string | null = null

--- a/src/app/api/modules/[id]/deck/route.ts
+++ b/src/app/api/modules/[id]/deck/route.ts
@@ -9,10 +9,15 @@ export async function GET(_request: Request, context: { params: Promise<{ id: st
   const supabase = createSupabaseServerClient()
 
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 500 })
+  }
+
+  if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/components/dashboard/subscription-status-card.tsx
+++ b/src/components/dashboard/subscription-status-card.tsx
@@ -22,10 +22,15 @@ function statusLabel(status: string) {
 export async function SubscriptionStatusCard() {
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     return null
   }
 
@@ -34,7 +39,7 @@ export async function SubscriptionStatusCard() {
   const { data } = await supabase
     .from("subscriptions" satisfies keyof Database["public"]["Tables"])
     .select("status, current_period_end, metadata")
-    .eq("user_id", session.user.id)
+    .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle<Pick<SubscriptionRow, "status" | "current_period_end" | "metadata">>()

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -12,20 +12,25 @@ const SUPPORT_EMAIL = "contact@coachhousesolutions.org"
 export async function SiteHeader() {
   const supabase = await createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    throw userError
+  }
 
   let displayName: string | null = null
-  const email: string | null = session?.user.email ?? null
+  const email: string | null = user?.email ?? null
 
-  if (session) {
+  if (user) {
     const { data: profile } = await supabase
       .from("profiles")
       .select("full_name")
-      .eq("id", session.user.id)
+      .eq("id", user.id)
       .maybeSingle<{ full_name: string | null }>()
 
-    displayName = profile?.full_name ?? (session.user.user_metadata?.full_name as string | undefined) ?? null
+    displayName = profile?.full_name ?? (user.user_metadata?.full_name as string | undefined) ?? null
   }
 
   return (
@@ -40,7 +45,7 @@ export async function SiteHeader() {
               Support
             </a>
           </Button>
-          {session ? (
+          {user ? (
             <UserMenu name={displayName} email={email} />
           ) : (
             <Button variant="outline" size="sm" asChild>

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -13,17 +13,22 @@ type RequireAdminResult = {
 async function requireAdminInternal(): Promise<RequireAdminResult> {
   const supabase = createSupabaseServerClient()
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  if (!session) {
+  if (userError) {
+    throw userError
+  }
+
+  if (!user) {
     redirect("/auth/sign-in")
   }
 
   const { data: profile, error } = await supabase
     .from("profiles")
     .select("role")
-    .eq("id", session.user.id)
+    .eq("id", user.id)
     .maybeSingle()
 
   if (error) {
@@ -34,7 +39,7 @@ async function requireAdminInternal(): Promise<RequireAdminResult> {
     redirect("/dashboard")
   }
 
-  return { supabase, userId: session.user.id }
+  return { supabase, userId: user.id }
 }
 
 export const requireAdmin = cache(requireAdminInternal)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,16 +30,17 @@ export async function middleware(request: NextRequest) {
   )
 
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
 
-  const hasSession = Boolean(session)
+  const hasUser = Boolean(user)
 
   const pathname = request.nextUrl.pathname
   const isProtected = PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
   const isAuthRoute = AUTH_ROUTES.has(pathname)
 
-  if (!hasSession && isProtected) {
+  if ((!hasUser || userError) && isProtected) {
     const redirectUrl = new URL("/login", request.url)
     redirectUrl.searchParams.set("redirect", pathname + request.nextUrl.search)
     const redirectResponse = NextResponse.redirect(redirectUrl)
@@ -47,7 +48,7 @@ export async function middleware(request: NextRequest) {
     return redirectResponse
   }
 
-  if (hasSession && isAuthRoute) {
+  if (hasUser && !userError && isAuthRoute) {
     const redirectResponse = NextResponse.redirect(new URL("/dashboard", request.url))
     copyCookies(response, redirectResponse)
     return redirectResponse


### PR DESCRIPTION
## Summary
- replace server-side Supabase session checks with getUser to verify authentication before authorizing admin guard, middleware, and dashboard/pricing entry points
- update server components and actions to handle unauthenticated users gracefully and only fetch session payloads when explicitly required

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a8b9449483278013c17c4e9518db