### PR TITLE
[STEP S94] Reconcile linked migration history

### DIFF
--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -211,3 +211,9 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Confirmed migration `20260716150000_add_native_fiscal_sponsorship_signing.sql` is already applied to linked Supabase. Hardened unauthenticated preview and document requests to return `401`.
 - Passed lint and structural guardrails, full acceptance (`295 files passed`, `1 skipped`; `1,426 tests passed`, `1 skipped`), linked RLS, production build, isolated visuals (`14/14`), performance budgets, and route probes (`sign 200`, unauthenticated preview/document 401).
 - No application deployment was performed in this checkpoint. The next step is PR S93, merge, Vercel production verification, and an authenticated signing smoke test.
+
+2026-07-17 15:17 EDT - reconciled linked Supabase migration history for release.
+
+- Added six immutable migration files already applied to linked Supabase but absent from `main`: four resource-map migrations, the admin organization-operations schema, and the refreshed coach workstream defaults.
+- Kept the pending admin-operations hardening migration out of this ledger-only step. It must run only after the application synchronization fix is deployed.
+- Verified the linked migration dry run reports no pending or missing remote versions, and the linked RLS suite passed. No database write was performed in this checkpoint.

--- a/supabase/migrations/20260714193000_resource_map_enrichment_runs.sql
+++ b/supabase/migrations/20260714193000_resource_map_enrichment_runs.sql
@@ -1,0 +1,79 @@
+create table if not exists public.resource_map_enrichment_runs (
+  id uuid primary key default gen_random_uuid(),
+  import_record_id uuid not null references public.resource_map_import_records(id) on delete cascade,
+  pass_type text not null,
+  pass_number integer not null default 1,
+  status text not null default 'queued',
+  provider text,
+  model text,
+  prompt_version text not null,
+  input_sha256 text not null,
+  output_sha256 text,
+  source_urls text[] not null default '{}'::text[],
+  structured_result jsonb not null default '{}'::jsonb,
+  issues jsonb not null default '[]'::jsonb,
+  error_message text,
+  attempt_count integer not null default 0,
+  actor_id uuid references public.profiles(id) on delete set null,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint resource_map_enrichment_runs_pass_type_check
+    check (pass_type in ('source_collection', 'draft', 'verification', 'human_review')),
+  constraint resource_map_enrichment_runs_pass_number_check
+    check (pass_number > 0),
+  constraint resource_map_enrichment_runs_status_check
+    check (status in ('queued', 'running', 'completed', 'failed', 'needs_review', 'rejected')),
+  constraint resource_map_enrichment_runs_input_sha256_check
+    check (input_sha256 ~ '^[a-f0-9]{64}$'),
+  constraint resource_map_enrichment_runs_output_sha256_check
+    check (output_sha256 is null or output_sha256 ~ '^[a-f0-9]{64}$'),
+  constraint resource_map_enrichment_runs_source_urls_check
+    check (array_position(source_urls, null) is null),
+  constraint resource_map_enrichment_runs_structured_result_check
+    check (jsonb_typeof(structured_result) = 'object'),
+  constraint resource_map_enrichment_runs_issues_check
+    check (jsonb_typeof(issues) = 'array'),
+  constraint resource_map_enrichment_runs_attempt_count_check
+    check (attempt_count >= 0),
+  constraint resource_map_enrichment_runs_completion_check
+    check (
+      (status in ('completed', 'failed', 'needs_review', 'rejected') and completed_at is not null)
+      or (status in ('queued', 'running') and completed_at is null)
+    ),
+  constraint resource_map_enrichment_runs_idempotency_key
+    unique (import_record_id, pass_type, pass_number, input_sha256, prompt_version)
+);
+
+create index if not exists resource_map_enrichment_runs_import_idx
+  on public.resource_map_enrichment_runs (import_record_id, pass_number, created_at desc);
+create index if not exists resource_map_enrichment_runs_queue_idx
+  on public.resource_map_enrichment_runs (status, created_at, id)
+  where status in ('queued', 'running', 'needs_review');
+create index if not exists resource_map_enrichment_runs_source_urls_idx
+  on public.resource_map_enrichment_runs using gin (source_urls);
+
+drop trigger if exists set_updated_at_resource_map_enrichment_runs
+  on public.resource_map_enrichment_runs;
+create trigger set_updated_at_resource_map_enrichment_runs
+  before update on public.resource_map_enrichment_runs
+  for each row execute procedure public.handle_updated_at();
+
+alter table public.resource_map_enrichment_runs enable row level security;
+alter table public.resource_map_enrichment_runs force row level security;
+
+drop policy if exists "resource_map_enrichment_runs_admin_manage"
+  on public.resource_map_enrichment_runs;
+create policy "resource_map_enrichment_runs_admin_manage"
+  on public.resource_map_enrichment_runs
+  for all
+  to authenticated
+  using ((select public.is_admin()))
+  with check ((select public.is_admin()));
+
+revoke all on table public.resource_map_enrichment_runs from public, anon, authenticated;
+grant select, insert, update, delete on table public.resource_map_enrichment_runs to authenticated;
+
+comment on table public.resource_map_enrichment_runs is
+  'Private, admin-only ledger for source collection, AI drafting, independent verification, and human review passes.';

