### PR TITLE
[STEP S76] Ship workspace activity readiness

### DIFF
--- a/src/actions/programs.ts
+++ b/src/actions/programs.ts
@@ -4,8 +4,18 @@
 import { revalidatePath } from "next/cache"
 import { requireServerSession } from "@/lib/auth"
 import { publicSharingEnabled } from "@/lib/feature-flags"
-import { PROGRAM_MEDIA_BUCKET, resolveProgramMediaCleanupPath } from "@/lib/storage/program-media"
-import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import {
+  resolveProfileAudience,
+  resolveTesterMetadata,
+} from "@/lib/devtools/audience"
+import {
+  PROGRAM_MEDIA_BUCKET,
+  resolveProgramMediaCleanupPath,
+} from "@/lib/storage/program-media"
+import {
+  canEditOrganization,
+  resolveActiveOrganization,
+} from "@/lib/organization/active-org"
 import { resolveProgramBannerImageUrl } from "@/lib/programs/display"
 
 export type CreateProgramPayload = {
@@ -38,8 +48,17 @@ export type CreateProgramPayload = {
 export async function createProgramAction(payload: CreateProgramPayload) {
   const { supabase, session } = await requireServerSession("/organization")
   const userId = session.user.id
-  const { orgId, role } = await resolveActiveOrganization(supabase, userId)
-  const canEdit = canEditOrganization(role)
+  const [{ orgId, role }, profileAudience] = await Promise.all([
+    resolveActiveOrganization(supabase, userId),
+    resolveProfileAudience({
+      supabase,
+      userId,
+      fallbackIsTester: resolveTesterMetadata(
+        session.user.user_metadata ?? null
+      ),
+    }),
+  ])
+  const canEdit = profileAudience.isAdmin || canEditOrganization(role)
   if (!canEdit) return { error: "Forbidden" }
   const allowPublicSharing = publicSharingEnabled
 
@@ -59,8 +78,12 @@ export async function createProgramAction(payload: CreateProgramPayload) {
     address_country: payload.addressCountry ?? null,
     image_url: payload.imageUrl ?? null,
     duration_label: payload.duration ?? null,
-    start_date: payload.startDate ? new Date(payload.startDate).toISOString() as unknown as any : null,
-    end_date: payload.endDate ? new Date(payload.endDate).toISOString() as unknown as any : null,
+    start_date: payload.startDate
+      ? (new Date(payload.startDate).toISOString() as unknown as any)
+      : null,
+    end_date: payload.endDate
+      ? (new Date(payload.endDate).toISOString() as unknown as any)
+      : null,
     features: payload.features ?? [],
     status_label: payload.statusLabel ?? null,
     goal_cents: payload.goalCents ?? 0,
@@ -71,11 +94,11 @@ export async function createProgramAction(payload: CreateProgramPayload) {
     wizard_snapshot: payload.wizardSnapshot ?? {},
   }
 
-  let { error } = await (supabase.from("programs") as any).insert(insert)
+  let { error } = await (supabase as any).from("programs").insert(insert)
   if (error && /wizard_snapshot/i.test(error.message)) {
     const legacyInsert = { ...insert }
     delete (legacyInsert as { wizard_snapshot?: unknown }).wizard_snapshot
-    const retry = await (supabase.from("programs") as any).insert(legacyInsert)
+    const retry = await (supabase as any).from("programs").insert(legacyInsert)
     error = retry.error
   }
   if (error) return { error: error.message }
@@ -85,24 +108,38 @@ export async function createProgramAction(payload: CreateProgramPayload) {
 
 export type UpdateProgramPayload = Partial<CreateProgramPayload>
 
-export async function updateProgramAction(id: string, payload: UpdateProgramPayload) {
+export async function updateProgramAction(
+  id: string,
+  payload: UpdateProgramPayload
+) {
   const { supabase, session } = await requireServerSession("/organization")
   const userId = session.user.id
-  const { orgId, role } = await resolveActiveOrganization(supabase, userId)
-  const canEdit = canEditOrganization(role)
+  const [{ orgId, role }, profileAudience] = await Promise.all([
+    resolveActiveOrganization(supabase, userId),
+    resolveProfileAudience({
+      supabase,
+      userId,
+      fallbackIsTester: resolveTesterMetadata(
+        session.user.user_metadata ?? null
+      ),
+    }),
+  ])
+  const canEdit = profileAudience.isAdmin || canEditOrganization(role)
   if (!canEdit) return { error: "Forbidden" }
   const allowPublicSharing = publicSharingEnabled
   const imageTouched = Object.prototype.hasOwnProperty.call(payload, "imageUrl")
   const hasKey = (key: keyof UpdateProgramPayload) =>
     Object.prototype.hasOwnProperty.call(payload, key)
-  const pick = <K extends keyof UpdateProgramPayload>(key: K): UpdateProgramPayload[K] | undefined =>
+  const pick = <K extends keyof UpdateProgramPayload>(
+    key: K
+  ): UpdateProgramPayload[K] | undefined =>
     hasKey(key) ? payload[key] : undefined
 
   let previousImageUrl: string | null = null
   let previousBannerImageUrl: string | null = null
   if (imageTouched || hasKey("wizardSnapshot")) {
-    const { data: existing, error: existingError } = await (supabase
-      .from("programs") as any)
+    const { data: existing, error: existingError } = await (supabase as any)
+      .from("programs")
       .select("image_url, wizard_snapshot")
       .eq("id", id)
       .eq("user_id", orgId)
@@ -136,24 +173,40 @@ export async function updateProgramAction(id: string, payload: UpdateProgramPayl
     address_state: pick("addressState"),
     address_postal: pick("addressPostal"),
     address_country: pick("addressCountry"),
-    image_url: payload.imageUrl === null ? null : payload.imageUrl ?? undefined,
+    image_url:
+      payload.imageUrl === null ? null : (payload.imageUrl ?? undefined),
     duration_label: pick("duration"),
     start_date:
-      startDate === undefined ? undefined : startDate ? (new Date(startDate).toISOString() as unknown as any) : null,
+      startDate === undefined
+        ? undefined
+        : startDate
+          ? (new Date(startDate).toISOString() as unknown as any)
+          : null,
     end_date:
-      endDate === undefined ? undefined : endDate ? (new Date(endDate).toISOString() as unknown as any) : null,
+      endDate === undefined
+        ? undefined
+        : endDate
+          ? (new Date(endDate).toISOString() as unknown as any)
+          : null,
     features: pick("features"),
     status_label: pick("statusLabel"),
     goal_cents: pick("goalCents"),
     raised_cents: pick("raisedCents"),
-    is_public: isPublic === undefined ? undefined : allowPublicSharing ? Boolean(isPublic) : false,
+    is_public:
+      isPublic === undefined
+        ? undefined
+        : allowPublicSharing
+          ? Boolean(isPublic)
+          : false,
     cta_label: pick("ctaLabel"),
     cta_url: pick("ctaUrl"),
-    wizard_snapshot: hasKey("wizardSnapshot") ? (payload.wizardSnapshot ?? {}) : undefined,
+    wizard_snapshot: hasKey("wizardSnapshot")
+      ? (payload.wizardSnapshot ?? {})
+      : undefined,
   }
 
-  let { error } = await (supabase
-    .from("programs") as any)
+  let { error } = await (supabase as any)
+    .from("programs")
     .update(update)
     .eq("id", id)
     .eq("user_id", orgId)
@@ -161,8 +214,8 @@ export async function updateProgramAction(id: string, payload: UpdateProgramPayl
   if (error && /wizard_snapshot/i.test(error.message)) {
     const legacyUpdate = { ...update }
     delete (legacyUpdate as { wizard_snapshot?: unknown }).wizard_snapshot
-    const retry = await (supabase
-      .from("programs") as any)
+    const retry = await (supabase as any)
+      .from("programs")
       .update(legacyUpdate)
       .eq("id", id)
       .eq("user_id", orgId)
@@ -197,7 +250,10 @@ export async function updateProgramAction(id: string, payload: UpdateProgramPayl
   return { ok: true }
 }
 
-async function revalidateOrganizationProgramViews(supabase: Awaited<ReturnType<typeof requireServerSession>>["supabase"], userId: string) {
+async function revalidateOrganizationProgramViews(
+  supabase: Awaited<ReturnType<typeof requireServerSession>>["supabase"],
+  userId: string
+) {
   revalidatePath("/organization")
   revalidatePath("/workspace")
   revalidatePath("/organization/workspace")
@@ -211,7 +267,10 @@ async function revalidateOrganizationProgramViews(supabase: Awaited<ReturnType<t
 
     if (error) return
 
-    const slug = typeof data?.public_slug === "string" && data.public_slug.length > 0 ? data.public_slug : null
+    const slug =
+      typeof data?.public_slug === "string" && data.public_slug.length > 0
+        ? data.public_slug
+        : null
     const isPublic = Boolean(data?.is_public)
 
     if (isPublic) revalidatePath("/community")
@@ -223,4 +282,3 @@ async function revalidateOrganizationProgramViews(supabase: Awaited<ReturnType<t
     // Swallow revalidation errors; they should not block program writes.
   }
 }
- 

--- a/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-programs-renderer.tsx
+++ b/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-programs-renderer.tsx
@@ -3,14 +3,22 @@
 import ChevronLeftIcon from "lucide-react/dist/esm/icons/chevron-left"
 import ChevronRightIcon from "lucide-react/dist/esm/icons/chevron-right"
 import { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
 
+import type { OrgProgram } from "@/components/organization/org-profile-card/types"
 import { Button } from "@/components/ui/button"
 import type { CarouselApi } from "@/components/ui/carousel"
-import { FiscalSponsorshipMark } from "@/features/fiscal-sponsorship"
+import {
+  analyzeFiscalSponsorshipActivityEligibility,
+  FiscalSponsorshipActivityAction,
+  type FiscalSponsorshipActivityEligibility,
+  type FiscalSponsorshipActivityEligibilityActivity,
+} from "@/features/fiscal-sponsorship"
 
 import { WORKSPACE_CARD_META } from "./workspace-board-copy"
 import type { WorkspaceBoardNodeData } from "./workspace-board-node-types"
 import {
+  buildWorkspaceProgramEditorHref,
   isWorkspaceProgramsPreviewOnlyStep,
   resolveWorkspaceProgramsDisplayPrograms,
   WorkspaceBoardProgramsCard,
@@ -18,106 +26,158 @@ import {
 import { WorkspaceBoardNodeCardShell } from "./workspace-board-node-card-shell"
 import type { WorkspaceCardSize } from "./workspace-board-types"
 
+type WorkspaceProgramsDisplayProgram = OrgProgram
+
+function getProgramField<K extends keyof WorkspaceProgramsDisplayProgram>(
+  program: WorkspaceProgramsDisplayProgram | null,
+  key: K
+) {
+  return program && key in program ? program[key] : null
+}
+
+function getProgramWizardSnapshot(
+  program: WorkspaceProgramsDisplayProgram | null
+) {
+  const value = getProgramField(program, "wizard_snapshot")
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readSnapshotString(
+  snapshot: Record<string, unknown> | null,
+  key: string
+) {
+  const value = snapshot?.[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function buildEligibilityActivity(
+  program: WorkspaceProgramsDisplayProgram | null
+): FiscalSponsorshipActivityEligibilityActivity | null {
+  if (!program) return null
+
+  const wizardSnapshot = getProgramWizardSnapshot(program)
+
+  return {
+    title: program.title,
+    subtitle: program.subtitle,
+    description: program.description,
+    location: getProgramField(program, "location"),
+    locationType: getProgramField(program, "location_type"),
+    addressCity: getProgramField(program, "address_city"),
+    addressState: getProgramField(program, "address_state"),
+    addressCountry: getProgramField(program, "address_country"),
+    focusArea:
+      readSnapshotString(wizardSnapshot, "programType") ??
+      program.features?.[0] ??
+      null,
+    objectKind: readSnapshotString(wizardSnapshot, "objectKind"),
+    estimatedBudgetCents: getProgramField(program, "goal_cents"),
+    goalCents: getProgramField(program, "goal_cents"),
+    wizardSnapshot,
+  }
+}
+
 function renderProgramsHeaderAction({
   canEdit,
-  canScrollNext,
-  canScrollPrevious,
+  eligibility,
   fiscalSponsorshipCardVisible,
-  hasCarouselControls,
   isCanvasFullscreen,
   onOpenFiscalSponsorship,
-  onScrollNext,
-  onScrollPrevious,
+  onProgramsCreateOpenChange,
+  onUpdateFiscalSponsorshipInfo,
   presentationMode,
   programsPreviewOnly,
 }: {
   canEdit: boolean
-  canScrollNext: boolean
-  canScrollPrevious: boolean
+  eligibility: FiscalSponsorshipActivityEligibility
   fiscalSponsorshipCardVisible: boolean
-  hasCarouselControls: boolean
   isCanvasFullscreen: boolean
   onOpenFiscalSponsorship: () => void
-  onScrollNext: () => void
-  onScrollPrevious: () => void
+  onProgramsCreateOpenChange: (open: boolean) => void
+  onUpdateFiscalSponsorshipInfo: () => void
   presentationMode: boolean
   programsPreviewOnly: boolean
 }) {
   const fiscalSponsorshipActionLabel = fiscalSponsorshipCardVisible
     ? "Close fiscal sponsorship tile"
-    : "Open fiscal sponsorship tile"
+    : eligibility.eligible
+      ? "Open fiscal sponsorship tile"
+      : "Fiscal sponsorship review readiness"
   const canOpenFiscalSponsorship =
     canEdit && !presentationMode && !isCanvasFullscreen && !programsPreviewOnly
-  if (!canOpenFiscalSponsorship && !hasCarouselControls) return null
+  if (!canOpenFiscalSponsorship && !canEdit) return null
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1.5">
       {canOpenFiscalSponsorship ? (
+        <FiscalSponsorshipActivityAction
+          active={fiscalSponsorshipCardVisible}
+          ariaLabel={fiscalSponsorshipActionLabel}
+          disabled={programsPreviewOnly}
+          eligibility={eligibility}
+          onOpen={onOpenFiscalSponsorship}
+          onUpdateInfo={onUpdateFiscalSponsorshipInfo}
+        />
+      ) : null}
+      {canEdit ? (
         <Button
           type="button"
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 rounded-lg p-0 hover:bg-transparent"
-          aria-label={fiscalSponsorshipActionLabel}
-          aria-pressed={fiscalSponsorshipCardVisible}
-          onClick={onOpenFiscalSponsorship}
+          size="sm"
+          className="h-8 rounded-md px-3"
+          disabled={programsPreviewOnly}
+          onClick={() => onProgramsCreateOpenChange(true)}
         >
-          <span aria-hidden>
-            <FiscalSponsorshipMark className="size-8 rounded-lg text-xs" />
-          </span>
+          Add
         </Button>
-      ) : null}
-      {hasCarouselControls ? (
-        <>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="border-border/70 bg-background/85 h-8 w-8 rounded-full backdrop-blur-sm"
-            disabled={!canScrollPrevious}
-            aria-label="Previous activity"
-            onClick={onScrollPrevious}
-          >
-            <ChevronLeftIcon aria-hidden />
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="border-border/70 bg-background/85 h-8 w-8 rounded-full backdrop-blur-sm"
-            disabled={!canScrollNext}
-            aria-label="Next activity"
-            onClick={onScrollNext}
-          >
-            <ChevronRightIcon aria-hidden />
-          </Button>
-        </>
       ) : null}
     </div>
   )
 }
 
 function renderProgramsFooterAction({
-  canEdit,
-  onProgramsCreateOpenChange,
-  programsPreviewOnly,
+  canScrollNext,
+  canScrollPrevious,
+  hasCarouselControls,
+  onScrollNext,
+  onScrollPrevious,
 }: {
-  canEdit: boolean
-  onProgramsCreateOpenChange: (open: boolean) => void
-  programsPreviewOnly: boolean
+  canScrollNext: boolean
+  canScrollPrevious: boolean
+  hasCarouselControls: boolean
+  onScrollNext: () => void
+  onScrollPrevious: () => void
 }) {
-  if (!canEdit) return null
+  if (!hasCarouselControls) return null
 
   return (
-    <Button
-      type="button"
-      size="sm"
-      className="ml-auto"
-      disabled={programsPreviewOnly}
-      onClick={() => onProgramsCreateOpenChange(true)}
-    >
-      Add
-    </Button>
+    <div className="flex w-full items-center justify-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="border-border/70 bg-background/85 h-8 w-8 rounded-full backdrop-blur-sm"
+        disabled={!canScrollPrevious}
+        aria-label="Previous activity"
+        onClick={onScrollPrevious}
+      >
+        <ChevronLeftIcon aria-hidden />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="border-border/70 bg-background/85 h-8 w-8 rounded-full backdrop-blur-sm"
+        disabled={!canScrollNext}
+        aria-label="Next activity"
+        onClick={onScrollNext}
+      >
+        <ChevronRightIcon aria-hidden />
+      </Button>
+    </div>
   )
 }
 
@@ -146,6 +206,7 @@ export function WorkspaceBoardProgramsNodeCard({
   presentationMode: boolean
   programsCreateOpen: boolean
 }) {
+  const router = useRouter()
   const workspacePrograms = data.organizationEditorData?.programs
   const programs = useMemo(() => workspacePrograms ?? [], [workspacePrograms])
   const legacyProgramsValue =
@@ -153,17 +214,51 @@ export function WorkspaceBoardProgramsNodeCard({
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null)
   const [canScrollPrevious, setCanScrollPrevious] = useState(false)
   const [canScrollNext, setCanScrollNext] = useState(false)
+  const [selectedProgramIndex, setSelectedProgramIndex] = useState(0)
   const programsPreviewOnly = isWorkspaceProgramsPreviewOnlyStep(
     data.tutorialStepId
   )
-  const hasCarouselControls = useMemo(
+  const displayPrograms = useMemo(
     () =>
       resolveWorkspaceProgramsDisplayPrograms({
         programs,
         legacyProgramsValue,
-      }).length > 1,
+      }) as WorkspaceProgramsDisplayProgram[],
     [legacyProgramsValue, programs]
   )
+  const hasCarouselControls = displayPrograms.length > 1
+  const selectedProgram =
+    displayPrograms[
+      Math.min(Math.max(selectedProgramIndex, 0), displayPrograms.length - 1)
+    ] ??
+    displayPrograms[0] ??
+    null
+  const fiscalSponsorshipEligibility = useMemo(
+    () =>
+      analyzeFiscalSponsorshipActivityEligibility({
+        activity: buildEligibilityActivity(selectedProgram),
+        organization: data.organizationEditorData?.initialProfile ?? null,
+        prefill:
+          data.organizationEditorData?.fiscalSponsorshipApplicationPrefill ??
+          null,
+      }),
+    [
+      data.organizationEditorData?.fiscalSponsorshipApplicationPrefill,
+      data.organizationEditorData?.initialProfile,
+      selectedProgram,
+    ]
+  )
+  const updateFiscalSponsorshipInfoHref = buildWorkspaceProgramEditorHref(
+    selectedProgram?.id?.startsWith("legacy-program-")
+      ? undefined
+      : selectedProgram?.id
+  )
+
+  useEffect(() => {
+    if (displayPrograms.length <= 1) {
+      setSelectedProgramIndex(0)
+    }
+  }, [displayPrograms.length])
 
   useEffect(() => {
     if (!hasCarouselControls || !carouselApi) {
@@ -175,6 +270,7 @@ export function WorkspaceBoardProgramsNodeCard({
     const updateCarouselState = () => {
       setCanScrollPrevious(carouselApi.canScrollPrev())
       setCanScrollNext(carouselApi.canScrollNext())
+      setSelectedProgramIndex(carouselApi.selectedScrollSnap())
     }
 
     updateCarouselState()
@@ -195,15 +291,14 @@ export function WorkspaceBoardProgramsNodeCard({
       hideSubtitle={hideHeaderSubtitle}
       headerAction={renderProgramsHeaderAction({
         canEdit,
-        canScrollNext,
-        canScrollPrevious,
+        eligibility: fiscalSponsorshipEligibility,
         fiscalSponsorshipCardVisible:
           data.fiscalSponsorshipCardVisible === true,
-        hasCarouselControls,
         isCanvasFullscreen,
         onOpenFiscalSponsorship: () => data.onOpenCard?.("fiscal-sponsorship"),
-        onScrollNext: () => carouselApi?.scrollNext(),
-        onScrollPrevious: () => carouselApi?.scrollPrev(),
+        onProgramsCreateOpenChange,
+        onUpdateFiscalSponsorshipInfo: () =>
+          router.push(updateFiscalSponsorshipInfoHref),
         presentationMode,
         programsPreviewOnly,
       })}
@@ -211,16 +306,18 @@ export function WorkspaceBoardProgramsNodeCard({
       presentationMode={presentationMode}
       fullHref={cardMeta.fullHref}
       canEdit={canEdit}
-      shellInsetClassName="px-3 pt-3 pb-0"
+      shellInsetClassName="px-3 pt-3 pb-3"
       contentClassName={contentClassName}
       contentSurface="plain"
       editorHref={null}
       footer={renderProgramsFooterAction({
-        canEdit,
-        onProgramsCreateOpenChange,
-        programsPreviewOnly,
+        canScrollNext,
+        canScrollPrevious,
+        hasCarouselControls,
+        onScrollNext: () => carouselApi?.scrollNext(),
+        onScrollPrevious: () => carouselApi?.scrollPrev(),
       })}
-      footerClassName="px-3 pt-2 pb-3"
+      footerClassName="justify-center px-3 pt-2 pb-3"
       isCanvasFullscreen={isCanvasFullscreen}
       onToggleCanvasFullscreen={frameFullscreenToggle}
     >

--- a/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-shell.tsx
+++ b/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-shell.tsx
@@ -101,7 +101,7 @@ export function WorkspaceBoardNodeCardShell({
       <CardContent
         className={cn(
           contentSurface === "plain" ? "px-3" : "px-0",
-          contentSurface === "plain" || footer ? "pb-0" : "pb-3"
+          contentSurface === "plain" || !footer ? "pb-3" : "pb-0"
         )}
       >
         <div

--- a/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-programs-card.tsx
+++ b/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-programs-card.tsx
@@ -130,7 +130,7 @@ export function WorkspaceBoardProgramsCard({
 
     return (
       <ProgramCard
-        title={program.title?.trim() || "Untitled object"}
+        title={program.title?.trim() || "Untitled activity"}
         location={locationSummary(program) ?? undefined}
         description={resolveProgramSummary(program) ?? undefined}
         bannerImageUrl={resolveProgramBannerImageUrl(program) ?? undefined}

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
@@ -3,6 +3,7 @@ import type { OrgPerson } from "@/actions/people"
 import type { ProfileTab } from "@/components/organization/org-profile-card/types"
 import { resolveOptionalAuthenticatedAppContext } from "@/lib/auth/request-context"
 import { canEditOrganization } from "@/lib/organization/active-org"
+import { measureServerStep } from "@/lib/performance/server-timing"
 import type { Json } from "@/lib/supabase"
 import { fetchAcceleratorProgressSummary } from "@/lib/accelerator/progress"
 import { fetchLearningEntitlements } from "@/lib/accelerator/entitlements"
@@ -157,7 +158,7 @@ export default async function MyOrganizationPage({
   const isAdmin = profileAudience.isAdmin
   const needsInitialOnboarding =
     !isAdmin && !Boolean(userMeta?.onboarding_completed) && orgId === user.id
-  const canEdit = canEditOrganization(role)
+  const canEdit = isAdmin || canEditOrganization(role)
   const acceleratorViewRequested = viewParam === "accelerator"
   const showEditor =
     !needsInitialOnboarding &&
@@ -165,7 +166,11 @@ export default async function MyOrganizationPage({
   const presentationMode =
     modeParam === "present" || modeParam === "presentation"
   const { orgRow, profile, initialProfile, roadmapSections } =
-    await loadMyOrganizationProfileContext({ supabase, orgId })
+    await measureServerStep(
+      "workspace.content.load_profile_context",
+      () => loadMyOrganizationProfileContext({ supabase, orgId }),
+      { thresholdMs: 750 }
+    )
   const nowIso = new Date().toISOString()
   const [
     programsResult,
@@ -173,46 +178,51 @@ export default async function MyOrganizationPage({
     acceleratorProgress,
     activeSubscriptionResult,
     entitlements,
-  ] = await Promise.all([
-    fetchWorkspacePrograms({ supabase, orgId }),
-    acceleratorViewRequested
-      ? Promise.resolve({
-          data: [] as UpcomingEventRow[],
-          error: null,
-        } as { data: UpcomingEventRow[]; error: null })
-      : supabase
-          .from("roadmap_calendar_internal_events")
-          .select(
-            "id,title,description,event_type,starts_at,ends_at,all_day,recurrence,status,assigned_roles"
-          )
-          .eq("org_id", orgId)
-          .gte("starts_at", nowIso)
-          .eq("status", "active")
-          .order("starts_at", { ascending: true })
-          .limit(5)
-          .returns<UpcomingEventRow[]>(),
-    fetchAcceleratorProgressSummary({
-      supabase,
-      userId: user.id,
-      isAdmin,
-      basePath: "/accelerator",
-    }),
-    supabase
-      .from("subscriptions")
-      .select("status, metadata")
-      .eq("user_id", orgId)
-      .in("status", ["active", "trialing", "past_due", "incomplete"])
-      .not("stripe_subscription_id", "ilike", "stub_%")
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle<{ status: string | null; metadata: Json | null }>(),
-    fetchLearningEntitlements({
-      supabase,
-      userId: user.id,
-      orgUserId: orgId,
-      isAdmin,
-    }),
-  ])
+  ] = await measureServerStep(
+    "workspace.content.load_parallel_data",
+    () =>
+      Promise.all([
+        fetchWorkspacePrograms({ supabase, orgId }),
+        acceleratorViewRequested
+          ? Promise.resolve({
+              data: [] as UpcomingEventRow[],
+              error: null,
+            } as { data: UpcomingEventRow[]; error: null })
+          : supabase
+              .from("roadmap_calendar_internal_events")
+              .select(
+                "id,title,description,event_type,starts_at,ends_at,all_day,recurrence,status,assigned_roles"
+              )
+              .eq("org_id", orgId)
+              .gte("starts_at", nowIso)
+              .eq("status", "active")
+              .order("starts_at", { ascending: true })
+              .limit(5)
+              .returns<UpcomingEventRow[]>(),
+        fetchAcceleratorProgressSummary({
+          supabase,
+          userId: user.id,
+          isAdmin,
+          basePath: "/accelerator",
+        }),
+        supabase
+          .from("subscriptions")
+          .select("status, metadata")
+          .eq("user_id", orgId)
+          .in("status", ["active", "trialing", "past_due", "incomplete"])
+          .not("stripe_subscription_id", "ilike", "stub_%")
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .maybeSingle<{ status: string | null; metadata: Json | null }>(),
+        fetchLearningEntitlements({
+          supabase,
+          userId: user.id,
+          orgUserId: orgId,
+          isAdmin,
+        }),
+      ]),
+    { thresholdMs: 1_000 }
+  )
   const programs = programsResult
   const upcomingEvents = mapUpcomingEvents(upcomingEventsResult.data)
   const currentPlanTier = resolvePricingPlanTier(
@@ -306,13 +316,18 @@ export default async function MyOrganizationPage({
   const moduleGroupMetaById = buildModuleGroupMetaById(
     acceleratorProgressSummary.groups
   )
-  const acceleratorTimelineModules = await buildAcceleratorTimelineModules({
-    supabase,
-    userId: user.id,
-    sortedRoadmapModules,
-    groupMetaById: moduleGroupMetaById,
-    onboardingDefaults,
-  })
+  const acceleratorTimelineModules = await measureServerStep(
+    "workspace.content.build_accelerator_timeline",
+    () =>
+      buildAcceleratorTimelineModules({
+        supabase,
+        userId: user.id,
+        sortedRoadmapModules,
+        groupMetaById: moduleGroupMetaById,
+        onboardingDefaults,
+      }),
+    { thresholdMs: 750 }
+  )
   const acceleratorTimeline = buildWorkspaceAcceleratorCardSteps(
     acceleratorTimelineModules
   )
@@ -380,34 +395,39 @@ export default async function MyOrganizationPage({
     )
   }
 
-  const workspaceSeed = await buildWorkspaceViewSeed({
-    supabase,
-    orgId,
-    role,
-    canEdit,
-    isPlatformAdmin: isAdmin,
-    hasAcceleratorAccess: hasWorkspaceAcceleratorAccess,
-    presentationMode,
-    viewer,
-    organizationTitle,
-    organizationSubtitle,
-    fundingGoalCents,
-    raisedCents,
-    programsCount,
-    peopleCount,
-    teammateCount,
-    organizationProfileComplete,
-    workspaceDocumentCount,
-    initialProfile,
-    roadmapSections,
-    formationSummary,
-    acceleratorTimeline,
-    calendar: calendarView,
-    initialOnboarding: {
-      required: needsInitialOnboarding,
-      defaults: onboardingDefaults,
-    },
-  })
+  const workspaceSeed = await measureServerStep(
+    "workspace.content.build_workspace_seed",
+    () =>
+      buildWorkspaceViewSeed({
+        supabase,
+        orgId,
+        role,
+        canEdit,
+        isPlatformAdmin: isAdmin,
+        hasAcceleratorAccess: hasWorkspaceAcceleratorAccess,
+        presentationMode,
+        viewer,
+        organizationTitle,
+        organizationSubtitle,
+        fundingGoalCents,
+        raisedCents,
+        programsCount,
+        peopleCount,
+        teammateCount,
+        organizationProfileComplete,
+        workspaceDocumentCount,
+        initialProfile,
+        roadmapSections,
+        formationSummary,
+        acceleratorTimeline,
+        calendar: calendarView,
+        initialOnboarding: {
+          required: needsInitialOnboarding,
+          defaults: onboardingDefaults,
+        },
+      }),
+    { thresholdMs: 1_000 }
+  )
 
   const hydratedWorkspaceSeed = hydrateWorkspaceSeedAcceleratorState(
     workspaceSeed,
@@ -431,21 +451,30 @@ export default async function MyOrganizationPage({
     }
   )
   const { fiscalSponsorshipProjectId, fiscalSponsorshipWorkflowSummary } =
-    await loadMyOrganizationFiscalSponsorshipWorkflow({ orgId, supabase })
+    await measureServerStep(
+      "workspace.content.load_fiscal_workflow",
+      () => loadMyOrganizationFiscalSponsorshipWorkflow({ orgId, supabase }),
+      { thresholdMs: 750 }
+    )
 
-  const organizationEditorData = await buildWorkspaceOrganizationEditorData({
-    ...resolveFiscalApplicantPrefillIdentity({ profileAudience, user }),
-    canAccessRoadmapDocuments: entitlements.hasAcceleratorAccess,
-    canEdit,
-    fiscalSponsorshipProjectId,
-    fiscalSponsorshipWorkflowSummary,
-    initialProfile,
-    peopleNormalized,
-    profile,
-    programs,
-    publicSlug: orgRow?.public_slug ?? null,
-    roadmapSections,
-  })
+  const organizationEditorData = await measureServerStep(
+    "workspace.content.build_organization_editor_data",
+    () =>
+      buildWorkspaceOrganizationEditorData({
+        ...resolveFiscalApplicantPrefillIdentity({ profileAudience, user }),
+        canAccessRoadmapDocuments: entitlements.hasAcceleratorAccess,
+        canEdit,
+        fiscalSponsorshipProjectId,
+        fiscalSponsorshipWorkflowSummary,
+        initialProfile,
+        peopleNormalized,
+        profile,
+        programs,
+        publicSlug: orgRow?.public_slug ?? null,
+        roadmapSections,
+      }),
+    { thresholdMs: 1_000 }
+  )
   const { MyOrganizationWorkspaceView } =
     await import("../_components/workspace-board/my-organization-workspace-view")
 

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   deleteMemberWorkspaceTaskAction,
   deleteMemberWorkspaceProjectNoteAction,
   deleteMemberWorkspaceProjectQuickLinkAction,
-  loadMemberWorkspaceProjectDetailPage,
+  loadPlatformAdminOrganizationProjectDetailPage,
   MemberWorkspaceProjectDetailPage,
   updateMemberWorkspaceProjectAction,
   updateMemberWorkspaceProjectNoteAction,
@@ -47,10 +47,13 @@ function getOrganizationAdminProjectKind(
 }
 
 export default async function OrganizationDetailPage({ params }: PageProps) {
-  await requireAdmin()
+  const admin = await requireAdmin()
 
   const { id } = await params
-  const result = await loadMemberWorkspaceProjectDetailPage(id)
+  const result = await loadPlatformAdminOrganizationProjectDetailPage({
+    projectId: id,
+    userId: admin.userId,
+  })
 
   if (result.state === "not-found") {
     notFound()

--- a/src/app/(dashboard)/workspace/page.tsx
+++ b/src/app/(dashboard)/workspace/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 
 import { FIND_PATH } from "@/lib/find/routes"
 import { resolveOptionalAuthenticatedAppContext } from "@/lib/auth/request-context"
+import { measureServerStep } from "@/lib/performance/server-timing"
 import { trackUserJourneyMilestone } from "@/lib/user-journey"
 
 import { resolveDashboardLayoutState } from "../_lib/dashboard-layout-state"
@@ -13,7 +14,11 @@ export default async function WorkspacePage({
 }: {
   searchParams?: Promise<MyOrganizationSearchParams>
 }) {
-  const state = await resolveDashboardLayoutState()
+  const state = await measureServerStep(
+    "workspace.page.resolve_layout_state",
+    () => resolveDashboardLayoutState(),
+    { thresholdMs: 250 }
+  )
 
   if (state.userPresent && !state.isAdmin && !state.showMemberWorkspace) {
     if (
@@ -33,28 +38,38 @@ export default async function WorkspacePage({
   if (state.userPresent && !state.isAdmin) {
     const context = await resolveOptionalAuthenticatedAppContext()
     if (context) {
-      await trackUserJourneyMilestone({
-        userId: context.user.id,
-        orgId: context.activeOrg.orgId,
-        eventName: "workspace_viewed",
-        journey: "workspace_activation",
-        source: "workspace_page",
-        surface: "workspace",
-        planTier: state.currentPlanTier,
-        checkpoint: "workspace_first_viewed",
-        metadata: {
-          hasActiveSubscription: state.hasActiveSubscription,
-          hasAcceleratorAccess: state.hasAcceleratorAccess,
-          hasElectiveAccess: state.hasElectiveAccess,
-          showMemberWorkspace: state.showMemberWorkspace,
-          onboardingLocked: state.onboardingLocked,
-          onboardingIntentFocus: state.onboardingIntentFocus,
-        },
-      })
+      await measureServerStep(
+        "workspace.page.track_user_journey",
+        () =>
+          trackUserJourneyMilestone({
+            userId: context.user.id,
+            orgId: context.activeOrg.orgId,
+            eventName: "workspace_viewed",
+            journey: "workspace_activation",
+            source: "workspace_page",
+            surface: "workspace",
+            planTier: state.currentPlanTier,
+            checkpoint: "workspace_first_viewed",
+            metadata: {
+              hasActiveSubscription: state.hasActiveSubscription,
+              hasAcceleratorAccess: state.hasAcceleratorAccess,
+              hasElectiveAccess: state.hasElectiveAccess,
+              showMemberWorkspace: state.showMemberWorkspace,
+              onboardingLocked: state.onboardingLocked,
+              onboardingIntentFocus: state.onboardingIntentFocus,
+            },
+          }),
+        { thresholdMs: 250 }
+      )
     }
   }
 
-  return MyOrganizationPageContent({
-    searchParams,
-  })
+  return measureServerStep(
+    "workspace.page.render_organization_content",
+    () =>
+      MyOrganizationPageContent({
+        searchParams,
+      }),
+    { thresholdMs: 1_000 }
+  )
 }

--- a/src/app/api/account/program-media/route.ts
+++ b/src/app/api/account/program-media/route.ts
@@ -1,11 +1,23 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
-import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import {
+  canEditOrganization,
+  resolveActiveOrganization,
+} from "@/lib/organization/active-org"
+import {
+  resolveProfileAudience,
+  resolveTesterMetadata,
+} from "@/lib/devtools/audience"
 import { extractPublicObjectPath } from "@/lib/storage/public-url"
 
 const BUCKET = "program-media"
 const MAX_BYTES = 20 * 1024 * 1024
-const ALLOWED = new Set(["image/png", "image/jpeg", "image/webp", "image/svg+xml"]) as Set<string>
+const ALLOWED = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/svg+xml",
+]) as Set<string>
 
 export async function POST(request: NextRequest) {
   const response = NextResponse.next()
@@ -15,11 +27,21 @@ export async function POST(request: NextRequest) {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    return NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 })
+    return NextResponse.json(
+      { error: error?.message ?? "Unauthorized" },
+      { status: 401 }
+    )
   }
 
-  const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
-  if (!canEditOrganization(role)) {
+  const [{ orgId, role }, profileAudience] = await Promise.all([
+    resolveActiveOrganization(supabase, user.id),
+    resolveProfileAudience({
+      supabase,
+      userId: user.id,
+      fallbackIsTester: resolveTesterMetadata(user.user_metadata ?? null),
+    }),
+  ])
+  if (!profileAudience.isAdmin && !canEditOrganization(role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
@@ -29,21 +51,31 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Missing file" }, { status: 400 })
   }
   if (!ALLOWED.has(file.type)) {
-    return NextResponse.json({ error: "Unsupported image type. Use PNG, JPEG, WebP, or SVG." }, { status: 400 })
+    return NextResponse.json(
+      { error: "Unsupported image type. Use PNG, JPEG, WebP, or SVG." },
+      { status: 400 }
+    )
   }
   if (file.size > MAX_BYTES) {
-    return NextResponse.json({ error: "Image too large. Max size is 20 MB." }, { status: 400 })
+    return NextResponse.json(
+      { error: "Image too large. Max size is 20 MB." },
+      { status: 400 }
+    )
   }
 
   const ext = file.type.split("/").pop() || "png"
   const objectName = `${orgId}/cover/${Date.now()}.${ext}`
   const buf = Buffer.from(await file.arrayBuffer())
 
-  const { error: uploadErr } = await supabase.storage.from(BUCKET).upload(objectName, buf, { contentType: file.type })
+  const { error: uploadErr } = await supabase.storage
+    .from(BUCKET)
+    .upload(objectName, buf, { contentType: file.type })
   if (uploadErr) {
     return NextResponse.json({ error: uploadErr.message }, { status: 500 })
   }
-  const { data: publicUrl } = supabase.storage.from(BUCKET).getPublicUrl(objectName)
+  const { data: publicUrl } = supabase.storage
+    .from(BUCKET)
+    .getPublicUrl(objectName)
   return NextResponse.json({ url: publicUrl.publicUrl }, { status: 200 })
 }
 
@@ -55,15 +87,27 @@ export async function DELETE(request: NextRequest) {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    return NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 })
+    return NextResponse.json(
+      { error: error?.message ?? "Unauthorized" },
+      { status: 401 }
+    )
   }
 
-  const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
-  if (!canEditOrganization(role)) {
+  const [{ orgId, role }, profileAudience] = await Promise.all([
+    resolveActiveOrganization(supabase, user.id),
+    resolveProfileAudience({
+      supabase,
+      userId: user.id,
+      fallbackIsTester: resolveTesterMetadata(user.user_metadata ?? null),
+    }),
+  ])
+  if (!profileAudience.isAdmin && !canEditOrganization(role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 })
   }
 
-  const body = await request.json().catch(() => null) as { url?: unknown } | null
+  const body = (await request.json().catch(() => null)) as {
+    url?: unknown
+  } | null
   const url = typeof body?.url === "string" ? body.url.trim() : ""
   if (!url) {
     return NextResponse.json({ error: "Missing url" }, { status: 400 })
@@ -74,7 +118,9 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ ok: true }, { status: 200 })
   }
 
-  const { error: removeError } = await supabase.storage.from(BUCKET).remove([objectPath])
+  const { error: removeError } = await supabase.storage
+    .from(BUCKET)
+    .remove([objectPath])
   if (removeError) {
     return NextResponse.json({ error: removeError.message }, { status: 500 })
   }

--- a/src/components/organization/program-builder-dashboard-card.tsx
+++ b/src/components/organization/program-builder-dashboard-card.tsx
@@ -24,8 +24,8 @@ import {
 } from "@/components/organization/org-profile-card/utils"
 import {
   isOrganizationPrimaryObjectKind,
-  ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS,
-  ORGANIZATION_PRIMARY_OBJECT_SUMMARY,
+  ORGANIZATION_ACTIVITY_KIND_DEFINITIONS,
+  ORGANIZATION_ACTIVITY_KIND_SUMMARY,
   resolveOrganizationPrimaryObjectKind,
 } from "@/lib/organization/primary-objects"
 import { cn } from "@/lib/utils"
@@ -186,7 +186,7 @@ export function ProgramBuilderDashboardCard({
                 Activity
               </CardTitle>
               <CardDescription>
-                Track {ORGANIZATION_PRIMARY_OBJECT_SUMMARY}
+                Track {ORGANIZATION_ACTIVITY_KIND_SUMMARY}
               </CardDescription>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -199,15 +199,15 @@ export function ProgramBuilderDashboardCard({
                 }}
               >
                 <FolderPlusIcon className="h-4 w-4" aria-hidden />
-                New object
+                Add activity
               </Button>
             </div>
           </div>
           <div
             className="flex flex-wrap gap-1.5"
-            aria-label="Supported primary object types"
+            aria-label="Supported activity types"
           >
-            {ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS.map(
+            {ORGANIZATION_ACTIVITY_KIND_DEFINITIONS.map(
               ({ kind, description }) => (
                 <span
                   key={kind}
@@ -241,7 +241,7 @@ export function ProgramBuilderDashboardCard({
                     setCreateOpen(true)
                   }}
                 >
-                  Start object builder
+                  Start activity builder
                 </Button>
               }
             />
@@ -250,7 +250,7 @@ export function ProgramBuilderDashboardCard({
               <div className={PROGRAM_CARD_PANEL_CLASS}>
                 {sortedPrograms.map((program, index) => {
                   const displayTitle =
-                    program.title?.trim() || "Untitled object"
+                    program.title?.trim() || "Untitled activity"
                   const displayObjectKind = parseObjectKind(program)
                   const displayType = parseProgramType(program)
                   const statusLabel = program.status_label?.trim() || "Draft"
@@ -297,7 +297,7 @@ export function ProgramBuilderDashboardCard({
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
                       <p className="text-foreground truncate text-base font-semibold">
-                        {activeProgram.title?.trim() || "Untitled object"}
+                        {activeProgram.title?.trim() || "Untitled activity"}
                       </p>
                       <p className="text-muted-foreground mt-1 truncate text-sm">
                         {locationSummary(activeProgram) || "Location pending"}

--- a/src/components/programs/program-wizard.tsx
+++ b/src/components/programs/program-wizard.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
-import { resolveOrganizationPrimaryObjectKind } from "@/lib/organization/primary-objects"
+import { resolveOrganizationActivityKind } from "@/lib/organization/primary-objects"
 import { toast } from "@/lib/toast"
 import { cn } from "@/lib/utils"
 
@@ -111,7 +111,7 @@ export function ProgramWizard({
         const next = {
           ...fallback,
           ...parsed,
-          objectKind: resolveOrganizationPrimaryObjectKind(parsed.objectKind),
+          objectKind: resolveOrganizationActivityKind(parsed.objectKind),
           formatAddons: normalizeAddons(
             parsed.coreFormat ?? fallback.coreFormat,
             Array.isArray(parsed.formatAddons)
@@ -196,7 +196,12 @@ export function ProgramWizard({
   const validateCurrentStep = () => {
     const allErrors = parseErrors(form)
     const fields = requiredFieldsForStep(currentStep)
-    const stepErrors = fields.filter((field) => Boolean(allErrors[field]))
+    const stepErrors = Object.keys(allErrors).filter((field) => {
+      return (
+        fields.includes(field as keyof ProgramWizardFormState) ||
+        stepForField(field) === currentStep
+      )
+    })
     if (stepErrors.length === 0) return true
     setErrors((current) => ({ ...current, ...allErrors }))
     toast.error("Complete required fields before continuing")

--- a/src/components/programs/program-wizard/components/program-wizard-header.tsx
+++ b/src/components/programs/program-wizard/components/program-wizard-header.tsx
@@ -36,9 +36,9 @@ export function ProgramWizardHeader({
               {isAutoSaving ? "Saving..." : "Autosave on"}
             </Badge>
           ) : null}
-          <Badge variant="outline" className="rounded-full text-[11px]">
+          <span className="text-muted-foreground text-[11px] font-medium tabular-nums">
             Step {currentStep + 1} of {STEPS.length}
-          </Badge>
+          </span>
         </div>
       </div>
       <div className="mt-3">

--- a/src/components/programs/program-wizard/components/step-activity-kind.tsx
+++ b/src/components/programs/program-wizard/components/step-activity-kind.tsx
@@ -6,7 +6,7 @@ import {
   FieldSet,
   FieldLegend,
 } from "@/components/ui/field"
-import { ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS } from "@/lib/organization/primary-objects"
+import { ORGANIZATION_ACTIVITY_KIND_DEFINITIONS } from "@/lib/organization/primary-objects"
 import { cn } from "@/lib/utils"
 
 import type { ProgramWizardFormState } from "../schema"
@@ -34,7 +34,7 @@ export function StepActivityKind({
       </div>
 
       <div className="grid gap-2 sm:grid-cols-2">
-        {ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS.map((option) => {
+        {ORGANIZATION_ACTIVITY_KIND_DEFINITIONS.map((option) => {
           const selected = form.objectKind === option.kind
 
           return (

--- a/src/components/programs/program-wizard/components/step-schedule-location.tsx
+++ b/src/components/programs/program-wizard/components/step-schedule-location.tsx
@@ -22,6 +22,19 @@ export function StepScheduleLocation({
   errors,
   update,
 }: StepScheduleLocationProps) {
+  const showLocationUrl =
+    form.objectKind === "Web resource" || form.locationMode !== "in_person"
+  const locationUrlLabel =
+    form.objectKind === "Web resource"
+      ? "Resource URL"
+      : form.locationMode === "hybrid"
+        ? "Online or map link (optional)"
+        : "Online location URL (optional)"
+  const locationUrlPlaceholder =
+    form.objectKind === "Web resource"
+      ? "https://example.org/resource"
+      : "https://example.org/join"
+
   return (
     <section className="grid gap-4 sm:grid-cols-2">
       <div className="grid gap-1.5">
@@ -30,11 +43,13 @@ export function StepScheduleLocation({
           id="startMonth"
           type="month"
           value={form.startMonth}
-          onChange={(event) => update({ startMonth: event.currentTarget.value })}
+          onChange={(event) =>
+            update({ startMonth: event.currentTarget.value })
+          }
           className="text-base"
         />
         {errors.startMonth ? (
-          <p className="text-xs text-destructive">{errors.startMonth}</p>
+          <p className="text-destructive text-xs">{errors.startMonth}</p>
         ) : null}
       </div>
       <div className="grid gap-1.5">
@@ -42,17 +57,22 @@ export function StepScheduleLocation({
         <Input
           id="durationLabel"
           value={form.durationLabel}
-          onChange={(event) => update({ durationLabel: event.currentTarget.value })}
+          onChange={(event) =>
+            update({ durationLabel: event.currentTarget.value })
+          }
           placeholder="12 weeks"
           className="text-base"
         />
         {errors.durationLabel ? (
-          <p className="text-xs text-destructive">{errors.durationLabel}</p>
+          <p className="text-destructive text-xs">{errors.durationLabel}</p>
         ) : null}
       </div>
       <div className="grid gap-1.5">
         <Label htmlFor="frequency">Frequency</Label>
-        <Select value={form.frequency} onValueChange={(value) => update({ frequency: value })}>
+        <Select
+          value={form.frequency}
+          onValueChange={(value) => update({ frequency: value })}
+        >
           <SelectTrigger id="frequency">
             <SelectValue placeholder="Select frequency" />
           </SelectTrigger>
@@ -64,14 +84,18 @@ export function StepScheduleLocation({
             <SelectItem value="Custom">Custom</SelectItem>
           </SelectContent>
         </Select>
-        {errors.frequency ? <p className="text-xs text-destructive">{errors.frequency}</p> : null}
+        {errors.frequency ? (
+          <p className="text-destructive text-xs">{errors.frequency}</p>
+        ) : null}
       </div>
       <div className="grid gap-1.5">
         <Label htmlFor="locationMode">Location mode</Label>
         <Select
           value={form.locationMode}
           onValueChange={(value) =>
-            update({ locationMode: value as ProgramWizardFormState["locationMode"] })
+            update({
+              locationMode: value as ProgramWizardFormState["locationMode"],
+            })
           }
         >
           <SelectTrigger id="locationMode">
@@ -84,7 +108,7 @@ export function StepScheduleLocation({
           </SelectContent>
         </Select>
         {errors.locationMode ? (
-          <p className="text-xs text-destructive">{errors.locationMode}</p>
+          <p className="text-destructive text-xs">{errors.locationMode}</p>
         ) : null}
       </div>
       <div className="grid gap-1.5 sm:col-span-2">
@@ -92,11 +116,31 @@ export function StepScheduleLocation({
         <Input
           id="locationDetails"
           value={form.locationDetails}
-          onChange={(event) => update({ locationDetails: event.currentTarget.value })}
+          onChange={(event) =>
+            update({ locationDetails: event.currentTarget.value })
+          }
           placeholder="South Side Community Center"
           className="text-base"
         />
       </div>
+      {showLocationUrl ? (
+        <div className="grid gap-1.5 sm:col-span-2">
+          <Label htmlFor="locationUrl">{locationUrlLabel}</Label>
+          <Input
+            id="locationUrl"
+            type="url"
+            value={form.locationUrl}
+            onChange={(event) =>
+              update({ locationUrl: event.currentTarget.value })
+            }
+            placeholder={locationUrlPlaceholder}
+            className="text-base"
+          />
+          {errors.locationUrl ? (
+            <p className="text-destructive text-xs">{errors.locationUrl}</p>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/src/components/programs/program-wizard/helpers/hydrate.ts
+++ b/src/components/programs/program-wizard/helpers/hydrate.ts
@@ -2,7 +2,7 @@ import {
   defaultProgramWizardForm,
   DELIVERY_FORMATS,
   LOCATION_MODES,
-  ORGANIZATION_PRIMARY_OBJECT_KINDS,
+  ORGANIZATION_ACTIVITY_KINDS,
   ProgramWizardFormState,
   PROGRAM_TYPES,
 } from "../schema"
@@ -48,7 +48,7 @@ export function hydrateFromProgram(
   const snapshotCoreFormat = toStringValue(snapshot.coreFormat)
 
   const objectKind = (
-    ORGANIZATION_PRIMARY_OBJECT_KINDS as readonly string[]
+    ORGANIZATION_ACTIVITY_KINDS as readonly string[]
   ).includes(snapshotObjectKind)
     ? (snapshotObjectKind as ProgramWizardFormState["objectKind"])
     : "Program"
@@ -164,6 +164,10 @@ export function hydrateFromProgram(
     locationDetails: toStringValue(
       snapshot.locationDetails,
       toStringValue(program.location)
+    ),
+    locationUrl: toStringValue(
+      snapshot.locationUrl,
+      toStringValue(program.location_url)
     ),
     budgetRows: budget.rows,
     budgetUsd: budget.totalBudget,

--- a/src/components/programs/program-wizard/helpers/serialize.ts
+++ b/src/components/programs/program-wizard/helpers/serialize.ts
@@ -10,6 +10,7 @@ export function serializePayload(
 ): CreateProgramPayload {
   const budget = computeBudgetBreakdown(form)
   const formatAddons = normalizeAddons(form.coreFormat, form.formatAddons)
+  const locationUrl = form.locationUrl.trim()
   const locationType = form.locationMode === "online" ? "online" : "in_person"
   const location =
     form.locationDetails.trim() ||
@@ -67,6 +68,7 @@ export function serializePayload(
     frequency: form.frequency.trim(),
     locationMode: form.locationMode,
     locationDetails: form.locationDetails.trim(),
+    locationUrl,
     budgetRows: budget.rows,
     budgetUsd: budget.totalBudget,
     costStaffUsd: budget.costStaffUsd,
@@ -101,7 +103,7 @@ export function serializePayload(
     description: form.oneSentence.trim(),
     location,
     locationType,
-    locationUrl: locationType === "online" ? null : null,
+    locationUrl: locationUrl || null,
     imageUrl: form.imageUrl.trim() || null,
     duration: form.durationLabel.trim() || null,
     startDate: monthToIsoStart(form.startMonth),

--- a/src/components/programs/program-wizard/schema.ts
+++ b/src/components/programs/program-wizard/schema.ts
@@ -3,9 +3,9 @@
 import { z } from "zod"
 import { publicSharingEnabled } from "@/lib/feature-flags"
 import type { BudgetTableRow } from "@/lib/modules"
-import { ORGANIZATION_PRIMARY_OBJECT_KINDS } from "@/lib/organization/primary-objects"
+import { ORGANIZATION_ACTIVITY_KINDS } from "@/lib/organization/primary-objects"
 
-export { ORGANIZATION_PRIMARY_OBJECT_KINDS }
+export { ORGANIZATION_ACTIVITY_KINDS }
 
 export const PROGRAM_TYPES = [
   "Direct Services",
@@ -49,7 +49,7 @@ export const ProgramWizardSchema = z.object({
   subtitle: z.string().max(200).or(z.literal("")).default(""),
   bannerImageUrl: z.string().url().or(z.literal("")).default(""),
   imageUrl: z.string().url().or(z.literal("")).default(""),
-  objectKind: z.enum(ORGANIZATION_PRIMARY_OBJECT_KINDS).default("Program"),
+  objectKind: z.enum(ORGANIZATION_ACTIVITY_KINDS).default("Program"),
   programType: z.enum(PROGRAM_TYPES),
   coreFormat: z.enum(DELIVERY_FORMATS),
   formatAddons: z.array(z.string().min(1)).default([]),
@@ -90,7 +90,7 @@ export const ProgramWizardSchema = z.object({
     .max(40)
     .or(z.literal("Learn more"))
     .default("Learn more"),
-  ctaUrl: z.string().url().or(z.literal("")).default(""),
+  ctaUrl: z.string().url("Enter a valid URL.").or(z.literal("")).default(""),
   goalUsd: z.coerce.number().nonnegative().default(0),
   raisedUsd: z.coerce.number().nonnegative().default(0),
   features: z.array(z.string().min(1)).default([]),
@@ -99,7 +99,11 @@ export const ProgramWizardSchema = z.object({
   description: z.string().max(2000).or(z.literal("")).default(""),
   location: z.string().max(160).or(z.literal("")).default(""),
   locationType: z.enum(["in_person", "online"]).default("in_person"),
-  locationUrl: z.string().url().or(z.literal("")).default(""),
+  locationUrl: z
+    .string()
+    .url("Enter a valid URL.")
+    .or(z.literal(""))
+    .default(""),
   teamIds: z.array(z.string().min(1)).default([]),
   startDate: z.string().or(z.literal("")).default(""),
   endDate: z.string().or(z.literal("")).default(""),

--- a/src/components/programs/program-wizard/validation-helpers.ts
+++ b/src/components/programs/program-wizard/validation-helpers.ts
@@ -18,6 +18,10 @@ export function parseErrors(form: ProgramWizardFormState) {
     next.budgetUsd = "Add at least one budget line item."
   }
 
+  if (form.objectKind === "Web resource" && !form.locationUrl.trim()) {
+    next.locationUrl = "Add the resource URL."
+  }
+
   return next
 }
 
@@ -76,6 +80,7 @@ const FIELD_STEP_MAP: Record<string, number> = {
   frequency: 5,
   locationMode: 5,
   locationDetails: 5,
+  locationUrl: 5,
   budgetUsd: 6,
 }
 

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-activity-action.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-activity-action.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import CheckCircle2Icon from "lucide-react/dist/esm/icons/check-circle-2"
+import CircleDashedIcon from "lucide-react/dist/esm/icons/circle-dashed"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+import type { FiscalSponsorshipActivityEligibility } from "../lib/activity-eligibility"
+import { FiscalSponsorshipMark } from "./fiscal-sponsorship-mark"
+
+export function FiscalSponsorshipActivityAction({
+  active,
+  ariaLabel,
+  disabled = false,
+  eligibility,
+  onOpen,
+  onUpdateInfo,
+}: {
+  active: boolean
+  ariaLabel?: string
+  disabled?: boolean
+  eligibility: FiscalSponsorshipActivityEligibility
+  onOpen: () => void
+  onUpdateInfo: () => void
+}) {
+  const markState = active ? "active" : eligibility.state
+  const actionLabel = eligibility.eligible ? "Request review" : "Update info"
+  const statusLabel = active
+    ? "Open"
+    : eligibility.eligible
+      ? "Review ready"
+      : "Needs data"
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 rounded-lg p-0 hover:bg-transparent"
+          aria-label={
+            ariaLabel ?? `Fiscal sponsorship ${statusLabel.toLowerCase()}`
+          }
+          aria-pressed={active}
+          data-fiscal-sponsorship-eligibility-state={markState}
+          disabled={disabled}
+          onClick={() => {
+            if (active || eligibility.eligible) {
+              onOpen()
+            }
+          }}
+        >
+          <FiscalSponsorshipMark
+            state={markState}
+            className="size-8 rounded-lg text-xs"
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-[17rem] max-w-[calc(100vw-2rem)] rounded-xl p-2 text-xs whitespace-normal shadow-lg"
+      >
+        <div className="space-y-2">
+          <div className="flex min-w-0 items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <FiscalSponsorshipMark
+                state={markState}
+                className="size-4 rounded-[0.35rem] text-[7px]"
+              />
+              <div className="min-w-0">
+                <p className="text-foreground truncate font-medium">
+                  Fiscal sponsorship
+                </p>
+                <p className="text-muted-foreground truncate text-[10px]">
+                  Signals only. Coach House reviews.
+                </p>
+              </div>
+            </div>
+            <Badge
+              variant={eligibility.eligible ? "default" : "secondary"}
+              className="h-6 shrink-0 rounded-full px-2 text-[10px]"
+            >
+              {eligibility.label}
+            </Badge>
+          </div>
+          <div className="space-y-1">
+            {eligibility.criteria.map((criterion) => {
+              const Icon = criterion.met ? CheckCircle2Icon : CircleDashedIcon
+
+              return (
+                <div
+                  key={criterion.id}
+                  className="flex min-w-0 items-center gap-2"
+                >
+                  <Icon
+                    className={cn(
+                      "size-3.5 shrink-0",
+                      criterion.met
+                        ? "text-emerald-600"
+                        : "text-muted-foreground"
+                    )}
+                    aria-hidden
+                  />
+                  <span className="text-foreground min-w-0 flex-1 truncate">
+                    {criterion.label}
+                  </span>
+                  {criterion.met ? (
+                    <CheckCircle2Icon
+                      className="size-3.5 shrink-0 text-emerald-600"
+                      aria-label="Complete"
+                    />
+                  ) : (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 shrink-0 rounded-full px-2 text-[10px]"
+                      disabled={disabled}
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        onUpdateInfo()
+                      }}
+                    >
+                      Add
+                    </Button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 w-full rounded-full text-xs"
+            disabled={disabled}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              if (eligibility.eligible) {
+                onOpen()
+                return
+              }
+
+              onUpdateInfo()
+            }}
+          >
+            {actionLabel}
+          </Button>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-mark.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-mark.tsx
@@ -1,10 +1,24 @@
 import { cn } from "@/lib/utils"
 
-export function FiscalSponsorshipMark({ className }: { className?: string }) {
+import type { FiscalSponsorshipActivityEligibilityState } from "../lib/activity-eligibility"
+
+export function FiscalSponsorshipMark({
+  className,
+  state,
+}: {
+  className?: string
+  state?: FiscalSponsorshipActivityEligibilityState
+}) {
   return (
     <span
       className={cn(
         "bg-primary/10 text-primary inline-flex size-10 shrink-0 items-center justify-center rounded-2xl text-lg font-semibold tracking-tight italic",
+        state === "inactive" &&
+          "bg-muted text-muted-foreground ring-border/60 ring-1",
+        state === "lit" &&
+          "bg-emerald-500/10 text-emerald-700 ring-1 ring-emerald-500/25 dark:text-emerald-300",
+        state === "active" &&
+          "bg-primary text-primary-foreground shadow-xs ring-transparent",
         className
       )}
     >

--- a/src/features/fiscal-sponsorship/components/index.ts
+++ b/src/features/fiscal-sponsorship/components/index.ts
@@ -1,4 +1,5 @@
 export { FiscalSponsorshipPanel } from "./fiscal-sponsorship-panel"
+export { FiscalSponsorshipActivityAction } from "./fiscal-sponsorship-activity-action"
 export { FiscalSponsorshipMark } from "./fiscal-sponsorship-mark"
 export { FiscalSponsorshipMarkdownDocument } from "./fiscal-sponsorship-markdown-document"
 export { FiscalSponsorshipApplicationDrawer } from "./fiscal-sponsorship-application-drawer"

--- a/src/features/fiscal-sponsorship/index.ts
+++ b/src/features/fiscal-sponsorship/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./actions"
 export {
   FiscalSponsorshipApplicationDrawer,
+  FiscalSponsorshipActivityAction,
   FiscalSponsorshipMark,
   FiscalSponsorshipMarkdownDocument,
   FiscalSponsorshipPanel,
@@ -20,6 +21,14 @@ export {
   FiscalSponsorshipWorkflowDrawer,
   FiscalSponsorshipWorkspaceCardSummary,
 } from "./components"
+export {
+  analyzeFiscalSponsorshipActivityEligibility,
+  type FiscalSponsorshipActivityEligibility,
+  type FiscalSponsorshipActivityEligibilityActivity,
+  type FiscalSponsorshipActivityEligibilityOrganization,
+  type FiscalSponsorshipActivityEligibilityState,
+  type FiscalSponsorshipActivityEligibilityCriterion,
+} from "./lib/activity-eligibility"
 export {
   FISCAL_SPONSORSHIP_HANDBOOK_DOWNLOAD_HREF,
   FISCAL_SPONSORSHIP_HANDBOOK_HREF,

--- a/src/features/fiscal-sponsorship/lib/activity-eligibility.ts
+++ b/src/features/fiscal-sponsorship/lib/activity-eligibility.ts
@@ -1,0 +1,251 @@
+import type { FiscalSponsorshipApplicationPrefill } from "../types"
+
+export type FiscalSponsorshipActivityEligibilityState =
+  | "inactive"
+  | "lit"
+  | "active"
+
+export type FiscalSponsorshipActivityEligibilityCriterion = {
+  id:
+    | "impact-narrative"
+    | "us-operations"
+    | "funding-use"
+    | "mission-fit"
+    | "tax-mailing"
+  label: string
+  met: boolean
+  detail: string
+}
+
+export type FiscalSponsorshipActivityEligibility = {
+  criteria: FiscalSponsorshipActivityEligibilityCriterion[]
+  completedCount: number
+  eligible: boolean
+  label: string
+  state: Exclude<FiscalSponsorshipActivityEligibilityState, "active">
+  totalCount: number
+}
+
+export type FiscalSponsorshipActivityEligibilityActivity = {
+  title?: string | null
+  subtitle?: string | null
+  description?: string | null
+  location?: string | null
+  locationType?: string | null
+  addressCity?: string | null
+  addressState?: string | null
+  addressCountry?: string | null
+  focusArea?: string | null
+  objectKind?: string | null
+  publicBenefit?: string | null
+  estimatedBudgetCents?: number | null
+  goalCents?: number | null
+  wizardSnapshot?: Record<string, unknown> | null
+}
+
+export type FiscalSponsorshipActivityEligibilityOrganization = {
+  description?: string | null
+  ein?: string | null
+  mission?: string | null
+  need?: string | null
+  address?: string | null
+  addressStreet?: string | null
+  addressCity?: string | null
+  addressState?: string | null
+  addressPostal?: string | null
+  addressCountry?: string | null
+}
+
+function cleanText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function hasText(value: string | null | undefined) {
+  return Boolean(cleanText(value))
+}
+
+function readSnapshotString(
+  snapshot: Record<string, unknown> | null | undefined,
+  key: string
+) {
+  const value = snapshot?.[key]
+  return typeof value === "string" ? cleanText(value) : null
+}
+
+function readSnapshotTextList(
+  snapshot: Record<string, unknown> | null | undefined,
+  key: string
+) {
+  const value = snapshot?.[key]
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((entry) => (typeof entry === "string" ? cleanText(entry) : null))
+    .filter((entry): entry is string => Boolean(entry))
+}
+
+function hasPositiveAmount(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+}
+
+function normalizeCountry(value: string | null | undefined) {
+  const normalized = cleanText(value)?.toLowerCase()
+  if (!normalized) return null
+
+  return normalized.replaceAll(".", "").replace(/\s+/g, " ")
+}
+
+function isUnitedStates(value: string | null | undefined) {
+  const normalized = normalizeCountry(value)
+  return (
+    normalized === "us" ||
+    normalized === "usa" ||
+    normalized === "u s" ||
+    normalized === "united states" ||
+    normalized === "united states of america"
+  )
+}
+
+function hasUnitedStatesSignal({
+  activity,
+  organization,
+  prefill,
+}: {
+  activity: FiscalSponsorshipActivityEligibilityActivity | null | undefined
+  organization:
+    | FiscalSponsorshipActivityEligibilityOrganization
+    | null
+    | undefined
+  prefill: FiscalSponsorshipApplicationPrefill | null | undefined
+}) {
+  if (
+    isUnitedStates(activity?.addressCountry) ||
+    isUnitedStates(organization?.addressCountry)
+  ) {
+    return true
+  }
+
+  const state = cleanText(
+    activity?.addressState ??
+      prefill?.mailingState ??
+      organization?.addressState
+  )
+  const city = cleanText(
+    activity?.addressCity ?? prefill?.mailingCity ?? organization?.addressCity
+  )
+  const postal = cleanText(
+    prefill?.mailingPostalCode ?? organization?.addressPostal
+  )
+
+  return Boolean(state && (city || postal))
+}
+
+function hasMailingAddress({
+  organization,
+  prefill,
+}: {
+  organization:
+    | FiscalSponsorshipActivityEligibilityOrganization
+    | null
+    | undefined
+  prefill: FiscalSponsorshipApplicationPrefill | null | undefined
+}) {
+  const street = cleanText(
+    prefill?.mailingStreetAddress ??
+      organization?.addressStreet ??
+      organization?.address
+  )
+  const city = cleanText(prefill?.mailingCity ?? organization?.addressCity)
+  const state = cleanText(prefill?.mailingState ?? organization?.addressState)
+  const postal = cleanText(
+    prefill?.mailingPostalCode ?? organization?.addressPostal
+  )
+
+  return Boolean(street && city && state && postal)
+}
+
+export function analyzeFiscalSponsorshipActivityEligibility({
+  activity,
+  organization,
+  prefill,
+}: {
+  activity?: FiscalSponsorshipActivityEligibilityActivity | null
+  organization?: FiscalSponsorshipActivityEligibilityOrganization | null
+  prefill?: FiscalSponsorshipApplicationPrefill | null
+}): FiscalSponsorshipActivityEligibility {
+  const snapshot = activity?.wizardSnapshot
+  const publicBenefit = cleanText(activity?.publicBenefit)
+  const successOutcomes = readSnapshotTextList(snapshot, "successOutcomes")
+  const oneSentence = readSnapshotString(snapshot, "oneSentence")
+  const fundingSource = readSnapshotString(snapshot, "fundingSource")
+  const focusArea =
+    cleanText(activity?.focusArea) ??
+    readSnapshotString(snapshot, "programType")
+  const estimatedBudgetKnown =
+    hasPositiveAmount(activity?.estimatedBudgetCents) ||
+    hasPositiveAmount(activity?.goalCents)
+  const hasActivityNarrative = Boolean(
+    cleanText(activity?.title) &&
+    (cleanText(activity?.description) ||
+      cleanText(activity?.subtitle) ||
+      oneSentence)
+  )
+  const hasPublicBenefit = Boolean(
+    publicBenefit || successOutcomes.length > 0 || prefill?.publicBenefit
+  )
+  const hasMissionFit = Boolean(
+    focusArea ||
+    cleanText(activity?.objectKind) ||
+    cleanText(organization?.mission) ||
+    cleanText(organization?.need)
+  )
+  const hasFundingUseSignal = Boolean(fundingSource || estimatedBudgetKnown)
+  const hasTaxId = hasText(organization?.ein)
+  const mailingReady = hasMailingAddress({ organization, prefill })
+
+  const criteria: FiscalSponsorshipActivityEligibilityCriterion[] = [
+    {
+      id: "impact-narrative",
+      label: "Impact narrative",
+      met: hasPublicBenefit || hasActivityNarrative,
+      detail: hasPublicBenefit ? "impact found" : "add impact",
+    },
+    {
+      id: "us-operations",
+      label: "U.S. operations",
+      met: hasUnitedStatesSignal({ activity, organization, prefill }),
+      detail: "location check",
+    },
+    {
+      id: "funding-use",
+      label: "Funding use",
+      met: hasFundingUseSignal,
+      detail: hasFundingUseSignal ? "use signal" : "add funding use",
+    },
+    {
+      id: "mission-fit",
+      label: "Mission fit signal",
+      met: hasMissionFit,
+      detail: hasMissionFit ? "mission signal" : "add focus",
+    },
+    {
+      id: "tax-mailing",
+      label: "Tax ID + mailing",
+      met: hasTaxId && mailingReady,
+      detail: hasTaxId && mailingReady ? "ready" : "need EIN/address",
+    },
+  ]
+  const completedCount = criteria.filter((criterion) => criterion.met).length
+  const totalCount = criteria.length
+  const eligible = completedCount === totalCount
+
+  return {
+    criteria,
+    completedCount,
+    eligible,
+    label: eligible ? "Review ready" : `${completedCount}/${totalCount}`,
+    state: eligible ? "lit" : "inactive",
+    totalCount,
+  }
+}

--- a/src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx
@@ -214,6 +214,31 @@ export function MemberWorkspaceProjectDetailTabs({
   updateTaskOrderAction,
   updateTaskStatusAction,
 }: MemberWorkspaceProjectDetailTabsProps) {
+  const resolvedFiscalSponsorshipWorkbench = fiscalSponsorshipWorkbench ?? (
+    <MemberWorkspaceProjectFiscalWorkbench
+      canConnectDocuments={canConnectFiscalDocuments}
+      connectFiscalSponsorshipDocumentAssetAction={
+        connectFiscalSponsorshipDocumentAssetAction
+      }
+      generateFiscalSponsorshipAgreementAction={
+        generateFiscalSponsorshipAgreementAction
+      }
+      fiscalSponsorshipWorkflowSummary={fiscalSponsorshipWorkflowSummary}
+      onOpenAssets={() => onActiveTabChange("assets")}
+      organizationSummary={organizationSummary}
+      project={project}
+      reviewFiscalSponsorshipApplicationAction={
+        reviewFiscalSponsorshipApplicationAction
+      }
+      reviewFiscalSponsorshipDocumentAction={
+        reviewFiscalSponsorshipDocumentAction
+      }
+      sendFiscalSponsorshipAgreementForSignatureAction={
+        sendFiscalSponsorshipAgreementForSignatureAction
+      }
+    />
+  )
+
   return (
     <Tabs value={activeTab} onValueChange={onActiveTabChange}>
       <ProjectDetailTabsList />
@@ -221,34 +246,7 @@ export function MemberWorkspaceProjectDetailTabs({
       <TabsContent value="overview">
         <ProjectDetailOverviewContent
           draft={draft}
-          fiscalSponsorshipWorkbench={
-            fiscalSponsorshipWorkbench ?? (
-              <MemberWorkspaceProjectFiscalWorkbench
-                canConnectDocuments={canConnectFiscalDocuments}
-                connectFiscalSponsorshipDocumentAssetAction={
-                  connectFiscalSponsorshipDocumentAssetAction
-                }
-                generateFiscalSponsorshipAgreementAction={
-                  generateFiscalSponsorshipAgreementAction
-                }
-                fiscalSponsorshipWorkflowSummary={
-                  fiscalSponsorshipWorkflowSummary
-                }
-                onOpenAssets={() => onActiveTabChange("assets")}
-                organizationSummary={organizationSummary}
-                project={project}
-                reviewFiscalSponsorshipApplicationAction={
-                  reviewFiscalSponsorshipApplicationAction
-                }
-                reviewFiscalSponsorshipDocumentAction={
-                  reviewFiscalSponsorshipDocumentAction
-                }
-                sendFiscalSponsorshipAgreementForSignatureAction={
-                  sendFiscalSponsorshipAgreementForSignatureAction
-                }
-              />
-            )
-          }
+          fiscalSponsorshipWorkbench={resolvedFiscalSponsorshipWorkbench}
           isEditing={isEditing}
           project={project}
           onChangeDraftField={onChangeDraftField}

--- a/src/features/member-workspace/components/projects/member-workspace-project-overview-typography.ts
+++ b/src/features/member-workspace/components/projects/member-workspace-project-overview-typography.ts
@@ -11,7 +11,7 @@ export const MEMBER_WORKSPACE_PROJECT_OVERVIEW_EDITOR_CLASS_NAME = cn(
 export const MEMBER_WORKSPACE_PROJECT_OVERVIEW_DOCUMENT_CLASS_NAME = cn(
   "tiptap ProseMirror block w-full min-w-0 break-words",
   "prose prose-sm dark:prose-invert max-w-none",
-  "min-h-[32rem] bg-transparent px-4 py-3",
+  "max-h-[32rem] overflow-y-auto bg-transparent px-4 py-3",
   "prose-h1:text-3xl prose-h1:font-bold prose-h1:tracking-tight",
   "prose-h2:text-2xl prose-h2:font-semibold prose-h3:text-xl prose-h3:font-semibold",
   "prose-p:my-3 prose-ul:list-disc prose-ol:list-decimal prose-ul:pl-5 prose-ol:pl-6 prose-ol:list-inside",

--- a/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
@@ -2,13 +2,11 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { Plus } from "@phosphor-icons/react/dist/ssr"
 
 import {
   ChipOverflow,
   type PlatformAdminDashboardLabProject,
 } from "@/features/platform-admin-dashboard"
-import { Button } from "@/components/ui/button"
 import type {
   MemberWorkspaceCreateProjectFormInput,
   MemberWorkspacePersonOption,
@@ -162,20 +160,6 @@ export function MemberWorkspaceProjectsPage(props: {
                 <MemberWorkspaceClearStarterDataButton
                   clearStarterDataAction={clearStarterDataAction}
                 />
-              ) : null}
-              {canCreateProjects ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  type="button"
-                  onClick={() => {
-                    setEditingProject(null)
-                    setIsProjectWizardOpen(true)
-                  }}
-                >
-                  <Plus data-icon="inline-start" weight="bold" />
-                  Add Organization
-                </Button>
               ) : null}
             </div>
           </div>

--- a/src/features/member-workspace/index.ts
+++ b/src/features/member-workspace/index.ts
@@ -23,6 +23,7 @@ export {
   loadAccessibleOrganizations,
   loadMemberWorkspacePeoplePage,
   loadMemberWorkspaceProjectDetailPage,
+  loadPlatformAdminOrganizationProjectDetailPage,
   loadMemberWorkspaceProjectsPage,
   loadMemberWorkspaceTasksPage,
 } from "./loaders"

--- a/src/features/member-workspace/loaders.ts
+++ b/src/features/member-workspace/loaders.ts
@@ -1,5 +1,8 @@
 export { loadAccessibleOrganizations } from "./server/load-accessible-organizations"
 export { loadMemberWorkspacePeoplePage } from "./server/loaders"
-export { loadMemberWorkspaceProjectDetailPage } from "./server/project-detail-loader"
+export {
+  loadMemberWorkspaceProjectDetailPage,
+  loadPlatformAdminOrganizationProjectDetailPage,
+} from "./server/project-detail-loader"
 export { loadMemberWorkspaceProjectsPage } from "./server/project-loaders"
 export { loadMemberWorkspaceTasksPage } from "./server/task-loaders"

--- a/src/features/member-workspace/public-components.tsx
+++ b/src/features/member-workspace/public-components.tsx
@@ -7,10 +7,12 @@ export const MemberWorkspaceOrgSwitcher = dynamic<
   ComponentProps<
     typeof import("./components/shell/member-workspace-org-switcher").MemberWorkspaceOrgSwitcher
   >
->(() =>
-  import("./components/shell/member-workspace-org-switcher").then(
-    (mod) => mod.MemberWorkspaceOrgSwitcher,
-  ),
+>(
+  () =>
+    import("./components/shell/member-workspace-org-switcher").then(
+      (mod) => mod.MemberWorkspaceOrgSwitcher
+    ),
+  { ssr: false }
 )
 
 export const MemberWorkspacePageLoading = dynamic<
@@ -19,8 +21,8 @@ export const MemberWorkspacePageLoading = dynamic<
   >
 >(() =>
   import("./components/shell/member-workspace-page-loading").then(
-    (mod) => mod.MemberWorkspacePageLoading,
-  ),
+    (mod) => mod.MemberWorkspacePageLoading
+  )
 )
 
 export const MemberWorkspaceProjectDetailLoading = dynamic<
@@ -29,8 +31,8 @@ export const MemberWorkspaceProjectDetailLoading = dynamic<
   >
 >(() =>
   import("./components/projects/member-workspace-project-detail-loading").then(
-    (mod) => mod.MemberWorkspaceProjectDetailLoading,
-  ),
+    (mod) => mod.MemberWorkspaceProjectDetailLoading
+  )
 )
 
 export const MemberWorkspaceProjectDetailPage = dynamic<
@@ -39,8 +41,8 @@ export const MemberWorkspaceProjectDetailPage = dynamic<
   >
 >(() =>
   import("./components/projects/member-workspace-project-detail-page").then(
-    (mod) => mod.MemberWorkspaceProjectDetailPage,
-  ),
+    (mod) => mod.MemberWorkspaceProjectDetailPage
+  )
 )
 
 export const MemberWorkspacePeoplePage = dynamic<
@@ -49,8 +51,8 @@ export const MemberWorkspacePeoplePage = dynamic<
   >
 >(() =>
   import("./components/people/member-workspace-people-page").then(
-    (mod) => mod.MemberWorkspacePeoplePage,
-  ),
+    (mod) => mod.MemberWorkspacePeoplePage
+  )
 )
 
 export const MemberWorkspaceProjectsPage = dynamic<
@@ -59,8 +61,8 @@ export const MemberWorkspaceProjectsPage = dynamic<
   >
 >(() =>
   import("./components/projects/member-workspace-projects-page").then(
-    (mod) => mod.MemberWorkspaceProjectsPage,
-  ),
+    (mod) => mod.MemberWorkspaceProjectsPage
+  )
 )
 
 export const MemberWorkspaceTasksPage = dynamic<
@@ -69,6 +71,6 @@ export const MemberWorkspaceTasksPage = dynamic<
   >
 >(() =>
   import("./components/tasks/member-workspace-tasks-page").then(
-    (mod) => mod.MemberWorkspaceTasksPage,
-  ),
+    (mod) => mod.MemberWorkspaceTasksPage
+  )
 )

--- a/src/features/member-workspace/server/project-detail-loader.ts
+++ b/src/features/member-workspace/server/project-detail-loader.ts
@@ -1,4 +1,5 @@
 import type { User } from "@/features/platform-admin-dashboard"
+import { createSupabaseAdminClient } from "@/lib/supabase/admin"
 import type { Database } from "@/lib/supabase"
 import type {
   MemberWorkspaceAdminOrganizationSummary,
@@ -105,6 +106,11 @@ export type MemberWorkspaceProjectDetailLoadResult =
       organizationSummary: MemberWorkspaceAdminOrganizationSummary
       project: ReturnType<typeof buildMemberWorkspaceProjectDetails>
     }
+
+type MemberWorkspaceProjectDetailActor = Pick<
+  Awaited<ReturnType<typeof resolveMemberWorkspaceActorContext>>,
+  "isAdmin" | "supabase" | "userId"
+>
 
 async function loadProjectTaskRows({
   orgId,
@@ -384,7 +390,7 @@ async function buildReadyProjectDetailResult({
   organizationSummary,
   project,
 }: {
-  actor: Awaited<ReturnType<typeof resolveMemberWorkspaceActorContext>>
+  actor: MemberWorkspaceProjectDetailActor
   organizationSummary: MemberWorkspaceAdminOrganizationSummary
   project: OrganizationProjectRecord
 }): Promise<
@@ -453,101 +459,130 @@ async function buildReadyProjectDetailResult({
   }
 }
 
+async function loadPlatformAdminProjectDetailPage({
+  projectId,
+  userId,
+}: {
+  projectId: string
+  userId: string
+}): Promise<MemberWorkspaceProjectDetailLoadResult> {
+  const adminActor: MemberWorkspaceProjectDetailActor = {
+    isAdmin: true,
+    supabase: createSupabaseAdminClient(),
+    userId,
+  }
+
+  const { data: projectRow, error: projectError } = await adminActor.supabase
+    .from("organization_projects")
+    .select(organizationProjectSelectFields)
+    .eq("id", projectId)
+    .maybeSingle<OrganizationProjectRecord>()
+
+  if (projectError) {
+    if (isMissingOrganizationProjectsTableError(projectError)) {
+      const organization = await loadAdminOrganizationSummaryById({
+        supabase: adminActor.supabase,
+        orgId: projectId,
+      })
+
+      if (!organization) {
+        return { state: "schema-unavailable" }
+      }
+
+      return buildReadyProjectDetailResult({
+        actor: adminActor,
+        organizationSummary: organization,
+        project: mapAdminOrganizationSummaryToProjectRecord(organization),
+      })
+    }
+    throw toMemberWorkspaceDataError(
+      projectError,
+      "Unable to load project details."
+    )
+  }
+
+  if (projectRow) {
+    const organizationSummary = await loadAdminOrganizationSummaryById({
+      supabase: adminActor.supabase,
+      orgId: projectRow.org_id,
+    })
+
+    if (!organizationSummary) {
+      return { state: "not-found" }
+    }
+
+    if (projectRow.project_kind === "organization_admin") {
+      const canonicalProjects = await ensureCanonicalAdminProjects({
+        organizations: [organizationSummary],
+        supabase: adminActor.supabase,
+      })
+      const canonicalProject = canonicalProjects?.[0] ?? null
+
+      return buildReadyProjectDetailResult({
+        actor: adminActor,
+        organizationSummary,
+        project:
+          canonicalProject ??
+          mapAdminOrganizationSummaryToProjectRecord(organizationSummary),
+      })
+    }
+
+    return buildReadyProjectDetailResult({
+      actor: adminActor,
+      organizationSummary,
+      project: projectRow,
+    })
+  }
+
+  const organization = await loadAdminOrganizationSummaryById({
+    supabase: adminActor.supabase,
+    orgId: projectId,
+  })
+
+  if (!organization) {
+    return { state: "not-found" }
+  }
+
+  const canonicalProjects = await ensureCanonicalAdminProjects({
+    organizations: [organization],
+    supabase: adminActor.supabase,
+  })
+  const canonicalProject = canonicalProjects?.[0] ?? null
+
+  if (canonicalProject) {
+    return buildReadyProjectDetailResult({
+      actor: adminActor,
+      organizationSummary: organization,
+      project: canonicalProject,
+    })
+  }
+
+  return buildReadyProjectDetailResult({
+    actor: adminActor,
+    organizationSummary: organization,
+    project: mapAdminOrganizationSummaryToProjectRecord(organization),
+  })
+}
+
+export async function loadPlatformAdminOrganizationProjectDetailPage({
+  projectId,
+  userId,
+}: {
+  projectId: string
+  userId: string
+}): Promise<MemberWorkspaceProjectDetailLoadResult> {
+  return loadPlatformAdminProjectDetailPage({ projectId, userId })
+}
+
 export async function loadMemberWorkspaceProjectDetailPage(
   projectId: string
 ): Promise<MemberWorkspaceProjectDetailLoadResult> {
   const actor = await resolveMemberWorkspaceActorContext()
 
   if (actor.isAdmin) {
-    const { data: projectRow, error: projectError } = await actor.supabase
-      .from("organization_projects")
-      .select(organizationProjectSelectFields)
-      .eq("id", projectId)
-      .maybeSingle<OrganizationProjectRecord>()
-
-    if (projectError) {
-      if (isMissingOrganizationProjectsTableError(projectError)) {
-        const organization = await loadAdminOrganizationSummaryById({
-          supabase: actor.supabase,
-          orgId: projectId,
-        })
-
-        if (!organization) {
-          return { state: "schema-unavailable" }
-        }
-
-        return buildReadyProjectDetailResult({
-          actor,
-          organizationSummary: organization,
-          project: mapAdminOrganizationSummaryToProjectRecord(organization),
-        })
-      }
-      throw toMemberWorkspaceDataError(
-        projectError,
-        "Unable to load project details."
-      )
-    }
-
-    if (projectRow) {
-      const organizationSummary = await loadAdminOrganizationSummaryById({
-        supabase: actor.supabase,
-        orgId: projectRow.org_id,
-      })
-
-      if (!organizationSummary) {
-        return { state: "not-found" }
-      }
-
-      if (projectRow.project_kind === "organization_admin") {
-        const canonicalProjects = await ensureCanonicalAdminProjects({
-          organizations: [organizationSummary],
-          supabase: actor.supabase,
-        })
-        const canonicalProject = canonicalProjects?.[0] ?? null
-
-        return buildReadyProjectDetailResult({
-          actor,
-          organizationSummary,
-          project:
-            canonicalProject ??
-            mapAdminOrganizationSummaryToProjectRecord(organizationSummary),
-        })
-      }
-
-      return buildReadyProjectDetailResult({
-        actor,
-        organizationSummary,
-        project: projectRow,
-      })
-    }
-
-    const organization = await loadAdminOrganizationSummaryById({
-      supabase: actor.supabase,
-      orgId: projectId,
-    })
-
-    if (!organization) {
-      return { state: "not-found" }
-    }
-
-    const canonicalProjects = await ensureCanonicalAdminProjects({
-      organizations: [organization],
-      supabase: actor.supabase,
-    })
-    const canonicalProject = canonicalProjects?.[0] ?? null
-
-    if (canonicalProject) {
-      return buildReadyProjectDetailResult({
-        actor,
-        organizationSummary: organization,
-        project: canonicalProject,
-      })
-    }
-
-    return buildReadyProjectDetailResult({
-      actor,
-      organizationSummary: organization,
-      project: mapAdminOrganizationSummaryToProjectRecord(organization),
+    return loadPlatformAdminProjectDetailPage({
+      projectId,
+      userId: actor.userId,
     })
   }
 

--- a/src/lib/organization/primary-objects.ts
+++ b/src/lib/organization/primary-objects.ts
@@ -9,12 +9,31 @@ export const ORGANIZATION_PRIMARY_OBJECT_KINDS = [
   "Fundraiser",
   "Grant application",
   "Re-grant request",
+  "Web resource",
 ] as const
 
 export type OrganizationPrimaryObjectKind =
   (typeof ORGANIZATION_PRIMARY_OBJECT_KINDS)[number]
 
-export const ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS = [
+export const ORGANIZATION_ACTIVITY_KINDS = [
+  "Initiative",
+  "Project",
+  "Program",
+  "Event",
+  "Service",
+  "Activity",
+  "Web resource",
+] as const
+
+export type OrganizationActivityKind =
+  (typeof ORGANIZATION_ACTIVITY_KINDS)[number]
+
+type OrganizationObjectDefinition<TKind extends string> = {
+  kind: TKind
+  description: string
+}
+
+const ORGANIZATION_SHARED_ACTIVITY_DEFINITIONS = [
   {
     kind: "Initiative",
     description: "Umbrella body of work that can contain projects or programs.",
@@ -32,10 +51,6 @@ export const ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS = [
     description: "Dated public activity.",
   },
   {
-    kind: "Campaign",
-    description: "Fundraising or awareness push.",
-  },
-  {
     kind: "Service",
     description: "Charitable service delivered to people or communities.",
   },
@@ -44,10 +59,23 @@ export const ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS = [
     description:
       "Smaller operating activity connected to a program or project.",
   },
-  {
-    kind: "Fundraiser",
-    description: "Donation-oriented campaign, event, or appeal.",
-  },
+] satisfies Array<
+  OrganizationObjectDefinition<
+    Exclude<OrganizationActivityKind, "Web resource">
+  >
+>
+
+const ORGANIZATION_CAMPAIGN_DEFINITION = {
+  kind: "Campaign",
+  description: "Fundraising or awareness push.",
+} satisfies OrganizationObjectDefinition<"Campaign">
+
+const ORGANIZATION_FUNDRAISER_DEFINITION = {
+  kind: "Fundraiser",
+  description: "Donation-oriented campaign, event, or appeal.",
+} satisfies OrganizationObjectDefinition<"Fundraiser">
+
+const ORGANIZATION_GRANT_WORKFLOW_DEFINITIONS = [
   {
     kind: "Grant application",
     description: "External funding request in preparation or review.",
@@ -56,13 +84,39 @@ export const ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS = [
     kind: "Re-grant request",
     description: "Money movement request after fiscal sponsorship approval.",
   },
-] satisfies Array<{
-  kind: OrganizationPrimaryObjectKind
-  description: string
-}>
+] satisfies Array<
+  OrganizationObjectDefinition<
+    Extract<
+      OrganizationPrimaryObjectKind,
+      "Grant application" | "Re-grant request"
+    >
+  >
+>
+
+const ORGANIZATION_WEB_RESOURCE_DEFINITION = {
+  kind: "Web resource",
+  description: "Online resource, guide, toolkit, or public information hub.",
+} satisfies OrganizationObjectDefinition<"Web resource">
+
+export const ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS = [
+  ...ORGANIZATION_SHARED_ACTIVITY_DEFINITIONS.slice(0, 4),
+  ORGANIZATION_CAMPAIGN_DEFINITION,
+  ...ORGANIZATION_SHARED_ACTIVITY_DEFINITIONS.slice(4),
+  ORGANIZATION_FUNDRAISER_DEFINITION,
+  ...ORGANIZATION_GRANT_WORKFLOW_DEFINITIONS,
+  ORGANIZATION_WEB_RESOURCE_DEFINITION,
+] satisfies Array<OrganizationObjectDefinition<OrganizationPrimaryObjectKind>>
+
+export const ORGANIZATION_ACTIVITY_KIND_DEFINITIONS = [
+  ...ORGANIZATION_SHARED_ACTIVITY_DEFINITIONS,
+  ORGANIZATION_WEB_RESOURCE_DEFINITION,
+] satisfies Array<OrganizationObjectDefinition<OrganizationActivityKind>>
 
 export const ORGANIZATION_PRIMARY_OBJECT_SUMMARY =
-  "Initiatives, projects, programs, events, campaigns, services, activities, fundraisers, grant applications, and re-grant requests."
+  "Initiatives, projects, programs, events, campaigns, services, activities, fundraisers, grant applications, re-grant requests, and web resources."
+
+export const ORGANIZATION_ACTIVITY_KIND_SUMMARY =
+  "initiatives, projects, programs, events, services, activities, and web resources."
 
 export function isOrganizationPrimaryObjectKind(
   value: unknown
@@ -76,4 +130,16 @@ export function resolveOrganizationPrimaryObjectKind(
   value: unknown
 ): OrganizationPrimaryObjectKind {
   return isOrganizationPrimaryObjectKind(value) ? value : "Program"
+}
+
+export function isOrganizationActivityKind(
+  value: unknown
+): value is OrganizationActivityKind {
+  return ORGANIZATION_ACTIVITY_KINDS.includes(value as OrganizationActivityKind)
+}
+
+export function resolveOrganizationActivityKind(
+  value: unknown
+): OrganizationActivityKind {
+  return isOrganizationActivityKind(value) ? value : "Program"
 }

--- a/tests/acceptance/fiscal-sponsorship-workbench-contract.test.ts
+++ b/tests/acceptance/fiscal-sponsorship-workbench-contract.test.ts
@@ -203,6 +203,16 @@ describe("fiscal sponsorship workbench contract", () => {
     expect(memberProjectDetailTabs).toContain(
       "MemberWorkspaceProjectFiscalWorkbench"
     )
+    expect(memberProjectDetailTabs).not.toContain("showFiscalSponsorshipTab")
+    expect(memberProjectDetailTabs).not.toContain(
+      '<TabsTrigger value="activity-feed">Activity Feed</TabsTrigger>'
+    )
+    expect(memberProjectDetailTabs).not.toContain(
+      '<TabsContent value="activity-feed">'
+    )
+    expect(memberProjectDetailTabs).toContain(
+      "resolvedFiscalSponsorshipWorkbench"
+    )
     expect(memberProjectDetailTabs.indexOf("<TimelineGantt")).toBeLessThan(
       memberProjectDetailTabs.indexOf("{fiscalSponsorshipWorkbench}")
     )

--- a/tests/acceptance/member-workspace-project-detail-page.test.ts
+++ b/tests/acceptance/member-workspace-project-detail-page.test.ts
@@ -220,6 +220,11 @@ describe("MemberWorkspaceProjectDetailPage", () => {
     expect(overviewTypographySource).toContain("[&_li]:whitespace-pre-wrap")
     expect(overviewTypographySource).toContain("ProseMirror")
     expect(overviewTypographySource).toContain("min-h-[32rem]")
+    expect(overviewTypographySource).toContain("max-h-[32rem]")
+    expect(overviewTypographySource).toContain("overflow-y-auto")
+    expect(overviewTypographySource).not.toContain(
+      "min-h-[32rem] bg-transparent px-4 py-3"
+    )
     expect(overviewDocumentSource).toContain("ReactMarkdown")
     expect(overviewDocumentSource).toContain("remarkGfm")
     expect(overviewDocumentSource).toContain(
@@ -258,7 +263,9 @@ describe("MemberWorkspaceProjectDetailPage", () => {
       'data-slot="member-workspace-project-overview-document"'
     )
     expect(markup).toContain("ProseMirror")
-    expect(markup).toContain("min-h-[32rem]")
+    expect(markup).toContain("max-h-[32rem]")
+    expect(markup).toContain("overflow-y-auto")
+    expect(markup).not.toContain("min-h-[32rem]")
     expect(markup).toContain("whitespace-pre-wrap")
     expect(markup).toContain("<h2>Saved overview</h2>")
     expect(markup).toContain("<p>This should show in view mode.</p>")
@@ -660,7 +667,16 @@ describe("MemberWorkspaceProjectDetailPage", () => {
       "requireMemberWorkspacePageAccess"
     )
     expect(organizationDetailRouteSource).toContain('from "@/lib/admin/auth"')
-    expect(organizationDetailRouteSource).toContain("await requireAdmin()")
+    expect(organizationDetailRouteSource).toContain(
+      "const admin = await requireAdmin()"
+    )
+    expect(organizationDetailRouteSource).toContain(
+      "loadPlatformAdminOrganizationProjectDetailPage({"
+    )
+    expect(organizationDetailRouteSource).toContain("userId: admin.userId")
+    expect(organizationDetailRouteSource).not.toContain(
+      "loadMemberWorkspaceProjectDetailPage(id)"
+    )
     expect(organizationDetailRouteSource).not.toContain(
       "requireMemberWorkspacePageAccess"
     )

--- a/tests/acceptance/member-workspace-projects-page.test.ts
+++ b/tests/acceptance/member-workspace-projects-page.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("MemberWorkspaceProjectsPage", () => {
+  it("does not render the top-level Add Organization header button", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/member-workspace/components/projects/member-workspace-projects-page.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(source).not.toContain("Add Organization")
+    expect(source).not.toContain('from "@/components/ui/button"')
+    expect(source).not.toContain('@phosphor-icons/react/dist/ssr"')
+    expect(source).toContain("onCreateProject={")
+    expect(source).toContain("onAddProject={")
+  })
+})

--- a/tests/acceptance/member-workspace-resource-review-removed.test.ts
+++ b/tests/acceptance/member-workspace-resource-review-removed.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+function readRepoFile(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8")
+}
+
+describe("member workspace resource review removal", () => {
+  it("does not expose a manual Resources review tab in organization detail", () => {
+    const detailTabsSource = readRepoFile(
+      "src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx"
+    )
+    const detailPageSource = readRepoFile(
+      "src/features/member-workspace/components/projects/member-workspace-project-detail-page.tsx"
+    )
+    const organizationRouteSource = readRepoFile(
+      "src/app/(dashboard)/organizations/[id]/page.tsx"
+    )
+    const memberWorkspaceIndexSource = readRepoFile(
+      "src/features/member-workspace/index.ts"
+    )
+    const projectDetailActionsSource = readRepoFile(
+      "src/features/member-workspace/project-detail-actions.ts"
+    )
+    const projectDetailLoaderSource = readRepoFile(
+      "src/features/member-workspace/server/project-detail-loader.ts"
+    )
+
+    for (const source of [
+      detailTabsSource,
+      detailPageSource,
+      organizationRouteSource,
+      memberWorkspaceIndexSource,
+      projectDetailActionsSource,
+      projectDetailLoaderSource,
+    ]) {
+      expect(source).not.toContain("createPublicResourceEvidenceAction")
+      expect(source).not.toContain("reviewPublicResourceEvidenceAction")
+      expect(source).not.toContain("MemberWorkspaceProjectResourceEvidenceTab")
+      expect(source).not.toContain("publicResourceEvidence")
+      expect(source).not.toContain("organization_public_resource_evidence")
+    }
+
+    expect(detailTabsSource).not.toContain(
+      '<TabsTrigger value="resources">Resources</TabsTrigger>'
+    )
+    expect(detailTabsSource).not.toContain('<TabsContent value="resources">')
+    expect(detailTabsSource).not.toContain(
+      '<TabsTrigger value="activity-feed">Activity Feed</TabsTrigger>'
+    )
+    expect(detailTabsSource).not.toContain(
+      '<TabsContent value="activity-feed">'
+    )
+  })
+})

--- a/tests/acceptance/organization-primary-objects.test.ts
+++ b/tests/acceptance/organization-primary-objects.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest"
 import { serializePayload } from "@/components/programs/program-wizard/helpers"
 import { defaultProgramWizardForm } from "@/components/programs/program-wizard/schema"
 import {
+  ORGANIZATION_ACTIVITY_KINDS,
   ORGANIZATION_PRIMARY_OBJECT_KINDS,
+  resolveOrganizationActivityKind,
   resolveOrganizationPrimaryObjectKind,
 } from "@/lib/organization/primary-objects"
 import { resolveProgramCardChips } from "@/lib/programs/display"
@@ -21,32 +23,84 @@ describe("organization primary objects", () => {
       "Fundraiser",
       "Grant application",
       "Re-grant request",
+      "Web resource",
     ])
   })
 
-  it("serializes the selected object kind into saved wizard data and chips", () => {
+  it("keeps grant workflow records readable without making them activity wizard choices", () => {
+    expect(ORGANIZATION_ACTIVITY_KINDS).toEqual([
+      "Initiative",
+      "Project",
+      "Program",
+      "Event",
+      "Service",
+      "Activity",
+      "Web resource",
+    ])
+    expect(ORGANIZATION_ACTIVITY_KINDS).not.toContain("Campaign")
+    expect(ORGANIZATION_ACTIVITY_KINDS).not.toContain("Fundraiser")
+    expect(ORGANIZATION_ACTIVITY_KINDS).not.toContain("Grant application")
+    expect(ORGANIZATION_ACTIVITY_KINDS).not.toContain("Re-grant request")
+    expect(resolveOrganizationActivityKind("Campaign")).toBe("Program")
+    expect(resolveOrganizationActivityKind("Fundraiser")).toBe("Program")
+    expect(resolveOrganizationActivityKind("Re-grant request")).toBe("Program")
+    expect(resolveOrganizationPrimaryObjectKind("Campaign")).toBe("Campaign")
+    expect(resolveOrganizationPrimaryObjectKind("Fundraiser")).toBe(
+      "Fundraiser"
+    )
+    expect(resolveOrganizationPrimaryObjectKind("Re-grant request")).toBe(
+      "Re-grant request"
+    )
+    expect(
+      resolveProgramCardChips({
+        duration_label: "Open request cycle",
+        features: ["Re-grant request"],
+        wizard_snapshot: { objectKind: "Re-grant request" },
+      })
+    ).toEqual(
+      expect.arrayContaining(["Re-grant request", "Open request cycle"])
+    )
+    expect(
+      resolveProgramCardChips({
+        duration_label: "Seasonal campaign",
+        features: ["Fundraiser"],
+        wizard_snapshot: { objectKind: "Fundraiser" },
+      })
+    ).toEqual(expect.arrayContaining(["Fundraiser", "Seasonal campaign"]))
+    expect(
+      resolveProgramCardChips({
+        duration_label: "Awareness sprint",
+        features: ["Campaign"],
+        wizard_snapshot: { objectKind: "Campaign" },
+      })
+    ).toEqual(expect.arrayContaining(["Campaign", "Awareness sprint"]))
+  })
+
+  it("serializes the selected activity kind into saved wizard data and chips", () => {
     const payload = serializePayload({
       ...defaultProgramWizardForm,
-      objectKind: "Re-grant request",
-      title: "Emergency Mutual Aid Re-grant",
-      oneSentence: "A re-grant request for direct community relief.",
-      servesWho: "Families affected by emergency displacement.",
-      participantReceive1: "Direct relief payments",
-      participantReceive2: "Referral support",
-      participantReceive3: "Follow-up documentation",
-      successOutcome1: "Funds reach eligible families within 14 days.",
+      objectKind: "Web resource",
+      title: "Neighborhood Resource Hub",
+      oneSentence: "A public web resource for neighborhood support services.",
+      servesWho: "Families looking for local support resources.",
+      participantReceive1: "Resource directory",
+      participantReceive2: "Plain-language guides",
+      participantReceive3: "Referral information",
+      successOutcome1: "Residents can find the right support in one place.",
       startMonth: "2026-04",
-      durationLabel: "Open request cycle",
-      frequency: "Monthly review",
+      durationLabel: "Always available",
+      frequency: "Updated monthly",
+      locationMode: "online",
+      locationUrl: "https://resources.example.org/hub",
       budgetRows: [
         {
-          category: "Direct re-grants",
-          description: "Relief payments to eligible families.",
-          costType: "Variable",
-          unit: "Grant",
-          units: "10",
-          costPerUnit: "1000.00",
-          totalCost: "10000.00",
+          category: "Content + maintenance",
+          description: "Resource hub updates and moderation.",
+          costType: "Fixed",
+          unit: "Month",
+          units: "12",
+          costPerUnit: "250.00",
+          totalCost: "3000.00",
         },
       ],
       costStaffUsd: 0,
@@ -55,17 +109,20 @@ describe("organization primary objects", () => {
       costOtherUsd: 0,
     })
 
-    expect(payload.wizardSnapshot?.objectKind).toBe("Re-grant request")
-    expect(payload.features).toContain("Re-grant request")
+    expect(payload.wizardSnapshot?.objectKind).toBe("Web resource")
+    expect(payload.wizardSnapshot?.locationUrl).toBe(
+      "https://resources.example.org/hub"
+    )
+    expect(payload.locationType).toBe("online")
+    expect(payload.locationUrl).toBe("https://resources.example.org/hub")
+    expect(payload.features).toContain("Web resource")
     expect(
       resolveProgramCardChips({
         duration_label: payload.duration,
         features: payload.features,
         wizard_snapshot: payload.wizardSnapshot,
       })
-    ).toEqual(
-      expect.arrayContaining(["Re-grant request", "Open request cycle"])
-    )
+    ).toEqual(expect.arrayContaining(["Web resource", "Always available"]))
   })
 
   it("falls back to Program for unknown legacy object values", () => {

--- a/tests/acceptance/program-wizard-activity-flow.test.ts
+++ b/tests/acceptance/program-wizard-activity-flow.test.ts
@@ -66,6 +66,9 @@ describe("program wizard activity flow", () => {
     const wizardTypesSource = readSource(
       "src/components/programs/program-wizard/types.ts"
     )
+    const scheduleLocationSource = readSource(
+      "src/components/programs/program-wizard/components/step-schedule-location.tsx"
+    )
     const dialogSource = readSource("src/components/ui/dialog.tsx")
 
     expect(constantsSource).toContain('title: "Choose activity type"')
@@ -79,9 +82,12 @@ describe("program wizard activity flow", () => {
     expect(stepContentSource).toContain("<StepBasicInfo")
     expect(activityKindSource).toContain("What are you adding?")
     expect(activityKindSource).toContain(
-      "ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS"
+      "ORGANIZATION_ACTIVITY_KIND_DEFINITIONS"
     )
     expect(activityKindSource).toContain("hover:border-primary/50")
+    expect(activityKindSource).not.toContain(
+      "ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS"
+    )
 
     expect(typeFormatSource).not.toContain("Object type")
     expect(typeFormatSource).not.toContain("ORGANIZATION_PRIMARY_OBJECT_KINDS")
@@ -94,9 +100,52 @@ describe("program wizard activity flow", () => {
     expect(wizardSource).toContain("px-3 py-3 sm:px-5 sm:py-5")
     expect(wizardSource).toContain("Activity builder")
     expect(wizardSource).not.toContain("Primary object created")
+    expect(scheduleLocationSource).toContain('id="locationUrl"')
+    expect(scheduleLocationSource).toContain(
+      'form.objectKind === "Web resource"'
+    )
+    expect(scheduleLocationSource).toContain("Resource URL")
     expect(wizardTypesSource).toContain("portalContainer?: HTMLElement | null")
     expect(dialogSource).toContain("portalContainer")
     expect(dialogSource).toContain("container={portalContainer}")
+  })
+
+  it("keeps grant workflows, campaigns, and fundraisers out of the activity picker while adding web resources", () => {
+    const primaryObjectsSource = readSource(
+      "src/lib/organization/primary-objects.ts"
+    )
+    const activityKindSource = readSource(
+      "src/components/programs/program-wizard/components/step-activity-kind.tsx"
+    )
+    const dashboardCardSource = readSource(
+      "src/components/organization/program-builder-dashboard-card.tsx"
+    )
+
+    expect(primaryObjectsSource).toContain('"Web resource"')
+    expect(primaryObjectsSource).toContain(
+      "ORGANIZATION_ACTIVITY_KIND_DEFINITIONS"
+    )
+    expect(primaryObjectsSource).toContain(
+      'description: "Online resource, guide, toolkit, or public information hub."'
+    )
+    expect(activityKindSource).toContain(
+      "ORGANIZATION_ACTIVITY_KIND_DEFINITIONS"
+    )
+    expect(dashboardCardSource).toContain(
+      "ORGANIZATION_ACTIVITY_KIND_DEFINITIONS.map"
+    )
+    expect(dashboardCardSource).toContain("ORGANIZATION_ACTIVITY_KIND_SUMMARY")
+    expect(activityKindSource).not.toContain("Grant application")
+    expect(activityKindSource).not.toContain("Re-grant request")
+    expect(activityKindSource).not.toContain("Campaign")
+    expect(activityKindSource).not.toContain("Fundraiser")
+    expect(dashboardCardSource).not.toContain(
+      "ORGANIZATION_PRIMARY_OBJECT_DEFINITIONS.map"
+    )
+    expect(dashboardCardSource).not.toContain("Grant application")
+    expect(dashboardCardSource).not.toContain("Re-grant request")
+    expect(dashboardCardSource).not.toContain("Campaign")
+    expect(dashboardCardSource).not.toContain("Fundraiser")
   })
 
   it("can render the activity dialog inside the workspace canvas frame", () => {
@@ -130,6 +179,7 @@ describe("program wizard activity flow", () => {
     expect(requiredFieldsForStep(2)).toEqual(["programType", "coreFormat"])
     expect(stepForField("objectKind")).toBe(0)
     expect(stepForField("title")).toBe(1)
+    expect(stepForField("locationUrl")).toBe(5)
     expect(stepForField("budgetUsd")).toBe(6)
   })
 
@@ -142,5 +192,23 @@ describe("program wizard activity flow", () => {
     expect(errors.startMonth).toBe("Choose a start month.")
     expect(errors.startMonth).not.toContain("Invalid string")
     expect(errors.startMonth).not.toContain("must match pattern")
+  })
+
+  it("requires a usable URL for web resource activities", () => {
+    const missingUrlErrors = parseErrors({
+      ...validScheduleForm,
+      objectKind: "Web resource",
+      locationMode: "online",
+      locationUrl: "",
+    })
+    const invalidUrlErrors = parseErrors({
+      ...validScheduleForm,
+      objectKind: "Web resource",
+      locationMode: "online",
+      locationUrl: "not a url",
+    })
+
+    expect(missingUrlErrors.locationUrl).toBe("Add the resource URL.")
+    expect(invalidUrlErrors.locationUrl).toBe("Enter a valid URL.")
   })
 })

--- a/tests/acceptance/program-wizard-header.test.ts
+++ b/tests/acceptance/program-wizard-header.test.ts
@@ -42,6 +42,10 @@ describe("program wizard header", () => {
     expect(headerSource).toContain("px-3 py-3 sm:px-5 sm:py-4 md:px-6")
     expect(headerSource).toContain("flex min-w-0 flex-1 flex-col gap-1")
     expect(headerSource).toContain("text-pretty")
+    expect(headerSource).toContain(
+      'className="text-muted-foreground text-[11px] font-medium tabular-nums"'
+    )
+    expect(headerSource).not.toContain('variant="outline"')
     expect(footerSource).toContain(
       "flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between"
     )

--- a/tests/acceptance/program-wizard-media.test.ts
+++ b/tests/acceptance/program-wizard-media.test.ts
@@ -61,6 +61,7 @@ describe("program wizard media fields", () => {
       id: "program-1",
       title: "Future Builders Mentorship Lab",
       description: "Fallback description",
+      location_url: "https://example.com/program-location",
       image_url: "https://example.com/program-profile.jpg",
       wizard_snapshot: {
         oneSentence: "Career-connected mentorship for transition-age youth.",
@@ -70,6 +71,7 @@ describe("program wizard media fields", () => {
 
     expect(form.bannerImageUrl).toBe("https://example.com/program-banner.jpg")
     expect(form.imageUrl).toBe("https://example.com/program-profile.jpg")
+    expect(form.locationUrl).toBe("https://example.com/program-location")
     expect(
       resolveProgramBannerImageUrl({
         wizard_snapshot: {

--- a/tests/acceptance/workspace-board-card-frame.test.ts
+++ b/tests/acceptance/workspace-board-card-frame.test.ts
@@ -181,7 +181,7 @@ describe("workspace board card frame", () => {
     expect(markup).toContain('data-slot="card-title"')
     expect(markup).toContain('data-slot="card-content"')
     expect(markup).not.toContain('data-slot="card-footer"')
-    expect(markup).toContain("px-3 pb-0")
+    expect(markup).toContain("px-3 pb-3")
     expect(markup).toContain("relative flex flex-col gap-2 px-3 pt-0 pb-3")
     expect(markup).toContain("flex w-full justify-between gap-2")
     expect(markup).toContain(
@@ -216,7 +216,7 @@ describe("workspace board card frame", () => {
       'contentSurface === "plain" ? "px-3" : "px-0"'
     )
     expect(shellSource).toContain(
-      'contentSurface === "plain" || footer ? "pb-0" : "pb-3"'
+      'contentSurface === "plain" || !footer ? "pb-3" : "pb-0"'
     )
     expect(shellSource).toContain('? "mx-0 p-0"')
     expect(shellSource).toContain("<CardContent")

--- a/tests/acceptance/workspace-fiscal-sponsorship-card.test.ts
+++ b/tests/acceptance/workspace-fiscal-sponsorship-card.test.ts
@@ -11,6 +11,7 @@ import {
   WORKSPACE_EDGE_SPECS,
 } from "@/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-copy"
 import type { OrgProgram } from "@/components/organization/org-profile-card/types"
+import { analyzeFiscalSponsorshipActivityEligibility } from "@/features/fiscal-sponsorship"
 import { buildSelectedProgramPrefill } from "@/features/fiscal-sponsorship/components/fiscal-sponsorship-workspace-card-summary"
 
 const ROOT = process.cwd()
@@ -47,9 +48,16 @@ describe("workspace fiscal sponsorship card", () => {
     const organizationSupport = readSource(
       "src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-organization-support.tsx"
     )
+    const activityAction = readSource(
+      "src/features/fiscal-sponsorship/components/fiscal-sponsorship-activity-action.tsx"
+    )
 
     expect(featureIndex).toContain("FiscalSponsorshipWorkspaceCardSummary")
     expect(featureIndex).toContain("FiscalSponsorshipMark")
+    expect(featureIndex).toContain("FiscalSponsorshipActivityAction")
+    expect(featureIndex).toContain(
+      "analyzeFiscalSponsorshipActivityEligibility"
+    )
     expect(featureIndex).toContain("FiscalSponsorshipWorkflowDrawer")
     expect(featureIndex).toContain(
       "FiscalSponsorshipRequiredDocumentsUploadPanel"
@@ -86,6 +94,84 @@ describe("workspace fiscal sponsorship card", () => {
     expect(organizationSupport).not.toContain(
       "@/features/fiscal-sponsorship/components"
     )
+    expect(activityAction).toContain("FiscalSponsorshipMark")
+    expect(activityAction).toContain("CheckCircle2Icon")
+    expect(activityAction).toContain("Signals only. Coach House reviews.")
+    expect(activityAction).toContain(
+      '<div className="flex min-w-0 items-center gap-1.5">'
+    )
+    expect(activityAction).toContain(
+      'className="h-6 shrink-0 rounded-full px-2 text-[10px]"'
+    )
+    expect(activityAction).not.toContain(
+      'className="h-6 shrink-0 gap-1 rounded-full px-2 text-[10px]"'
+    )
+    const tooltipTitleGroupIndex = activityAction.indexOf(
+      '<div className="flex min-w-0 items-center gap-1.5">'
+    )
+    const tooltipTitleMarkIndex = activityAction.indexOf(
+      'className="size-4 rounded-[0.35rem] text-[7px]"',
+      tooltipTitleGroupIndex
+    )
+    const tooltipSubtitleIndex = activityAction.indexOf(
+      "Signals only. Coach House reviews."
+    )
+    const tooltipBadgeIndex = activityAction.indexOf(
+      "<Badge",
+      tooltipTitleGroupIndex
+    )
+
+    expect(tooltipTitleGroupIndex).toBeGreaterThan(-1)
+    expect(tooltipTitleMarkIndex).toBeGreaterThan(tooltipTitleGroupIndex)
+    expect(tooltipTitleMarkIndex).toBeLessThan(tooltipSubtitleIndex)
+    expect(tooltipSubtitleIndex).toBeLessThan(tooltipBadgeIndex)
+    expect(activityAction).toContain("Request review")
+    expect(activityAction).toContain("Update info")
+    expect(activityAction).toContain("onUpdateInfo()")
+    expect(activityAction).not.toContain("String(criterion.met)")
+  })
+
+  it("analyzes activity eligibility before lighting up the fiscal action", () => {
+    const ready = analyzeFiscalSponsorshipActivityEligibility({
+      activity: {
+        title: "Youth Stewardship Fellows",
+        description: "Youth leaders coordinate neighborhood food access.",
+        addressCity: "Chicago",
+        addressState: "IL",
+        addressCountry: "United States",
+        focusArea: "Training & Capacity Building",
+        goalCents: 1400000,
+        publicBenefit: "Residents get reliable resource-night support.",
+      },
+      organization: {
+        ein: "12-3456789",
+        mission: "Support neighborhood leaders.",
+        addressStreet: "100 Main St",
+        addressCity: "Chicago",
+        addressState: "IL",
+        addressPostal: "60601",
+        addressCountry: "United States",
+      },
+      prefill: null,
+    })
+    const missing = analyzeFiscalSponsorshipActivityEligibility({
+      activity: { title: "Untitled" },
+      organization: null,
+      prefill: null,
+    })
+
+    expect(ready.eligible).toBe(true)
+    expect(ready.state).toBe("lit")
+    expect(ready.completedCount).toBe(5)
+    expect(ready.criteria.map((criterion) => criterion.label)).toEqual([
+      "Impact narrative",
+      "U.S. operations",
+      "Funding use",
+      "Mission fit signal",
+      "Tax ID + mailing",
+    ])
+    expect(missing.eligible).toBe(false)
+    expect(missing.state).toBe("inactive")
   })
 
   it("opens the handbook-aligned user sidebar flow with saved application data when available", () => {
@@ -499,22 +585,31 @@ describe("workspace fiscal sponsorship card", () => {
     expect(programsRenderer).toContain("fiscalSponsorshipActionLabel")
     expect(programsRenderer).toContain("Close fiscal sponsorship tile")
     expect(programsRenderer).toContain("Open fiscal sponsorship tile")
+    expect(programsRenderer).toContain("Fiscal sponsorship review readiness")
+    expect(programsRenderer).toContain("FiscalSponsorshipActivityAction")
+    expect(programsRenderer).toContain(
+      "analyzeFiscalSponsorshipActivityEligibility"
+    )
+    expect(programsRenderer).toContain("selectedProgramIndex")
+    expect(programsRenderer).toContain("carouselApi.selectedScrollSnap()")
+    expect(programsRenderer).toContain("fiscalSponsorshipEligibility")
     expect(programsRenderer).toContain("!programsPreviewOnly")
+    expect(programsRenderer).toContain("active={fiscalSponsorshipCardVisible}")
+    expect(programsRenderer).toContain("eligibility={eligibility}")
     expect(programsRenderer).toContain(
-      "aria-label={fiscalSponsorshipActionLabel}"
+      "onUpdateInfo={onUpdateFiscalSponsorshipInfo}"
+    )
+    expect(programsRenderer).toContain("buildWorkspaceProgramEditorHref")
+    expect(programsRenderer).toContain(
+      "router.push(updateFiscalSponsorshipInfoHref)"
     )
     expect(programsRenderer).toContain(
-      "aria-pressed={fiscalSponsorshipCardVisible}"
-    )
-    expect(programsRenderer).toContain(
-      'className="h-8 w-8 rounded-lg p-0 hover:bg-transparent"'
-    )
-    expect(programsRenderer).toContain(
-      'FiscalSponsorshipMark className="size-8 rounded-lg text-xs"'
+      "eligibility: fiscalSponsorshipEligibility"
     )
     expect(programsRenderer).not.toContain(
       'FiscalSponsorshipMark className="size-5 rounded-lg text-[10px]"'
     )
+    expect(programsRenderer).not.toContain("FiscalSponsorshipMark")
     expect(programsRenderer).toContain(
       'data.onOpenCard?.("fiscal-sponsorship")'
     )

--- a/tests/acceptance/workspace-node-frame-contract.test.ts
+++ b/tests/acceptance/workspace-node-frame-contract.test.ts
@@ -58,7 +58,9 @@ describe("workspace node frame contract", () => {
       "src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-card-shell.tsx"
     )
 
-    expect(nodeCardShell).toContain('footer ? "pb-0" : "pb-3"')
+    expect(nodeCardShell).toContain(
+      'contentSurface === "plain" || !footer ? "pb-3" : "pb-0"'
+    )
     expect(nodeCardShell).not.toContain('"px-0 pb-0"')
   })
 })

--- a/tests/acceptance/workspace-organization-overview-programs.test.ts
+++ b/tests/acceptance/workspace-organization-overview-programs.test.ts
@@ -101,7 +101,7 @@ describe("workspace organization overview programs", () => {
     expect(isWorkspaceProgramsPreviewOnlyStep(null)).toBe(false)
   })
 
-  it("uses Activity copy for empty primary-object surfaces", () => {
+  it("uses Activity copy and keeps owner activity cards editable", () => {
     const workspaceProgramsCard = readSource(
       "src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-programs-card.tsx"
     )
@@ -117,17 +117,23 @@ describe("workspace organization overview programs", () => {
     const dashboardCard = readSource(
       "src/components/organization/program-builder-dashboard-card.tsx"
     )
-    const programsTab = readSource(
-      "src/components/organization/org-profile-card/tabs/programs-tab.tsx"
+    const myOrganizationPage = readSource(
+      "src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx"
+    )
+    const programActions = readSource("src/actions/programs.ts")
+    const programMediaRoute = readSource(
+      "src/app/api/account/program-media/route.ts"
     )
 
     expect(workspaceProgramsCard).toContain('title="No activity to display"')
+    expect(workspaceProgramsCard).toContain('"Untitled activity"')
     expect(workspaceProgramsCard).toContain("Open activity")
     expect(workspaceProgramsCard).toContain(
       'className="bg-background min-h-[148px] rounded-xl px-4 py-6 shadow-none"'
     )
+    expect(workspaceProgramsCard).not.toContain('<div className="pb-3">')
     expect(workspaceProgramsCard).not.toContain(
-      'className="bg-background mb-3 min-h-[148px] rounded-xl px-4 py-6"'
+      "bg-background mb-3 min-h-[148px]"
     )
     expect(workspaceProgramsCard).toContain(
       'className="flex min-h-0 flex-col gap-3 pb-0"'
@@ -175,15 +181,27 @@ describe("workspace organization overview programs", () => {
       "onCarouselApiChange={setCarouselApi}"
     )
     expect(workspaceProgramsRenderer).toContain(
+      "headerAction={renderProgramsHeaderAction({"
+    )
+    expect(workspaceProgramsRenderer).toContain(
       "footer={renderProgramsFooterAction({"
     )
     expect(workspaceProgramsRenderer).toContain(
+      'shellInsetClassName="px-3 pt-3 pb-3"'
+    )
+    expect(workspaceProgramsRenderer).not.toContain(
       'shellInsetClassName="px-3 pt-3 pb-0"'
     )
     expect(workspaceProgramsRenderer).toContain(
-      'footerClassName="px-3 pt-2 pb-3"'
+      'footerClassName="justify-center px-3 pt-2 pb-3"'
     )
-    expect(workspaceProgramsRenderer).toContain('className="ml-auto"')
+    expect(workspaceProgramsRenderer).toContain(
+      'className="h-8 rounded-md px-3"'
+    )
+    expect(workspaceProgramsRenderer).not.toContain('className="ml-auto"')
+    expect(workspaceProgramsRenderer).toContain(
+      "onProgramsCreateOpenChange(true)"
+    )
     expect(shellSource).toContain("gap-3 px-3 py-3")
     expect(shellSource).not.toContain("gap-3 px-4 pt-4 pb-1")
     expect(workspaceProgramsCard).not.toContain("<CarouselPrevious")
@@ -207,14 +225,29 @@ describe("workspace organization overview programs", () => {
       'cardId === "organization-overview" ||\n    cardId === "programs" ||'
     )
     expect(dashboardCard).toContain('title="No activity to display"')
+    expect(dashboardCard).toContain("Add activity")
+    expect(dashboardCard).toContain("Start activity builder")
+    expect(dashboardCard).toContain("Supported activity types")
+    expect(dashboardCard).toContain("Untitled activity")
     expect(dashboardCard).toContain("Open full view")
     expect(dashboardCard).not.toContain("ArrowUpRightIcon")
-    expect(programsTab).toContain('title="No activity yet"')
-    expect(programsTab).toContain('title="No activity to display"')
+    expect(myOrganizationPage).toContain(
+      "const canEdit = isAdmin || canEditOrganization(role)"
+    )
+    expect(programActions).toContain("resolveProfileAudience")
+    expect(programActions).toContain(
+      "const canEdit = profileAudience.isAdmin || canEditOrganization(role)"
+    )
+    expect(programMediaRoute).toContain("resolveProfileAudience")
+    expect(programMediaRoute).toContain(
+      "if (!profileAudience.isAdmin && !canEditOrganization(role))"
+    )
     expect(workspaceProgramsCard).not.toContain(
       'title="No primary objects to display"'
     )
     expect(dashboardCard).not.toContain('title="No primary objects to display"')
-    expect(programsTab).not.toContain('title="No primary objects yet"')
+    expect(dashboardCard).not.toContain("New object")
+    expect(dashboardCard).not.toContain("Start object builder")
+    expect(dashboardCard).not.toContain("Supported primary object types")
   })
 })


### PR DESCRIPTION
## Release notes

- Improves workspace Activity surfaces, including editable activity cards, carousel controls, drawer-scoped program wizard rendering, and Activity copy.
- Adds fiscal sponsorship readiness evaluation for selected activities and exposes a focused review/update action from the workspace programs card.
- Tightens program creation/media permissions so platform admins can manage program writes when appropriate.
- Routes platform-admin organization project detail through the platform-admin loader so fiscal document actions stay admin-scoped.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec eslint <staged ts/tsx files>`
- `git diff --check --cached`
- `./node_modules/.bin/vitest tests/acceptance/program-wizard-activity-flow.test.ts tests/acceptance/program-wizard-header.test.ts tests/acceptance/program-wizard-media.test.ts tests/acceptance/workspace-fiscal-sponsorship-card.test.ts tests/acceptance/workspace-board-card-frame.test.ts tests/acceptance/workspace-organization-overview-programs.test.ts tests/acceptance/member-workspace-project-detail-page.test.ts tests/acceptance/member-workspace-projects-page.test.ts tests/acceptance/member-workspace-resource-review-removed.test.ts tests/acceptance/organization-primary-objects.test.ts tests/acceptance/fiscal-sponsorship-workbench-contract.test.ts --run` (`11 files`, `62 passed`)
- `./node_modules/.bin/vitest tests/acceptance/workspace-node-frame-contract.test.ts --run` (`1 file`, `3 passed`)
- `pnpm build`
- Pre-push `pnpm check:prepush`, including snapshots and full acceptance (`279 passed`, `1 skipped`)

## Risk

- Authenticated workspace-only behavioral surface; no public `/find` resource-map changes and no database migrations.
- Main risk is workspace activity/fiscal sponsorship UI behavior around project/program records and platform-admin access.

## Rollback

- Revert this PR. No schema or environment rollback required.
