### PR TITLE
[STEP S26] Darkmode/lightmode/system aware

### DIFF
--- a/docs/CODEX_RUNBOOK.md
+++ b/docs/CODEX_RUNBOOK.md
@@ -258,10 +258,15 @@ feat(step {id}): {title}
     * Middleware now redirects authenticated users without `onboarding_completed` to `/onboarding` and allows skipping (defaults to opt-in true) while still marking completion.
   * PR: https://github.com/Hamernick/coach-house-lms/pull/38
 
-  * [ ] **S26** — Darkmode/lightmode/system aware
+* [x] **S26** — Darkmode/lightmode/system aware
 
   * Every single page, element, component, etc should be system aware for darkmode/lightmode
   * **Accept**: Theme switches successfully throughout the entire app when I change my system setting manually on my computer.
+  * **Changelog**:
+    * Added `next-themes` provider with `attribute="class"` and `defaultTheme="system"` at the app root to sync with OS theme.
+    * Switched Sonner Toaster to theme-aware variant wired to `next-themes`.
+    * Ensured middleware and pages rely on CSS variables with `.dark` class; html uses `suppressHydrationWarning` to avoid flicker.
+  * PR: (pending)
 
 ## Controller prompt (for “Proceed” runs)
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react"
 import "./globals.css"
 
 import { ToastProvider } from "@/components/providers/toast-provider"
+import { ThemeProvider } from "@/components/providers/theme-provider"
 import { getLocale } from "@/lib/locale.server"
 
 export const metadata: Metadata = {
@@ -24,8 +25,10 @@ export default async function RootLayout({
   return (
     <html lang={language} suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
-        <ToastProvider />
-        {children}
+        <ThemeProvider>
+          <ToastProvider />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ReactNode } from "react"
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      {children}
+    </NextThemesProvider>
+  )
+}
+

--- a/src/components/providers/toast-provider.tsx
+++ b/src/components/providers/toast-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Toaster } from "sonner"
+import { Toaster } from "@/components/ui/sonner"
 
 export function ToastProvider() {
   return <Toaster position="top-right" richColors />


### PR DESCRIPTION
## Summary
Enable system-aware theming across the app.
- Add `next-themes` provider with `attribute="class"`, `defaultTheme="system"`, `enableSystem` to sync with OS theme.
- Swap Sonner Toaster to a theme-aware wrapper using `useTheme()` for consistent notifications.
- The design system already uses CSS variables + `.dark` tokens; with the provider, the whole UI respects system changes without manual toggles.

## Checks
- [x] typecheck
- [x] lint
- [x] build
- [x] unit
- [x] e2e

## Notes
- No migrations. Minimal footprint; no UI toggle added (system-driven).

## Links
- Runbook step: docs/CODEX_RUNBOOK.md (S26)