--- a/supabase/migrations/20260714194500_resource_map_public_items_pagination.sql
+++ b/supabase/migrations/20260714194500_resource_map_public_items_pagination.sql
@@ -1,0 +1,117 @@
+alter function public.get_resource_map_public_items(
+  text,
+  text[],
+  integer,
+  double precision,
+  double precision,
+  double precision
+) set search_path = '';
+
+create or replace function public.get_resource_map_public_items_page(
+  p_query text default null,
+  p_category_keys text[] default null,
+  p_limit integer default 500,
+  p_offset integer default 0,
+  p_latitude double precision default null,
+  p_longitude double precision default null,
+  p_radius_miles double precision default null
+)
+returns setof public.resource_map_public_items
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select *
+  from public.resource_map_public_items item
+  where (
+    nullif(btrim(coalesce(p_query, '')), '') is null
+    or (
+      item.title || ' ' ||
+      coalesce(item.subtitle, '') || ' ' ||
+      coalesce(item.description, '') || ' ' ||
+      item.organization_name || ' ' ||
+      coalesce(item.city, '') || ' ' ||
+      coalesce(item.state, '') || ' ' ||
+      array_to_string(item.resource_categories, ' ')
+    ) ilike '%' || btrim(coalesce(p_query, '')) || '%'
+  )
+  and (
+    p_category_keys is null
+    or cardinality(p_category_keys) = 0
+    or item.resource_categories && p_category_keys
+  )
+  and (
+    p_latitude is null
+    or p_longitude is null
+    or p_radius_miles is null
+    or exists (
+      select 1
+      from public.resource_map_locations location
+      where location.organization_id = item.organization_id
+        and (location.service_id = item.service_id or location.service_id is null)
+        and location.geo_point is not null
+        and extensions.st_dwithin(
+          location.geo_point,
+          extensions.st_setsrid(
+            extensions.st_makepoint(p_longitude, p_latitude),
+            4326
+          )::extensions.geography,
+          least(greatest(p_radius_miles, 0), 500) * 1609.344
+        )
+    )
+  )
+  order by
+    case
+      when p_latitude is not null
+        and p_longitude is not null
+        and p_radius_miles is not null
+        and item.latitude is not null
+        and item.longitude is not null
+      then extensions.st_distance(
+        extensions.st_setsrid(
+          extensions.st_makepoint(item.longitude, item.latitude),
+          4326
+        )::extensions.geography,
+        extensions.st_setsrid(
+          extensions.st_makepoint(p_longitude, p_latitude),
+          4326
+        )::extensions.geography
+      )
+      else null
+    end asc nulls last,
+    coalesce(item.last_verified_at, item.last_updated_at) desc nulls last,
+    item.title asc,
+    item.item_id asc
+  limit least(greatest(coalesce(p_limit, 500), 1), 1000)
+  offset least(greatest(coalesce(p_offset, 0), 0), 1000000);
+$$;
+
+comment on function public.get_resource_map_public_items_page(
+  text,
+  text[],
+  integer,
+  integer,
+  double precision,
+  double precision,
+  double precision
+) is 'Paginated public resource-map reader over the sanitized projection.';
+
+revoke all on function public.get_resource_map_public_items_page(
+  text,
+  text[],
+  integer,
+  integer,
+  double precision,
+  double precision,
+  double precision
+) from public;
+grant execute on function public.get_resource_map_public_items_page(
+  text,
+  text[],
+  integer,
+  integer,
+  double precision,
+  double precision,
+  double precision
+) to anon, authenticated;

--- a/supabase/migrations/20260714201500_resource_map_atomic_promotion.sql
+++ b/supabase/migrations/20260714201500_resource_map_atomic_promotion.sql
@@ -1,0 +1,795 @@
+set check_function_bodies = on;
+set search_path = public;
+
+create index if not exists resource_map_import_record_matches_accepted_idx
+  on public.resource_map_import_record_matches (import_record_id, match_score desc, id)
+  where match_status = 'accepted';
+
+create or replace function public.lock_resource_map_match_acceptance()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_promotion_status text;
+begin
+  if new.match_status <> 'accepted' then
+    return new;
+  end if;
+
+  select import_record.promotion_status
+  into v_promotion_status
+  from public.resource_map_import_records import_record
+  where import_record.id = new.import_record_id
+  for update;
+
+  if v_promotion_status is null then
+    raise exception 'Resource map import record % does not exist.', new.import_record_id
+      using errcode = 'P0002';
+  end if;
+
+  if v_promotion_status = 'promoted' then
+    raise exception 'Resource map import record % is already promoted and cannot accept a duplicate match.', new.import_record_id
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists lock_resource_map_match_acceptance
+  on public.resource_map_import_record_matches;
+create trigger lock_resource_map_match_acceptance
+  before insert or update of match_status, import_record_id
+  on public.resource_map_import_record_matches
+  for each row execute function public.lock_resource_map_match_acceptance();
+
+create or replace function public.promote_resource_map_import_record(
+  p_import_record_id uuid,
+  p_payload jsonb,
+  p_publish boolean default false
+)
+returns table (
+  promotion_result text,
+  organization_id uuid,
+  service_id uuid,
+  location_id uuid,
+  contact_count integer,
+  link_count integer,
+  field_evidence_count integer
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_record public.resource_map_import_records%rowtype;
+  v_match public.resource_map_import_record_matches%rowtype;
+  v_organization jsonb;
+  v_service jsonb;
+  v_location jsonb;
+  v_contact jsonb;
+  v_link jsonb;
+  v_contact_id uuid;
+  v_link_id uuid;
+  v_first_contact_id uuid;
+  v_first_link_id uuid;
+  v_contact_ids jsonb := '{}'::jsonb;
+  v_link_ids jsonb := '{}'::jsonb;
+  v_organization_id uuid;
+  v_service_id uuid;
+  v_location_id uuid;
+  v_contact_count integer := 0;
+  v_link_count integer := 0;
+  v_evidence_count integer := 0;
+  v_visibility text;
+  v_review_status text;
+  v_approved_at timestamptz;
+  v_source_comparison_count integer;
+begin
+  if coalesce(auth.role(), '') <> 'service_role' then
+    if not (select public.is_admin()) then
+      raise exception 'Only administrators may promote resource map records.'
+        using errcode = '42501';
+    end if;
+  end if;
+
+  if p_import_record_id is null then
+    raise exception 'p_import_record_id is required.' using errcode = '22004';
+  end if;
+
+  if p_payload is null or jsonb_typeof(p_payload) <> 'object' then
+    raise exception 'p_payload must be a JSON object.' using errcode = '22023';
+  end if;
+
+  select import_record.*
+  into v_record
+  from public.resource_map_import_records import_record
+  where import_record.id = p_import_record_id
+  for update;
+
+  if not found then
+    raise exception 'Resource map import record % does not exist.', p_import_record_id
+      using errcode = 'P0002';
+  end if;
+
+  if v_record.review_status <> 'approved' then
+    raise exception 'Resource map import record % must be approved before promotion.', p_import_record_id
+      using errcode = '23514';
+  end if;
+
+  if v_record.reviewed_by is null or v_record.reviewed_at is null then
+    raise exception 'Resource map import record % requires an identified reviewer and review timestamp.', p_import_record_id
+      using errcode = '23514';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles reviewer
+    where reviewer.id = v_record.reviewed_by
+  ) then
+    raise exception 'Resource map import record % reviewer does not exist.', p_import_record_id
+      using errcode = '23503';
+  end if;
+
+  if v_record.promotion_status = 'promoted' then
+    if v_record.promoted_organization_id is null or v_record.promoted_service_id is null then
+      raise exception 'Resource map import record % has an invalid promoted state.', p_import_record_id
+        using errcode = '23514';
+    end if;
+
+    return query select
+      'already_promoted'::text,
+      v_record.promoted_organization_id,
+      v_record.promoted_service_id,
+      (
+        select location.id
+        from public.resource_map_locations location
+        where location.service_id = v_record.promoted_service_id
+          and location.is_primary
+        order by location.created_at, location.id
+        limit 1
+      ),
+      (
+        select count(*)::integer
+        from public.resource_map_contacts contact
+        where contact.service_id = v_record.promoted_service_id
+      ),
+      (
+        select count(*)::integer
+        from public.resource_map_links link
+        where link.service_id = v_record.promoted_service_id
+      ),
+      (
+        select count(*)::integer
+        from public.resource_map_field_evidence evidence
+        where evidence.import_record_id = p_import_record_id
+          and evidence.service_id = v_record.promoted_service_id
+      );
+    return;
+  end if;
+
+  select match.*
+  into v_match
+  from public.resource_map_import_record_matches match
+  where match.import_record_id = p_import_record_id
+    and match.match_status = 'accepted'
+  order by match.match_score desc nulls last, match.id
+  limit 1;
+
+  if found then
+    if v_record.promotion_status <> 'blocked' then
+      update public.resource_map_import_records
+      set promotion_status = 'blocked'
+      where id = p_import_record_id;
+
+      insert into public.resource_map_curation_events (
+        action,
+        organization_id,
+        service_id,
+        import_record_id,
+        actor_id,
+        reason,
+        before_state,
+        after_state
+      ) values (
+        'merge_duplicate',
+        v_match.organization_id,
+        v_match.service_id,
+        p_import_record_id,
+        v_record.reviewed_by,
+        'Blocked promotion because an accepted duplicate match exists. Merge manually before creating a new canonical resource.',
+        to_jsonb(v_record),
+        jsonb_build_object(
+          'blocked', true,
+          'acceptedMatch', jsonb_build_object(
+            'id', v_match.id,
+            'organizationId', v_match.organization_id,
+            'serviceId', v_match.service_id,
+            'matchKind', v_match.match_kind,
+            'matchScore', v_match.match_score
+          )
+        )
+      );
+    end if;
+
+    return query select
+      'blocked'::text,
+      v_match.organization_id,
+      v_match.service_id,
+      null::uuid,
+      0,
+      0,
+      0;
+    return;
+  end if;
+
+  if v_record.promotion_status not in ('not_promoted', 'ready') then
+    raise exception 'Resource map import record % has unsupported promotion status %.', p_import_record_id, v_record.promotion_status
+      using errcode = '23514';
+  end if;
+
+  if v_record.last_verified_at is null then
+    raise exception 'Resource map import record % requires a real verification timestamp.', p_import_record_id
+      using errcode = '23514';
+  end if;
+
+  v_source_comparison_count := coalesce(
+    nullif(v_record.extracted_fields #>> '{enrichment,sourceComparisonCount}', '')::integer,
+    nullif(v_record.extracted_fields #>> '{enrichment,source_comparison_count}', '')::integer,
+    0
+  );
+
+  if coalesce(v_record.extracted_fields #>> '{enrichment,verification,status}', '') <> 'approved'
+    or v_source_comparison_count < 2
+    or jsonb_array_length(coalesce(
+      v_record.extracted_fields #> '{enrichment,verification,unsupportedClaims}',
+      v_record.extracted_fields #> '{enrichment,verification,unsupported_claims}',
+      '[]'::jsonb
+    )) > 0
+    or jsonb_array_length(coalesce(
+      v_record.extracted_fields #> '{enrichment,verification,contradictions}',
+      '[]'::jsonb
+    )) > 0
+  then
+    raise exception 'Resource map import record % requires approved source-verified enrichment with two comparison passes and no unresolved claims.', p_import_record_id
+      using errcode = '23514';
+  end if;
+
+  if not exists (
+    select 1
+    from public.resource_map_enrichment_runs enrichment_run
+    where enrichment_run.import_record_id = p_import_record_id
+      and enrichment_run.pass_type = 'verification'
+      and enrichment_run.status = 'completed'
+      and coalesce(
+        enrichment_run.structured_result ->> 'status',
+        enrichment_run.structured_result #>> '{verification,status}'
+      ) = 'approved'
+      and jsonb_array_length(coalesce(enrichment_run.issues, '[]'::jsonb)) = 0
+      and jsonb_array_length(coalesce(
+        enrichment_run.structured_result -> 'unsupportedClaims',
+        enrichment_run.structured_result #> '{verification,unsupportedClaims}',
+        enrichment_run.structured_result -> 'unsupported_claims',
+        enrichment_run.structured_result #> '{verification,unsupported_claims}',
+        '[]'::jsonb
+      )) = 0
+      and jsonb_array_length(coalesce(
+        enrichment_run.structured_result -> 'contradictions',
+        enrichment_run.structured_result #> '{verification,contradictions}',
+        '[]'::jsonb
+      )) = 0
+  ) then
+    raise exception 'Resource map import record % has no completed approved verification ledger entry.', p_import_record_id
+      using errcode = '23514';
+  end if;
+
+  v_organization := p_payload -> 'organization';
+  v_service := p_payload -> 'service';
+  v_location := p_payload -> 'location';
+
+  if jsonb_typeof(v_organization) <> 'object'
+    or nullif(btrim(v_organization ->> 'name'), '') is null
+  then
+    raise exception 'p_payload.organization.name is required.' using errcode = '22023';
+  end if;
+
+  if jsonb_typeof(v_service) <> 'object'
+    or nullif(btrim(v_service ->> 'title'), '') is null
+  then
+    raise exception 'p_payload.service.title is required.' using errcode = '22023';
+  end if;
+
+  if jsonb_typeof(coalesce(p_payload -> 'categoryKeys', '[]'::jsonb)) <> 'array'
+    or jsonb_array_length(coalesce(p_payload -> 'categoryKeys', '[]'::jsonb)) = 0
+  then
+    raise exception 'p_payload.categoryKeys must contain at least one category.' using errcode = '22023';
+  end if;
+
+  if jsonb_typeof(coalesce(p_payload -> 'contacts', '[]'::jsonb)) <> 'array'
+    or jsonb_typeof(coalesce(p_payload -> 'links', '[]'::jsonb)) <> 'array'
+  then
+    raise exception 'p_payload contacts and links must be arrays.' using errcode = '22023';
+  end if;
+
+  v_visibility := case when p_publish then 'published' else 'draft' end;
+  v_review_status := case when p_publish then 'approved' else 'pending_review' end;
+  v_approved_at := case when p_publish then v_record.reviewed_at else null end;
+
+  insert into public.resource_map_organizations (
+    source_id,
+    source_record_id,
+    name,
+    tagline,
+    description,
+    website_url,
+    donate_url,
+    logo_url,
+    favicon_url,
+    domain,
+    email,
+    phone,
+    normalized_email,
+    normalized_phone,
+    visibility,
+    review_status,
+    approved_by,
+    approved_at,
+    data_quality_score,
+    source_url,
+    source_snapshot,
+    last_seen_at,
+    last_verified_at,
+    created_by,
+    updated_by
+  ) values (
+    v_record.source_id,
+    v_record.source_record_id,
+    btrim(v_organization ->> 'name'),
+    nullif(btrim(v_organization ->> 'tagline'), ''),
+    nullif(btrim(v_organization ->> 'description'), ''),
+    nullif(btrim(v_organization ->> 'website_url'), ''),
+    nullif(btrim(v_organization ->> 'donate_url'), ''),
+    nullif(btrim(v_organization ->> 'logo_url'), ''),
+    nullif(btrim(v_organization ->> 'favicon_url'), ''),
+    nullif(btrim(v_organization ->> 'domain'), ''),
+    nullif(btrim(v_organization ->> 'email'), ''),
+    nullif(btrim(v_organization ->> 'phone'), ''),
+    nullif(btrim(v_organization ->> 'normalized_email'), ''),
+    nullif(btrim(v_organization ->> 'normalized_phone'), ''),
+    v_visibility,
+    v_review_status,
+    case when p_publish then v_record.reviewed_by else null end,
+    v_approved_at,
+    v_record.confidence_score,
+    coalesce(nullif(btrim(v_record.source_url), ''), nullif(btrim(v_organization ->> 'source_url'), '')),
+    v_record.raw_snapshot,
+    v_record.last_seen_at,
+    v_record.last_verified_at,
+    v_record.reviewed_by,
+    v_record.reviewed_by
+  ) returning id into v_organization_id;
+
+  insert into public.resource_map_services (
+    organization_id,
+    source_id,
+    source_record_id,
+    title,
+    subtitle,
+    description,
+    service_kind,
+    delivery_modes,
+    eligibility,
+    cost,
+    who_it_helps,
+    intake_url,
+    appointment_info,
+    documents_needed,
+    accessibility_notes,
+    urgent_availability,
+    languages,
+    hours,
+    timezone,
+    appointment_required,
+    availability_status,
+    availability_notes,
+    temporary_closed_until,
+    coverage_area,
+    visibility,
+    review_status,
+    approved_by,
+    approved_at,
+    source_url,
+    source_snapshot,
+    last_seen_at,
+    last_verified_at,
+    created_by,
+    updated_by
+  ) values (
+    v_organization_id,
+    v_record.source_id,
+    v_record.source_record_id,
+    btrim(v_service ->> 'title'),
+    nullif(btrim(v_service ->> 'subtitle'), ''),
+    nullif(btrim(v_service ->> 'description'), ''),
+    coalesce(nullif(btrim(v_service ->> 'service_kind'), ''), 'service'),
+    coalesce(array(
+      select jsonb_array_elements_text(coalesce(v_service -> 'delivery_modes', '[]'::jsonb))
+    ), '{}'::text[]),
+    nullif(btrim(v_service ->> 'eligibility'), ''),
+    nullif(btrim(v_service ->> 'cost'), ''),
+    nullif(btrim(v_service ->> 'who_it_helps'), ''),
+    nullif(btrim(v_service ->> 'intake_url'), ''),
+    nullif(btrim(v_service ->> 'appointment_info'), ''),
+    coalesce(array(
+      select jsonb_array_elements_text(coalesce(v_service -> 'documents_needed', '[]'::jsonb))
+    ), '{}'::text[]),
+    nullif(btrim(v_service ->> 'accessibility_notes'), ''),
+    nullif(btrim(v_service ->> 'urgent_availability'), ''),
+    coalesce(array(
+      select jsonb_array_elements_text(coalesce(v_service -> 'languages', '[]'::jsonb))
+    ), '{}'::text[]),
+    coalesce(v_service -> 'hours', '{}'::jsonb),
+    nullif(btrim(v_service ->> 'timezone'), ''),
+    coalesce((v_service ->> 'appointment_required')::boolean, false),
+    coalesce(nullif(btrim(v_service ->> 'availability_status'), ''), 'unknown'),
+    nullif(btrim(v_service ->> 'availability_notes'), ''),
+    nullif(v_service ->> 'temporary_closed_until', '')::timestamptz,
+    coalesce(array(
+      select jsonb_array_elements_text(coalesce(v_service -> 'coverage_area', '[]'::jsonb))
+    ), '{}'::text[]),
+    v_visibility,
+    v_review_status,
+    case when p_publish then v_record.reviewed_by else null end,
+    v_approved_at,
+    coalesce(nullif(btrim(v_record.source_url), ''), nullif(btrim(v_service ->> 'source_url'), '')),
+    v_record.raw_snapshot,
+    v_record.last_seen_at,
+    v_record.last_verified_at,
+    v_record.reviewed_by,
+    v_record.reviewed_by
+  ) returning id into v_service_id;
+
+  with requested_categories as (
+    select
+      category.category_key,
+      min(category.position) as position
+    from jsonb_array_elements_text(p_payload -> 'categoryKeys')
+      with ordinality as category(category_key, position)
+    group by category.category_key
+  )
+  insert into public.resource_map_service_categories (
+    service_id,
+    category_key,
+    is_primary,
+    confidence,
+    source_id
+  )
+  select
+    v_service_id,
+    category.category_key,
+    row_number() over (order by category.position) = 1,
+    coalesce(
+      nullif(p_payload #>> array['categoryConfidenceByKey', category.category_key], '')::numeric,
+      v_record.confidence_score
+    ),
+    v_record.source_id
+  from requested_categories category
+  order by category.position;
+
+  if v_location is not null and jsonb_typeof(v_location) <> 'null' then
+    if jsonb_typeof(v_location) <> 'object' then
+      raise exception 'p_payload.location must be an object or null.' using errcode = '22023';
+    end if;
+
+    insert into public.resource_map_locations (
+      organization_id,
+      service_id,
+      label,
+      location_type,
+      address_line1,
+      address_line2,
+      city,
+      state,
+      county,
+      postal_code,
+      country,
+      latitude,
+      longitude,
+      geocoding_accuracy,
+      service_radius_miles,
+      location_url,
+      service_area,
+      accessibility_notes,
+      hours,
+      timezone,
+      appointment_required,
+      availability_status,
+      availability_notes,
+      temporary_closed_until,
+      is_primary
+    ) values (
+      v_organization_id,
+      v_service_id,
+      nullif(btrim(v_location ->> 'label'), ''),
+      coalesce(nullif(btrim(v_location ->> 'location_type'), ''), 'physical'),
+      nullif(btrim(v_location ->> 'address_line1'), ''),
+      nullif(btrim(v_location ->> 'address_line2'), ''),
+      nullif(btrim(v_location ->> 'city'), ''),
+      nullif(btrim(v_location ->> 'state'), ''),
+      nullif(btrim(v_location ->> 'county'), ''),
+      nullif(btrim(v_location ->> 'postal_code'), ''),
+      coalesce(nullif(btrim(v_location ->> 'country'), ''), 'United States'),
+      nullif(v_location ->> 'latitude', '')::double precision,
+      nullif(v_location ->> 'longitude', '')::double precision,
+      coalesce(nullif(btrim(v_location ->> 'geocoding_accuracy'), ''), 'unknown'),
+      nullif(v_location ->> 'service_radius_miles', '')::numeric,
+      nullif(btrim(v_location ->> 'location_url'), ''),
+      coalesce(array(
+        select jsonb_array_elements_text(coalesce(v_location -> 'service_area', '[]'::jsonb))
+      ), '{}'::text[]),
+      nullif(btrim(v_location ->> 'accessibility_notes'), ''),
+      coalesce(v_location -> 'hours', '{}'::jsonb),
+      nullif(btrim(v_location ->> 'timezone'), ''),
+      coalesce((v_location ->> 'appointment_required')::boolean, false),
+      coalesce(nullif(btrim(v_location ->> 'availability_status'), ''), 'unknown'),
+      nullif(btrim(v_location ->> 'availability_notes'), ''),
+      nullif(v_location ->> 'temporary_closed_until', '')::timestamptz,
+      true
+    ) returning id into v_location_id;
+  end if;
+
+  for v_contact in
+    select value
+    from jsonb_array_elements(coalesce(p_payload -> 'contacts', '[]'::jsonb))
+  loop
+    if jsonb_typeof(v_contact) <> 'object' then
+      raise exception 'Every p_payload.contacts entry must be an object.' using errcode = '22023';
+    end if;
+
+    insert into public.resource_map_contacts (
+      organization_id,
+      service_id,
+      contact_type,
+      label,
+      value,
+      url,
+      is_primary,
+      is_public,
+      metadata
+    ) values (
+      v_organization_id,
+      v_service_id,
+      btrim(v_contact ->> 'contact_type'),
+      nullif(btrim(v_contact ->> 'label'), ''),
+      btrim(v_contact ->> 'value'),
+      nullif(btrim(v_contact ->> 'url'), ''),
+      coalesce((v_contact ->> 'is_primary')::boolean, false),
+      false,
+      coalesce(v_contact -> 'metadata', '{}'::jsonb)
+    ) returning id into v_contact_id;
+
+    v_contact_count := v_contact_count + 1;
+    v_first_contact_id := coalesce(v_first_contact_id, v_contact_id);
+    if not v_contact_ids ? (v_contact ->> 'contact_type') then
+      v_contact_ids := v_contact_ids || jsonb_build_object(v_contact ->> 'contact_type', v_contact_id);
+    end if;
+  end loop;
+
+  for v_link in
+    select value
+    from jsonb_array_elements(coalesce(p_payload -> 'links', '[]'::jsonb))
+  loop
+    if jsonb_typeof(v_link) <> 'object' then
+      raise exception 'Every p_payload.links entry must be an object.' using errcode = '22023';
+    end if;
+
+    insert into public.resource_map_links (
+      organization_id,
+      service_id,
+      link_type,
+      label,
+      url,
+      domain,
+      is_primary,
+      is_public,
+      metadata
+    ) values (
+      v_organization_id,
+      v_service_id,
+      btrim(v_link ->> 'link_type'),
+      nullif(btrim(v_link ->> 'label'), ''),
+      btrim(v_link ->> 'url'),
+      nullif(btrim(v_link ->> 'domain'), ''),
+      coalesce((v_link ->> 'is_primary')::boolean, false),
+      false,
+      coalesce(v_link -> 'metadata', '{}'::jsonb)
+    ) returning id into v_link_id;
+
+    v_link_count := v_link_count + 1;
+    v_first_link_id := coalesce(v_first_link_id, v_link_id);
+    if not v_link_ids ? (v_link ->> 'link_type') then
+      v_link_ids := v_link_ids || jsonb_build_object(v_link ->> 'link_type', v_link_id);
+    end if;
+  end loop;
+
+  with staged as (
+    select
+      evidence.*,
+      regexp_replace(
+        regexp_replace(evidence.field_path, '\[[0-9]+\]', '', 'g'),
+        '^.*\.',
+        ''
+      ) as field_name
+    from public.resource_map_field_evidence evidence
+    where evidence.import_record_id = p_import_record_id
+      and evidence.organization_id is null
+      and evidence.service_id is null
+      and evidence.location_id is null
+      and evidence.contact_id is null
+      and evidence.link_id is null
+  ), targets as (
+    select
+      staged.*,
+      case
+        when staged.field_name in (
+          'address', 'addressLine1', 'address_line1', 'addressLine2', 'address_line2',
+          'streetAddress', 'fullAddress', 'city', 'state', 'county', 'postalCode',
+          'postal_code', 'country', 'latitude', 'lat', 'longitude', 'lng', 'lon',
+          'locationUrl', 'location_url', 'locationType', 'location_type',
+          'locationLabel', 'location_label', 'serviceArea', 'service_area',
+          'serviceRadiusMiles', 'service_radius_miles', 'geocodingAccuracy',
+          'geocoding_accuracy', 'hours', 'timezone', 'timeZone',
+          'appointmentRequired', 'appointment_required', 'availabilityStatus',
+          'availability_status', 'availabilityNotes', 'availability_notes',
+          'temporaryClosedUntil', 'temporary_closed_until'
+        ) or staged.field_path like 'extractedFields.location.%'
+          or staged.field_path like 'extractedFields.locations.%'
+        then v_location_id
+        else null
+      end as canonical_location_id,
+      case
+        when staged.field_name in ('contacts', 'public_contacts', 'phone', 'phoneNumber', 'email', 'contactEmail')
+          or staged.field_path like 'extractedFields.contacts.%'
+          or staged.field_path like 'contacts.%'
+        then case staged.field_name
+          when 'phone' then coalesce(nullif(v_contact_ids ->> 'phone', '')::uuid, v_first_contact_id)
+          when 'phoneNumber' then coalesce(nullif(v_contact_ids ->> 'phone', '')::uuid, v_first_contact_id)
+          when 'email' then coalesce(nullif(v_contact_ids ->> 'email', '')::uuid, v_first_contact_id)
+          when 'contactEmail' then coalesce(nullif(v_contact_ids ->> 'email', '')::uuid, v_first_contact_id)
+          else v_first_contact_id
+        end
+        else null
+      end as canonical_contact_id,
+      case
+        when staged.field_name in (
+          'links', 'public_links', 'website', 'websiteUrl', 'website_url',
+          'donateUrl', 'donate_url', 'intakeUrl', 'intake_url', 'logoUrl',
+          'logo_url', 'sourceUrl', 'source_url'
+        ) or staged.field_path like 'extractedFields.links.%'
+          or staged.field_path like 'links.%'
+        then case staged.field_name
+          when 'website' then coalesce(nullif(v_link_ids ->> 'website', '')::uuid, v_first_link_id)
+          when 'websiteUrl' then coalesce(nullif(v_link_ids ->> 'website', '')::uuid, v_first_link_id)
+          when 'website_url' then coalesce(nullif(v_link_ids ->> 'website', '')::uuid, v_first_link_id)
+          when 'donateUrl' then coalesce(nullif(v_link_ids ->> 'donate', '')::uuid, v_first_link_id)
+          when 'donate_url' then coalesce(nullif(v_link_ids ->> 'donate', '')::uuid, v_first_link_id)
+          when 'intakeUrl' then coalesce(nullif(v_link_ids ->> 'intake', '')::uuid, v_first_link_id)
+          when 'intake_url' then coalesce(nullif(v_link_ids ->> 'intake', '')::uuid, v_first_link_id)
+          when 'logoUrl' then coalesce(nullif(v_link_ids ->> 'logo', '')::uuid, v_first_link_id)
+          when 'logo_url' then coalesce(nullif(v_link_ids ->> 'logo', '')::uuid, v_first_link_id)
+          when 'sourceUrl' then coalesce(nullif(v_link_ids ->> 'source', '')::uuid, v_first_link_id)
+          when 'source_url' then coalesce(nullif(v_link_ids ->> 'source', '')::uuid, v_first_link_id)
+          else v_first_link_id
+        end
+        else null
+      end as canonical_link_id
+    from staged
+  )
+  insert into public.resource_map_field_evidence (
+    import_record_id,
+    source_id,
+    organization_id,
+    service_id,
+    location_id,
+    contact_id,
+    link_id,
+    field_path,
+    field_value,
+    confidence_score,
+    source_url,
+    evidence_type,
+    derived_from,
+    transformation,
+    evidence_metadata,
+    observed_at
+  )
+  select
+    targets.import_record_id,
+    coalesce(targets.source_id, v_record.source_id),
+    v_organization_id,
+    v_service_id,
+    targets.canonical_location_id,
+    targets.canonical_contact_id,
+    targets.canonical_link_id,
+    targets.field_path,
+    targets.field_value,
+    targets.confidence_score,
+    targets.source_url,
+    targets.evidence_type,
+    targets.derived_from,
+    targets.transformation,
+    targets.evidence_metadata || jsonb_build_object(
+      'promotedFromImport', true,
+      'originalEvidenceId', targets.id,
+      'canonicalTarget', jsonb_build_object(
+        'organizationId', v_organization_id,
+        'serviceId', v_service_id,
+        'locationId', targets.canonical_location_id,
+        'contactId', targets.canonical_contact_id,
+        'linkId', targets.canonical_link_id
+      )
+    ),
+    targets.observed_at
+  from targets;
+
+  get diagnostics v_evidence_count = row_count;
+
+  update public.resource_map_import_records
+  set
+    promotion_status = 'promoted',
+    promoted_organization_id = v_organization_id,
+    promoted_service_id = v_service_id
+  where id = p_import_record_id;
+
+  insert into public.resource_map_curation_events (
+    action,
+    organization_id,
+    service_id,
+    import_record_id,
+    actor_id,
+    reason,
+    before_state,
+    after_state
+  ) values (
+    'promote',
+    v_organization_id,
+    v_service_id,
+    p_import_record_id,
+    v_record.reviewed_by,
+    case
+      when p_publish then 'Promoted approved import as published canonical resource.'
+      else 'Promoted approved import as draft canonical resource.'
+    end,
+    to_jsonb(v_record),
+    jsonb_build_object(
+      'organizationId', v_organization_id,
+      'serviceId', v_service_id,
+      'locationId', v_location_id,
+      'categoryKeys', p_payload -> 'categoryKeys',
+      'privateContactCount', v_contact_count,
+      'privateLinkCount', v_link_count,
+      'fieldEvidencePromotedCount', v_evidence_count,
+      'visibility', v_visibility,
+      'lastVerifiedAt', v_record.last_verified_at
+    )
+  );
+
+  return query select
+    'promoted'::text,
+    v_organization_id,
+    v_service_id,
+    v_location_id,
+    v_contact_count,
+    v_link_count,
+    v_evidence_count;
+end;
+$$;
+
+comment on function public.promote_resource_map_import_record(uuid, jsonb, boolean) is
+  'Atomically promotes one approved, source-verified resource-map import record or blocks an accepted duplicate match.';
+
+revoke all on function public.lock_resource_map_match_acceptance() from public, anon, authenticated;
+revoke all on function public.promote_resource_map_import_record(uuid, jsonb, boolean) from public, anon, authenticated;
+grant execute on function public.promote_resource_map_import_record(uuid, jsonb, boolean) to authenticated, service_role;

--- a/supabase/migrations/20260715120000_resource_map_rename_reproductive_health.sql
+++ b/supabase/migrations/20260715120000_resource_map_rename_reproductive_health.sql
@@ -1,0 +1,7 @@
+-- Use concise public copy while preserving the stable taxonomy key.
+
+update public.resource_map_categories
+set
+  label = 'Reproductive Health',
+  updated_at = timezone('utc', now())
+where key = 'health_sexual_reproductive_health';

--- a/supabase/migrations/20260716203000_add_admin_organization_operations.sql
+++ b/supabase/migrations/20260716203000_add_admin_organization_operations.sql
@@ -1,0 +1,448 @@
+set check_function_bodies = off;
+set search_path = public;
+
+create table if not exists public.platform_admin_workstream_categories (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  color text not null default 'slate',
+  position integer not null default 0,
+  default_key text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint platform_admin_workstream_categories_owner_id_id_key
+    unique (owner_id, id),
+  constraint platform_admin_workstream_categories_name_check
+    check (char_length(trim(name)) between 1 and 48),
+  constraint platform_admin_workstream_categories_color_check
+    check (color in ('slate', 'blue', 'amber', 'emerald', 'rose', 'violet')),
+  constraint platform_admin_workstream_categories_position_check
+    check (position >= 0),
+  constraint platform_admin_workstream_categories_default_key_check
+    check (
+      default_key is null
+      or default_key in ('backlog', 'planned', 'active', 'completed', 'cancelled')
+    )
+);
+
+create unique index if not exists platform_admin_workstream_categories_owner_name_idx
+  on public.platform_admin_workstream_categories (owner_id, lower(trim(name)));
+
+create unique index if not exists platform_admin_workstream_categories_owner_default_idx
+  on public.platform_admin_workstream_categories (owner_id, default_key)
+  where default_key is not null;
+
+create index if not exists platform_admin_workstream_categories_owner_position_idx
+  on public.platform_admin_workstream_categories (owner_id, position, created_at);
+
+create table if not exists public.platform_admin_project_workstream_states (
+  owner_id uuid not null references public.profiles(id) on delete cascade,
+  project_id uuid not null references public.organization_projects(id) on delete cascade,
+  category_id uuid not null,
+  started_at timestamptz not null default timezone('utc', now()),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  primary key (owner_id, project_id),
+  constraint platform_admin_project_workstream_states_category_fkey
+    foreign key (owner_id, category_id)
+    references public.platform_admin_workstream_categories(owner_id, id)
+    on delete cascade
+);
+
+create index if not exists platform_admin_project_workstream_states_category_idx
+  on public.platform_admin_project_workstream_states (owner_id, category_id, updated_at desc);
+
+update public.organization_projects as project
+set task_count = (
+  select count(*)::integer
+  from public.organization_tasks as task
+  where task.project_id = project.id
+)
+where project.project_kind = 'organization_admin';
+
+create table if not exists public.organization_project_activity_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(user_id) on delete cascade,
+  project_id uuid references public.organization_projects(id) on delete cascade,
+  entity_type text not null,
+  entity_id uuid not null,
+  event_type text not null,
+  title text not null,
+  from_status text,
+  to_status text,
+  actor_id uuid references public.profiles(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  occurred_at timestamptz not null default timezone('utc', now()),
+  constraint organization_project_activity_events_entity_type_check
+    check (entity_type in ('project', 'task', 'program', 'fiscal_application')),
+  constraint organization_project_activity_events_event_type_check
+    check (event_type in ('created', 'status_changed', 'scheduled', 'published', 'completed', 'updated')),
+  constraint organization_project_activity_events_title_check
+    check (char_length(trim(title)) between 1 and 240),
+  constraint organization_project_activity_events_metadata_check
+    check (jsonb_typeof(metadata) = 'object')
+);
+
+create index if not exists organization_project_activity_events_project_idx
+  on public.organization_project_activity_events (project_id, occurred_at desc, id);
+
+create index if not exists organization_project_activity_events_org_idx
+  on public.organization_project_activity_events (org_id, occurred_at desc, id);
+
+create index if not exists organization_project_activity_events_entity_idx
+  on public.organization_project_activity_events (entity_type, entity_id, occurred_at, id);
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_trigger
+    where tgname = 'set_updated_at_platform_admin_workstream_categories'
+  ) then
+    create trigger set_updated_at_platform_admin_workstream_categories
+      before update on public.platform_admin_workstream_categories
+      for each row execute procedure public.handle_updated_at();
+  end if;
+
+  if not exists (
+    select 1 from pg_trigger
+    where tgname = 'set_updated_at_platform_admin_project_workstream_states'
+  ) then
+    create trigger set_updated_at_platform_admin_project_workstream_states
+      before update on public.platform_admin_project_workstream_states
+      for each row execute procedure public.handle_updated_at();
+  end if;
+end $$;
+
+create or replace function public.record_organization_project_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  event_kind text;
+begin
+  if tg_op = 'INSERT' then
+    event_kind := 'created';
+  elsif old.status is not distinct from new.status then
+    return new;
+  elsif new.status = 'completed' then
+    event_kind := 'completed';
+  else
+    event_kind := 'status_changed';
+  end if;
+
+  insert into public.organization_project_activity_events (
+    org_id,
+    project_id,
+    entity_type,
+    entity_id,
+    event_type,
+    title,
+    from_status,
+    to_status,
+    actor_id,
+    metadata,
+    occurred_at
+  ) values (
+    new.org_id,
+    new.id,
+    'project',
+    new.id,
+    event_kind,
+    new.name,
+    case when tg_op = 'UPDATE' then old.status else null end,
+    new.status,
+    coalesce(new.updated_by, new.created_by),
+    jsonb_build_object(
+      'start_date', new.start_date,
+      'end_date', new.end_date,
+      'project_kind', new.project_kind
+    ),
+    coalesce(new.updated_at, timezone('utc', now()))
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.record_organization_task_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  event_kind text;
+begin
+  if tg_op = 'INSERT' then
+    event_kind := 'created';
+  elsif old.status is not distinct from new.status then
+    return new;
+  elsif new.status = 'done' then
+    event_kind := 'completed';
+  else
+    event_kind := 'status_changed';
+  end if;
+
+  insert into public.organization_project_activity_events (
+    org_id,
+    project_id,
+    entity_type,
+    entity_id,
+    event_type,
+    title,
+    from_status,
+    to_status,
+    actor_id,
+    metadata,
+    occurred_at
+  ) values (
+    new.org_id,
+    new.project_id,
+    'task',
+    new.id,
+    event_kind,
+    new.title,
+    case when tg_op = 'UPDATE' then old.status else null end,
+    new.status,
+    coalesce(new.updated_by, new.created_by),
+    jsonb_build_object(
+      'start_date', new.start_date,
+      'end_date', new.end_date,
+      'workstream_name', new.workstream_name
+    ),
+    coalesce(new.updated_at, timezone('utc', now()))
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.record_organization_program_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  canonical_project_id uuid;
+  event_kind text;
+  previous_status text;
+  next_status text;
+begin
+  previous_status := case
+    when tg_op = 'UPDATE' then coalesce(nullif(trim(old.status_label), ''), case when old.is_public then 'Published' else 'Draft' end)
+    else null
+  end;
+  next_status := coalesce(nullif(trim(new.status_label), ''), case when new.is_public then 'Published' else 'Draft' end);
+
+  if tg_op = 'INSERT' then
+    event_kind := 'created';
+  elsif old.status_label is distinct from new.status_label then
+    event_kind := case when lower(next_status) in ('complete', 'completed', 'ended') then 'completed' else 'status_changed' end;
+  elsif old.is_public is distinct from new.is_public and new.is_public then
+    event_kind := 'published';
+  elsif old.start_date is distinct from new.start_date or old.end_date is distinct from new.end_date then
+    event_kind := 'scheduled';
+  else
+    return new;
+  end if;
+
+  select project.id
+  into canonical_project_id
+  from public.organization_projects as project
+  where project.canonical_org_id = new.user_id
+    and project.project_kind = 'organization_admin'
+  limit 1;
+
+  insert into public.organization_project_activity_events (
+    org_id,
+    project_id,
+    entity_type,
+    entity_id,
+    event_type,
+    title,
+    from_status,
+    to_status,
+    actor_id,
+    metadata,
+    occurred_at
+  ) values (
+    new.user_id,
+    canonical_project_id,
+    'program',
+    new.id,
+    event_kind,
+    new.title,
+    previous_status,
+    next_status,
+    new.user_id,
+    jsonb_build_object(
+      'start_date', new.start_date,
+      'end_date', new.end_date,
+      'is_public', new.is_public
+    ),
+    coalesce(new.updated_at, timezone('utc', now()))
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.record_fiscal_sponsorship_application_activity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  event_kind text;
+begin
+  if tg_op = 'INSERT' then
+    event_kind := 'created';
+  elsif old.status is not distinct from new.status
+    and old.submitted_at is not distinct from new.submitted_at then
+    return new;
+  elsif new.status = 'submitted'
+    or (old.submitted_at is null and new.submitted_at is not null) then
+    event_kind := 'published';
+  elsif new.status in ('countersigned', 'declined') then
+    event_kind := 'completed';
+  else
+    event_kind := 'status_changed';
+  end if;
+
+  insert into public.organization_project_activity_events (
+    org_id,
+    project_id,
+    entity_type,
+    entity_id,
+    event_type,
+    title,
+    from_status,
+    to_status,
+    actor_id,
+    metadata,
+    occurred_at
+  ) values (
+    new.org_id,
+    new.project_id,
+    'fiscal_application',
+    new.id,
+    event_kind,
+    coalesce(nullif(trim(new.project_name), ''), 'Fiscal sponsorship application'),
+    case when tg_op = 'UPDATE' then old.status else null end,
+    new.status,
+    coalesce(new.updated_by, new.created_by),
+    jsonb_build_object(
+      'submitted_at', new.submitted_at,
+      'reviewed_at', new.reviewed_at
+    ),
+    coalesce(new.updated_at, timezone('utc', now()))
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists record_organization_project_activity on public.organization_projects;
+create trigger record_organization_project_activity
+  after insert or update of status on public.organization_projects
+  for each row execute procedure public.record_organization_project_activity();
+
+drop trigger if exists record_organization_task_activity on public.organization_tasks;
+create trigger record_organization_task_activity
+  after insert or update of status on public.organization_tasks
+  for each row execute procedure public.record_organization_task_activity();
+
+drop trigger if exists record_organization_program_activity on public.programs;
+create trigger record_organization_program_activity
+  after insert or update of status_label, is_public, start_date, end_date on public.programs
+  for each row execute procedure public.record_organization_program_activity();
+
+drop trigger if exists record_fiscal_sponsorship_application_activity
+  on public.fiscal_sponsorship_applications;
+create trigger record_fiscal_sponsorship_application_activity
+  after insert or update of status, submitted_at
+  on public.fiscal_sponsorship_applications
+  for each row execute procedure public.record_fiscal_sponsorship_application_activity();
+
+alter table public.platform_admin_workstream_categories enable row level security;
+alter table public.platform_admin_workstream_categories force row level security;
+alter table public.platform_admin_project_workstream_states enable row level security;
+alter table public.platform_admin_project_workstream_states force row level security;
+alter table public.organization_project_activity_events enable row level security;
+
+drop policy if exists "platform_admin_workstream_categories_select" on public.platform_admin_workstream_categories;
+drop policy if exists "platform_admin_workstream_categories_insert" on public.platform_admin_workstream_categories;
+drop policy if exists "platform_admin_workstream_categories_update" on public.platform_admin_workstream_categories;
+drop policy if exists "platform_admin_workstream_categories_delete" on public.platform_admin_workstream_categories;
+
+create policy "platform_admin_workstream_categories_select"
+  on public.platform_admin_workstream_categories
+  for select to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_workstream_categories_insert"
+  on public.platform_admin_workstream_categories
+  for insert to authenticated
+  with check (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_workstream_categories_update"
+  on public.platform_admin_workstream_categories
+  for update to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()))
+  with check (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_workstream_categories_delete"
+  on public.platform_admin_workstream_categories
+  for delete to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+drop policy if exists "platform_admin_project_workstream_states_select" on public.platform_admin_project_workstream_states;
+drop policy if exists "platform_admin_project_workstream_states_insert" on public.platform_admin_project_workstream_states;
+drop policy if exists "platform_admin_project_workstream_states_update" on public.platform_admin_project_workstream_states;
+drop policy if exists "platform_admin_project_workstream_states_delete" on public.platform_admin_project_workstream_states;
+
+create policy "platform_admin_project_workstream_states_select"
+  on public.platform_admin_project_workstream_states
+  for select to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_project_workstream_states_insert"
+  on public.platform_admin_project_workstream_states
+  for insert to authenticated
+  with check (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_project_workstream_states_update"
+  on public.platform_admin_project_workstream_states
+  for update to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()))
+  with check (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+create policy "platform_admin_project_workstream_states_delete"
+  on public.platform_admin_project_workstream_states
+  for delete to authenticated
+  using (owner_id = (select auth.uid()) and (select public.is_admin()));
+
+drop policy if exists "organization_project_activity_events_select" on public.organization_project_activity_events;
+
+create policy "organization_project_activity_events_select"
+  on public.organization_project_activity_events
+  for select to authenticated
+  using (
+    (select public.is_admin())
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from public.organization_memberships as membership
+      where membership.org_id = organization_project_activity_events.org_id
+        and membership.member_id = (select auth.uid())
+    )
+  );
+
+revoke insert, update, delete on public.organization_project_activity_events from anon, authenticated;
+grant select on public.organization_project_activity_events to authenticated;
+grant select, insert, update, delete on public.platform_admin_workstream_categories to authenticated;
+grant select, insert, update, delete on public.platform_admin_project_workstream_states to authenticated;

--- a/supabase/migrations/20260717130000_refresh_admin_workstream_defaults.sql
+++ b/supabase/migrations/20260717130000_refresh_admin_workstream_defaults.sql
@@ -1,0 +1,73 @@
+set check_function_bodies = off;
+set search_path = public;
+
+alter table public.platform_admin_workstream_categories
+  drop constraint if exists platform_admin_workstream_categories_default_key_check;
+
+alter table public.platform_admin_workstream_categories
+  add constraint platform_admin_workstream_categories_default_key_check
+  check (
+    default_key is null
+    or default_key in (
+      'backlog',
+      'planned',
+      'waiting_on_organization',
+      'review_approval',
+      'active',
+      'completed',
+      'cancelled'
+    )
+  );
+
+update public.platform_admin_workstream_categories
+set
+  name = case default_key
+    when 'backlog' then 'New Intake'
+    when 'planned' then 'Coach Action'
+    when 'active' then 'Ongoing Support'
+    when 'completed' then 'Complete'
+    else name
+  end,
+  color = case default_key
+    when 'backlog' then 'slate'
+    when 'planned' then 'amber'
+    when 'active' then 'violet'
+    when 'completed' then 'emerald'
+    else color
+  end,
+  position = case default_key
+    when 'backlog' then 0
+    when 'planned' then 1
+    when 'active' then 4
+    when 'completed' then 5
+    else position
+  end
+where
+  (default_key = 'backlog' and name = 'Backlog')
+  or (default_key = 'planned' and name = 'Planned')
+  or (default_key = 'active' and name = 'Active')
+  or (default_key = 'completed' and name = 'Completed');
+
+insert into public.platform_admin_workstream_categories (
+  owner_id,
+  name,
+  color,
+  position,
+  default_key
+)
+select
+  owners.owner_id,
+  defaults.name,
+  defaults.color,
+  defaults.position,
+  defaults.default_key
+from (
+  select distinct owner_id
+  from public.platform_admin_workstream_categories
+) as owners
+cross join (
+  values
+    ('Waiting on Organization', 'rose', 2, 'waiting_on_organization'),
+    ('Review & Approval', 'blue', 3, 'review_approval')
+) as defaults(name, color, position, default_key)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- restore six immutable migration files already applied to linked Supabase
- reconcile resource-map and organization-operations migration history with main
- keep the pending admin-operations hardening migration out of this ledger-only step

## Verification
- linked Supabase migration dry run: up to date
- linked RLS suite: passed
- pre-push structural quality subset: passed
- acceptance: 295 files passed, 1 skipped; 1,426 tests passed, 1 skipped

## Database impact
No database write. These migrations already exist in the linked migration ledger.