### PR TITLE
[STEP S95] Ship coach organization operations

### DIFF
--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -212,6 +212,13 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Passed lint and structural guardrails, full acceptance (`295 files passed`, `1 skipped`; `1,426 tests passed`, `1 skipped`), linked RLS, production build, isolated visuals (`14/14`), performance budgets, and route probes (`sign 200`, unauthenticated preview/document 401).
 - No application deployment was performed in this checkpoint. The next step is PR S93, merge, Vercel production verification, and an authenticated signing smoke test.
 
+2026-07-17 15:14 EDT - prepared coach organization operations and category management for release.
+
+- Replaced the coach workstream defaults with New Intake, Coach Action, Waiting on Organization, Review & Approval, Ongoing Support, and Complete. Super admins can add, rename, and delete custom categories; protected defaults can be restored atomically.
+- Added production-backed organization cards, coach-owned placements, real task counts, member completeness, program dates, editable project operations, task CRUD and reordering, activity history, and fiscal-sponsorship document access.
+- Added migrations `20260716203000_add_admin_organization_operations.sql`, `20260717130000_refresh_admin_workstream_defaults.sql`, and `20260717143300_harden_admin_organization_operations.sql`. The first two are already applied to linked Supabase; the hardening migration remains intentionally pending until the application synchronization fix is deployed.
+- Focused acceptance passed (`10 files`, `68 tests`). The complete `pnpm check:quality` gate passed: lint and all structural guardrails, snapshots, acceptance (`299 files passed`, `1 skipped`; `1,449 tests passed`, `1 skipped`), linked RLS, production build and TypeScript, visuals (`14/14`), and performance budgets. The original dirty worktree remains untouched outside this isolated release packaging.
+
 2026-07-17 15:17 EDT - reconciled linked Supabase migration history for release.
 
 - Added six immutable migration files already applied to linked Supabase but absent from `main`: four resource-map migrations, the admin organization-operations schema, and the refreshed coach workstream defaults.

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -71,13 +71,16 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
     )
   }
 
-  const canManageProject = result.scope === "organization"
+  const canManageProject =
+    result.scope === "organization" || result.scope === "platform-admin"
   const canManageProjectAssets =
     result.scope === "organization" || result.scope === "platform-admin"
   const canEditProjectDetails =
     result.scope === "organization" || result.scope === "platform-admin"
   const canManageFiscalSponsorship = result.scope === "platform-admin"
   const projectKind = getOrganizationAdminProjectKind(result.project.source)
+  const canManageProjectTasks =
+    result.scope === "organization" || result.scope === "platform-admin"
   const canDeleteProject =
     canEditProjectDetails && projectKind !== "organization_admin"
   const fiscalSponsorshipWorkflowSummary =
@@ -103,13 +106,13 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
           : undefined
       }
       createTaskAction={
-        canManageProject ? createMemberWorkspaceTaskAction : undefined
+        canManageProjectTasks ? createMemberWorkspaceTaskAction : undefined
       }
       updateTaskAction={
-        canManageProject ? updateMemberWorkspaceTaskAction : undefined
+        canManageProjectTasks ? updateMemberWorkspaceTaskAction : undefined
       }
       deleteTaskAction={
-        canManageProject ? deleteMemberWorkspaceTaskAction : undefined
+        canManageProjectTasks ? deleteMemberWorkspaceTaskAction : undefined
       }
       updateProjectAction={
         canEditProjectDetails ? updateMemberWorkspaceProjectAction : undefined
@@ -118,10 +121,12 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
         canDeleteProject ? deleteMemberWorkspaceProjectAction : undefined
       }
       updateTaskStatusAction={
-        canManageProject ? updateMemberWorkspaceTaskStatusAction : undefined
+        canManageProjectTasks
+          ? updateMemberWorkspaceTaskStatusAction
+          : undefined
       }
       updateTaskOrderAction={
-        canManageProject ? updateMemberWorkspaceTaskOrderAction : undefined
+        canManageProjectTasks ? updateMemberWorkspaceTaskOrderAction : undefined
       }
       createNoteAction={
         canManageProject ? createMemberWorkspaceProjectNoteAction : undefined

--- a/src/app/(dashboard)/organizations/page.tsx
+++ b/src/app/(dashboard)/organizations/page.tsx
@@ -1,8 +1,13 @@
 import {
   clearMemberWorkspaceStarterDataAction,
+  createPlatformAdminWorkstreamCategoryAction,
   createMemberWorkspaceProjectAction,
+  deletePlatformAdminWorkstreamCategoryAction,
   loadMemberWorkspaceProjectsPage,
   MemberWorkspaceProjectsPage,
+  restorePlatformAdminWorkstreamDefaultsAction,
+  updatePlatformAdminProjectWorkstreamAction,
+  updatePlatformAdminWorkstreamCategoryAction,
   updateMemberWorkspaceProjectAction,
   updateMemberWorkspaceProjectScheduleAction,
   updateMemberWorkspaceProjectStatusAction,
@@ -21,6 +26,7 @@ export default async function OrganizationsPage() {
     scope,
     organizationOptions,
     assigneeOptions,
+    workstreamCategories,
   } = await loadMemberWorkspaceProjectsPage()
 
   return (
@@ -48,6 +54,20 @@ export default async function OrganizationsPage() {
       scope={scope}
       organizationOptions={organizationOptions}
       assigneeOptions={assigneeOptions}
+      workstreamCategories={workstreamCategories}
+      createWorkstreamCategoryAction={
+        createPlatformAdminWorkstreamCategoryAction
+      }
+      updateWorkstreamCategoryAction={
+        updatePlatformAdminWorkstreamCategoryAction
+      }
+      deleteWorkstreamCategoryAction={
+        deletePlatformAdminWorkstreamCategoryAction
+      }
+      restoreWorkstreamDefaultsAction={
+        restorePlatformAdminWorkstreamDefaultsAction
+      }
+      updateProjectWorkstreamAction={updatePlatformAdminProjectWorkstreamAction}
     />
   )
 }

--- a/src/features/member-workspace/admin-workstream-actions.ts
+++ b/src/features/member-workspace/admin-workstream-actions.ts
@@ -1,0 +1,7 @@
+export {
+  createPlatformAdminWorkstreamCategoryAction,
+  deletePlatformAdminWorkstreamCategoryAction,
+  restorePlatformAdminWorkstreamDefaultsAction,
+  updatePlatformAdminProjectWorkstreamAction,
+  updatePlatformAdminWorkstreamCategoryAction,
+} from "./server/admin-workstreams"

--- a/src/features/member-workspace/components/projects/member-workspace-project-activity-timeline.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-activity-timeline.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import {
+  CalendarBlank,
+  CheckCircle,
+  Clock,
+  Flag,
+} from "@phosphor-icons/react/dist/ssr"
+import { differenceInCalendarDays, format } from "date-fns"
+
+import type {
+  ProjectActivityItem,
+  ProjectDetails,
+} from "@/features/platform-admin-dashboard"
+import type { MemberWorkspaceAdminOrganizationSummary } from "../../types"
+
+function toTitleCase(value: string | null) {
+  if (!value) return null
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function eventSummary(item: ProjectActivityItem) {
+  const fromStatus = toTitleCase(item.fromStatus)
+  const toStatus = toTitleCase(item.toStatus)
+  if (fromStatus && toStatus && fromStatus !== toStatus) {
+    return `${fromStatus} to ${toStatus}`
+  }
+  if (toStatus) return toStatus
+  return toTitleCase(item.eventType) ?? "Updated"
+}
+
+function programDuration(startAt: string | null, endAt: string | null) {
+  if (!startAt) return "Start date not set"
+  const start = new Date(startAt)
+  const end = endAt ? new Date(endAt) : new Date()
+  const days = Math.max(differenceInCalendarDays(end, start) + 1, 1)
+  return endAt ? `${days} days scheduled` : `${days} days running`
+}
+
+export function MemberWorkspaceProjectActivityTimeline({
+  organizationSummary,
+  project,
+}: {
+  organizationSummary: MemberWorkspaceAdminOrganizationSummary
+  project: ProjectDetails
+}) {
+  const activity = project.activity ?? []
+  const programs = organizationSummary.programs ?? []
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-foreground text-base font-semibold">
+            Program timelines
+          </h2>
+          <p className="text-muted-foreground text-sm leading-6">
+            Program run dates and elapsed or scheduled duration.
+          </p>
+        </div>
+
+        {programs.length > 0 ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {programs.map((program) => (
+              <article
+                key={program.id}
+                className="border-border bg-card/70 space-y-3 rounded-lg border p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-foreground truncate text-sm font-medium">
+                      {program.title}
+                    </p>
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      {program.statusLabel}
+                    </p>
+                  </div>
+                  {program.isPublic ? (
+                    <span className="rounded-full bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-200">
+                      Public
+                    </span>
+                  ) : null}
+                </div>
+                <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                  <CalendarBlank className="h-4 w-4" />
+                  <span>
+                    {program.startAt
+                      ? format(new Date(program.startAt), "MMM d, yyyy")
+                      : "No start date"}
+                    {program.endAt
+                      ? ` – ${format(new Date(program.endAt), "MMM d, yyyy")}`
+                      : ""}
+                  </span>
+                </div>
+                <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                  <Clock className="h-4 w-4" />
+                  <span>{programDuration(program.startAt, program.endAt)}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
+            No programs have been added yet.
+          </p>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-foreground text-base font-semibold">Activity</h2>
+          <p className="text-muted-foreground text-sm leading-6">
+            Project, task, and program transitions recorded by the system.
+          </p>
+        </div>
+
+        {activity.length > 0 ? (
+          <ol className="relative space-y-0 pl-6">
+            {activity.map((item, index) => (
+              <li
+                key={item.id}
+                className="border-border relative border-l pb-6 pl-6 last:border-transparent last:pb-0"
+              >
+                <span className="border-border bg-background absolute top-0 -left-2.5 flex h-5 w-5 items-center justify-center rounded-full border">
+                  {item.eventType === "completed" ? (
+                    <CheckCircle className="h-3.5 w-3.5 text-emerald-600" />
+                  ) : (
+                    <Flag className="text-muted-foreground h-3.5 w-3.5" />
+                  )}
+                </span>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                  <div className="min-w-0">
+                    <p className="text-foreground text-sm font-medium">
+                      {item.title}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {toTitleCase(item.entityType)} · {eventSummary(item)}
+                    </p>
+                  </div>
+                  <div className="text-muted-foreground shrink-0 text-xs sm:text-right">
+                    <p>{format(item.occurredAt, "MMM d, yyyy, h:mm a")}</p>
+                    {item.durationLabel && index < activity.length ? (
+                      <p>{item.durationLabel} in the prior step</p>
+                    ) : null}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
+            Activity will appear after the operations migration is applied and a
+            project, task, or program changes.
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/features/member-workspace/components/projects/member-workspace-project-board-category-controls.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-board-category-controls.tsx
@@ -1,0 +1,324 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import {
+  ArrowCounterClockwise,
+  CircleNotch,
+  DotsThreeVertical,
+  PencilSimple,
+  Plus,
+  TrashSimple,
+} from "@phosphor-icons/react/dist/ssr"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import type { MemberWorkspaceWorkstreamCategory } from "../../types"
+
+type CategoryMutationAction = (
+  categoryId: string
+) => Promise<{ ok: true; id: string } | { error: string }>
+
+export function MemberWorkspaceProjectBoardCategoryToolbar({
+  createCategoryAction,
+  restoreDefaultsAction,
+}: {
+  createCategoryAction?: (
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  restoreDefaultsAction?: () => Promise<{ ok: true } | { error: string }>
+}) {
+  const router = useRouter()
+  const [newCategoryName, setNewCategoryName] = useState("")
+  const [restoreOpen, setRestoreOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const handleCreateCategory = () => {
+    if (!createCategoryAction) return
+    const name = newCategoryName.trim()
+    if (!name) {
+      toast.error("Category name is required.")
+      return
+    }
+
+    startTransition(async () => {
+      const result = await createCategoryAction(name)
+      if ("error" in result) {
+        toast.error(result.error)
+        return
+      }
+      setNewCategoryName("")
+      toast.success("Category added")
+      router.refresh()
+    })
+  }
+
+  const handleRestoreDefaults = () => {
+    if (!restoreDefaultsAction) return
+    startTransition(async () => {
+      const result = await restoreDefaultsAction()
+      if ("error" in result) {
+        toast.error(result.error)
+        return
+      }
+      setRestoreOpen(false)
+      toast.success("Default categories restored")
+      router.refresh()
+    })
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          Your workstream categories
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          {restoreDefaultsAction ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={isPending}
+              onClick={() => setRestoreOpen(true)}
+            >
+              <ArrowCounterClockwise className="h-4 w-4" />
+              Restore defaults…
+            </Button>
+          ) : null}
+          {createCategoryAction ? (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button type="button" variant="outline" size="sm">
+                  <Plus className="h-4 w-4" />
+                  Add category
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-72 space-y-3" align="end">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">New category</p>
+                  <p className="text-muted-foreground text-xs">
+                    This category is visible only in your admin workstream.
+                  </p>
+                </div>
+                <Input
+                  value={newCategoryName}
+                  maxLength={48}
+                  placeholder="Needs review"
+                  aria-label="New workstream category name"
+                  onChange={(event) => setNewCategoryName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") handleCreateCategory()
+                  }}
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  className="w-full"
+                  disabled={isPending}
+                  onClick={handleCreateCategory}
+                >
+                  Add category
+                </Button>
+              </PopoverContent>
+            </Popover>
+          ) : null}
+        </div>
+      </div>
+
+      <AlertDialog
+        open={restoreOpen}
+        onOpenChange={(open) => {
+          if (!isPending) setRestoreOpen(open)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore default categories?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This resets the names and order of the six default categories.
+              Custom categories will not be changed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isPending}
+              onClick={(event) => {
+                event.preventDefault()
+                handleRestoreDefaults()
+              }}
+            >
+              {isPending ? (
+                <CircleNotch className="h-4 w-4 animate-spin" />
+              ) : null}
+              Restore defaults
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+export function MemberWorkspaceProjectBoardCategoryMenu({
+  category,
+  deleteCategoryAction,
+  updateCategoryAction,
+}: {
+  category: MemberWorkspaceWorkstreamCategory
+  deleteCategoryAction?: CategoryMutationAction
+  updateCategoryAction: (
+    categoryId: string,
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+}) {
+  const router = useRouter()
+  const [draftName, setDraftName] = useState(category.name)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const isDefaultCategory = category.defaultKey !== null
+
+  useEffect(() => setDraftName(category.name), [category.name])
+
+  const handleRename = () => {
+    const name = draftName.trim()
+    if (!name) {
+      toast.error("Category name is required.")
+      return
+    }
+
+    startTransition(async () => {
+      const result = await updateCategoryAction(category.id, name)
+      if ("error" in result) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Category renamed")
+      router.refresh()
+    })
+  }
+
+  const handleDelete = () => {
+    if (!deleteCategoryAction) return
+    startTransition(async () => {
+      const result = await deleteCategoryAction(category.id)
+      if ("error" in result) {
+        toast.error(result.error)
+        return
+      }
+      setDeleteOpen(false)
+      toast.success("Category deleted")
+      router.refresh()
+    })
+  }
+
+  return (
+    <>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 rounded-lg"
+            type="button"
+            aria-label={`Manage ${category.name} category`}
+            disabled={isPending}
+          >
+            <DotsThreeVertical className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 space-y-3" align="end">
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Edit category</p>
+            <p className="text-muted-foreground text-xs">
+              {isDefaultCategory
+                ? "Default categories can be renamed but cannot be deleted."
+                : "Moving organizations does not change their readiness."}
+            </p>
+          </div>
+          <Input
+            value={draftName}
+            maxLength={48}
+            aria-label={`${category.name} category name`}
+            onChange={(event) => setDraftName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") handleRename()
+            }}
+          />
+          <div className="flex items-center justify-between gap-2">
+            {isDefaultCategory ? (
+              <span className="text-muted-foreground text-xs">
+                Cannot be deleted
+              </span>
+            ) : deleteCategoryAction ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setDeleteOpen(true)}
+              >
+                <TrashSimple className="h-4 w-4" />
+                Delete
+              </Button>
+            ) : (
+              <span />
+            )}
+            <Button
+              type="button"
+              size="sm"
+              disabled={isPending}
+              onClick={handleRename}
+            >
+              <PencilSimple className="h-4 w-4" />
+              Save name
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {!isDefaultCategory && deleteCategoryAction ? (
+        <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this category?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Organizations in {category.name} will return to their default
+                workstream stage. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isPending}
+                onClick={(event) => {
+                  event.preventDefault()
+                  handleDelete()
+                }}
+              >
+                Delete category
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
+    </>
+  )
+}

--- a/src/features/member-workspace/components/projects/member-workspace-project-board-view.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-board-view.tsx
@@ -26,6 +26,11 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { MemberWorkspaceProjectCard } from "./member-workspace-project-card"
+import type { MemberWorkspaceWorkstreamCategory } from "../../types"
+import {
+  MemberWorkspaceProjectBoardCategoryMenu,
+  MemberWorkspaceProjectBoardCategoryToolbar,
+} from "./member-workspace-project-board-category-controls"
 
 const OPEN_COLUMN_ORDER: Array<PlatformAdminDashboardLabProject["status"]> = [
   "backlog",
@@ -89,6 +94,12 @@ export function MemberWorkspaceProjectBoardView({
   updateProjectStatusAction,
   showClosedProjects,
   visibleProperties,
+  workstreamCategories = [],
+  createWorkstreamCategoryAction,
+  updateWorkstreamCategoryAction,
+  deleteWorkstreamCategoryAction,
+  restoreWorkstreamDefaultsAction,
+  updateProjectWorkstreamAction,
 }: {
   projects: PlatformAdminDashboardLabProject[]
   onAddProject?: () => void
@@ -99,6 +110,24 @@ export function MemberWorkspaceProjectBoardView({
   ) => Promise<{ ok: true; id: string } | { error: string }>
   showClosedProjects: boolean
   visibleProperties?: Array<"title" | "status" | "assignee" | "dueDate">
+  workstreamCategories?: MemberWorkspaceWorkstreamCategory[]
+  createWorkstreamCategoryAction?: (
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  updateWorkstreamCategoryAction?: (
+    categoryId: string,
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  deleteWorkstreamCategoryAction?: (
+    categoryId: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  restoreWorkstreamDefaultsAction?: () => Promise<
+    { ok: true } | { error: string }
+  >
+  updateProjectWorkstreamAction?: (
+    projectId: string,
+    categoryId: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
 }) {
   const router = useRouter()
   const [items, setItems] =
@@ -106,37 +135,54 @@ export function MemberWorkspaceProjectBoardView({
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [pendingProjectIds, setPendingProjectIds] = useState<string[]>([])
   const [isPending, startTransition] = useTransition()
-  const canManageBoard = Boolean(updateProjectStatusAction)
-  const columnOrder = useMemo(
-    () => getMemberWorkspaceProjectBoardColumnOrder(showClosedProjects),
-    [showClosedProjects]
-  )
+  const usesCustomWorkstreams = workstreamCategories.length > 0
+  const canManageBoard = usesCustomWorkstreams
+    ? Boolean(updateProjectWorkstreamAction)
+    : Boolean(updateProjectStatusAction)
+  const columns = useMemo(() => {
+    if (usesCustomWorkstreams) {
+      return workstreamCategories.map((category) => ({
+        id: category.id,
+        label: category.name,
+        color: category.color,
+        defaultKey: category.defaultKey,
+      }))
+    }
+
+    return getMemberWorkspaceProjectBoardColumnOrder(showClosedProjects).map(
+      (status) => ({
+        id: status,
+        label: getColumnStatusLabel(status),
+        color: "slate",
+        defaultKey: status,
+      })
+    )
+  }, [showClosedProjects, usesCustomWorkstreams, workstreamCategories])
 
   useEffect(() => {
     setItems(projects)
   }, [projects])
 
   const groups = useMemo(() => {
-    const grouped = new Map<
-      PlatformAdminDashboardLabProject["status"],
-      PlatformAdminDashboardLabProject[]
-    >()
-    for (const status of columnOrder) {
-      grouped.set(status, [])
+    const grouped = new Map<string, PlatformAdminDashboardLabProject[]>()
+    for (const column of columns) {
+      grouped.set(column.id, [])
     }
     for (const project of items) {
-      if (!grouped.has(project.status)) {
-        if (showClosedProjects) {
-          continue
-        }
-        if (project.status === "completed" || project.status === "cancelled") {
-          continue
-        }
+      const statusCategory = columns.find(
+        (column) => column.defaultKey === project.status
+      )
+      const columnId = usesCustomWorkstreams
+        ? (project.workstreamCategoryId ?? statusCategory?.id ?? columns[0]?.id)
+        : project.status
+
+      if (!columnId || !grouped.has(columnId)) {
+        continue
       }
-      grouped.get(project.status)?.push(project)
+      grouped.get(columnId)?.push(project)
     }
     return grouped
-  }, [columnOrder, items, showClosedProjects])
+  }, [columns, items, usesCustomWorkstreams])
 
   const commitProjectStatus = (
     projectId: string,
@@ -173,14 +219,55 @@ export function MemberWorkspaceProjectBoardView({
     })
   }
 
+  const commitProjectWorkstream = (projectId: string, categoryId: string) => {
+    if (!updateProjectWorkstreamAction) return
+
+    const previousItems = items
+    setItems((current) =>
+      current.map((project) =>
+        project.id === projectId
+          ? { ...project, workstreamCategoryId: categoryId }
+          : project
+      )
+    )
+    setPendingProjectIds((current) =>
+      Array.from(new Set([...current, projectId]))
+    )
+
+    startTransition(async () => {
+      const result = await updateProjectWorkstreamAction(projectId, categoryId)
+      setPendingProjectIds((current) =>
+        current.filter((value) => value !== projectId)
+      )
+
+      if ("error" in result) {
+        setItems(previousItems)
+        toast.error(result.error)
+        return
+      }
+
+      router.refresh()
+    })
+  }
+
+  const moveProject = (projectId: string, columnId: string) => {
+    if (usesCustomWorkstreams) {
+      commitProjectWorkstream(projectId, columnId)
+      return
+    }
+    commitProjectStatus(
+      projectId,
+      columnId as PlatformAdminDashboardLabProject["status"]
+    )
+  }
+
   const handleDropTo =
-    (status: PlatformAdminDashboardLabProject["status"]) =>
-    (event: DragEvent<HTMLDivElement>) => {
+    (columnId: string) => (event: DragEvent<HTMLDivElement>) => {
       event.preventDefault()
       const id = event.dataTransfer.getData("text/id")
       if (!id) return
       setDraggingId(null)
-      commitProjectStatus(id, status)
+      moveProject(id, columnId)
     }
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
@@ -188,23 +275,36 @@ export function MemberWorkspaceProjectBoardView({
   }
 
   return (
-    <div className="p-4">
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
-        {columnOrder.map((status) => (
+    <div className="space-y-3 p-4">
+      {usesCustomWorkstreams ? (
+        <MemberWorkspaceProjectBoardCategoryToolbar
+          createCategoryAction={createWorkstreamCategoryAction}
+          restoreDefaultsAction={restoreWorkstreamDefaultsAction}
+        />
+      ) : null}
+
+      <div className="grid auto-cols-[minmax(17rem,1fr)] grid-flow-col gap-4 overflow-x-auto pb-2 lg:auto-cols-[minmax(18rem,1fr)]">
+        {columns.map((column) => (
           <div
-            key={status}
-            className="bg-muted rounded-xl"
+            key={column.id}
+            className="bg-muted min-w-0 rounded-xl"
             onDragOver={canManageBoard ? handleDragOver : undefined}
-            onDrop={canManageBoard ? handleDropTo(status) : undefined}
+            onDrop={canManageBoard ? handleDropTo(column.id) : undefined}
           >
             <div className="flex items-center justify-between px-3 py-3">
               <div className="flex items-center gap-2">
-                {getColumnStatusIcon(status)}
+                {column.defaultKey ? (
+                  getColumnStatusIcon(
+                    column.defaultKey as PlatformAdminDashboardLabProject["status"]
+                  )
+                ) : (
+                  <StackSimple className="text-muted-foreground h-4 w-4" />
+                )}
                 <span className="inline-flex items-center gap-1 text-sm font-medium">
-                  {getColumnStatusLabel(status)}
+                  {column.label}
                 </span>
                 <span className="text-muted-foreground text-xs">
-                  {groups.get(status)?.length ?? 0}
+                  {groups.get(column.id)?.length ?? 0}
                 </span>
               </div>
               <div className="flex items-center gap-1">
@@ -219,21 +319,27 @@ export function MemberWorkspaceProjectBoardView({
                     <Plus className="h-4 w-4" />
                   </Button>
                 ) : null}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 rounded-lg"
-                  type="button"
-                  disabled={isPending || !canManageBoard}
-                >
-                  <DotsThreeVertical className="h-4 w-4" />
-                </Button>
+                {usesCustomWorkstreams && updateWorkstreamCategoryAction ? (
+                  <MemberWorkspaceProjectBoardCategoryMenu
+                    category={{
+                      id: column.id,
+                      name: column.label,
+                      color: column.color,
+                      position: 0,
+                      defaultKey: column.defaultKey,
+                    }}
+                    deleteCategoryAction={deleteWorkstreamCategoryAction}
+                    updateCategoryAction={updateWorkstreamCategoryAction}
+                  />
+                ) : null}
               </div>
             </div>
             <div className="min-h-[120px] space-y-3 px-3 pb-3">
-              {(groups.get(status) ?? []).map((project) => {
+              {(groups.get(column.id) ?? []).map((project) => {
                 const canManageProjectCard =
-                  canManageBoard && project.projectKind !== "organization_admin"
+                  canManageBoard &&
+                  (usesCustomWorkstreams ||
+                    project.projectKind !== "organization_admin")
 
                 return (
                   <div
@@ -287,21 +393,16 @@ export function MemberWorkspaceProjectBoardView({
                             </PopoverTrigger>
                             <PopoverContent className="w-40 p-2" align="end">
                               <div className="space-y-1">
-                                {getMemberWorkspaceProjectBoardColumnOrder(
-                                  true
-                                ).map((nextStatus) => (
+                                {columns.map((nextColumn) => (
                                   <button
-                                    key={nextStatus}
+                                    key={nextColumn.id}
                                     type="button"
                                     className="hover:bg-accent w-full rounded-md px-2 py-1 text-left text-sm"
                                     onClick={() =>
-                                      commitProjectStatus(
-                                        project.id,
-                                        nextStatus
-                                      )
+                                      moveProject(project.id, nextColumn.id)
                                     }
                                   >
-                                    Move to {getColumnStatusLabel(nextStatus)}
+                                    Move to {nextColumn.label}
                                   </button>
                                 ))}
                               </div>

--- a/src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx
@@ -31,15 +31,21 @@ import type {
 } from "../../types"
 import type { MemberWorkspaceProjectDetailDraft } from "./member-workspace-project-detail-editing"
 import { MemberWorkspaceProjectFiscalWorkbench } from "./member-workspace-project-fiscal-workbench"
+import {
+  getMemberWorkspaceProjectFiscalDocumentAssetIds,
+  MemberWorkspaceProjectFiscalDocuments,
+} from "./member-workspace-project-fiscal-documents"
 import { MemberWorkspaceProjectOverviewDocument } from "./member-workspace-project-overview-document"
 import { MemberWorkspaceProjectOverviewEditor } from "./member-workspace-project-overview-editor"
 import { MemberWorkspaceProjectTasksEditor } from "./member-workspace-project-tasks-editor"
+import { MemberWorkspaceProjectActivityTimeline } from "./member-workspace-project-activity-timeline"
 
 function ProjectDetailTabsList() {
   return (
     <div className="-mx-1 overflow-x-auto pb-2">
       <TabsList className="inline-flex w-max min-w-full gap-2 px-1 sm:w-full sm:gap-6">
         <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="activity">Activity</TabsTrigger>
         <TabsTrigger value="workstream">Workstream</TabsTrigger>
         <TabsTrigger value="tasks">Tasks</TabsTrigger>
         <TabsTrigger value="notes">Notes</TabsTrigger>
@@ -238,6 +244,13 @@ export function MemberWorkspaceProjectDetailTabs({
       }
     />
   )
+  const fiscalDocumentAssetIds =
+    getMemberWorkspaceProjectFiscalDocumentAssetIds(
+      fiscalSponsorshipWorkflowSummary
+    )
+  const generalProjectFiles = project.files.filter(
+    (file) => !fiscalDocumentAssetIds.has(file.id)
+  )
 
   return (
     <Tabs value={activeTab} onValueChange={onActiveTabChange}>
@@ -253,12 +266,20 @@ export function MemberWorkspaceProjectDetailTabs({
         />
       </TabsContent>
 
+      <TabsContent value="activity">
+        <MemberWorkspaceProjectActivityTimeline
+          organizationSummary={organizationSummary}
+          project={project}
+        />
+      </TabsContent>
+
       <TabsContent value="workstream">
         <WorkstreamTab
           workstreams={project.workstreams}
           canReorder={false}
           canToggleTasks={Boolean(updateTaskStatusAction)}
           onCreateTask={onCreateTask}
+          onUpdateTaskStatus={updateTaskStatusAction}
         />
       </TabsContent>
 
@@ -299,12 +320,17 @@ export function MemberWorkspaceProjectDetailTabs({
       </TabsContent>
 
       <TabsContent value="assets">
-        <AssetsFilesTab
-          files={project.files}
-          onCreateAsset={onCreateAsset}
-          onUpdateAsset={onUpdateAsset}
-          onDeleteAsset={onDeleteAsset}
-        />
+        <div className="space-y-8">
+          <MemberWorkspaceProjectFiscalDocuments
+            workflowSummary={fiscalSponsorshipWorkflowSummary}
+          />
+          <AssetsFilesTab
+            files={generalProjectFiles}
+            onCreateAsset={onCreateAsset}
+            onUpdateAsset={onUpdateAsset}
+            onDeleteAsset={onDeleteAsset}
+          />
+        </div>
       </TabsContent>
     </Tabs>
   )

--- a/src/features/member-workspace/components/projects/member-workspace-project-fiscal-documents.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-fiscal-documents.tsx
@@ -1,0 +1,118 @@
+import { Download, ExternalLink, FileCheck2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import type {
+  FiscalSponsorshipProjectWorkflowSummary,
+  FiscalSponsorshipProjectWorkflowSummaryDocument,
+} from "@/features/fiscal-sponsorship"
+
+type MemberWorkspaceProjectFiscalDocumentsProps = {
+  workflowSummary?: FiscalSponsorshipProjectWorkflowSummary | null
+}
+
+export function getMemberWorkspaceProjectFiscalDocuments(
+  workflowSummary?: FiscalSponsorshipProjectWorkflowSummary | null
+) {
+  return [
+    workflowSummary?.latestExecutedAgreementDocument ?? null,
+    workflowSummary?.latestAuditCertificateDocument ?? null,
+  ].filter(
+    (document): document is FiscalSponsorshipProjectWorkflowSummaryDocument =>
+      document?.status === "executed" &&
+      Boolean(document.viewHref || document.downloadHref)
+  )
+}
+
+export function getMemberWorkspaceProjectFiscalDocumentAssetIds(
+  workflowSummary?: FiscalSponsorshipProjectWorkflowSummary | null
+) {
+  return new Set(
+    getMemberWorkspaceProjectFiscalDocuments(workflowSummary)
+      .map((document) => document.assetId)
+      .filter((assetId): assetId is string => Boolean(assetId))
+  )
+}
+
+function getDocumentKindLabel(
+  document: FiscalSponsorshipProjectWorkflowSummaryDocument
+) {
+  return document.kind === "audit_certificate"
+    ? "Execution certificate"
+    : "Executed agreement"
+}
+
+export function MemberWorkspaceProjectFiscalDocuments({
+  workflowSummary,
+}: MemberWorkspaceProjectFiscalDocumentsProps) {
+  const documents = getMemberWorkspaceProjectFiscalDocuments(workflowSummary)
+
+  if (documents.length === 0) return null
+
+  return (
+    <section
+      className="space-y-4"
+      data-member-workspace-project-fiscal-documents
+    >
+      <div className="space-y-1">
+        <h2 className="text-foreground text-sm font-semibold">
+          Signed fiscal sponsorship documents
+        </h2>
+        <p className="text-muted-foreground text-sm leading-6">
+          Final agreements and execution certificates are read-only.
+        </p>
+      </div>
+
+      <ul className="border-border bg-card divide-y overflow-hidden rounded-xl border">
+        {documents.map((document) => (
+          <li
+            className="flex min-w-0 flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between"
+            key={document.id}
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg">
+                <FileCheck2 aria-hidden="true" className="size-5" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-foreground truncate text-sm font-medium">
+                  {document.title}
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {getDocumentKindLabel(document)} · Version {document.version}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex shrink-0 flex-wrap gap-2">
+              {document.viewHref ? (
+                <Button
+                  asChild
+                  className="min-h-11 sm:min-h-9"
+                  size="sm"
+                  variant="outline"
+                >
+                  <a href={document.viewHref} rel="noreferrer" target="_blank">
+                    <ExternalLink aria-hidden="true" className="size-4" />
+                    Open
+                  </a>
+                </Button>
+              ) : null}
+              {document.downloadHref ? (
+                <Button
+                  asChild
+                  className="min-h-11 sm:min-h-9"
+                  size="sm"
+                  variant="ghost"
+                >
+                  <a href={document.downloadHref}>
+                    <Download aria-hidden="true" className="size-4" />
+                    Download
+                  </a>
+                </Button>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/features/member-workspace/components/projects/member-workspace-project-organization-card.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-organization-card.tsx
@@ -9,7 +9,9 @@ function toTrimmedString(value: unknown) {
   return typeof value === "string" ? value.trim() : ""
 }
 
-function organizationStatusLabel(status: MemberWorkspaceAdminOrganizationSummary["organizationStatus"]) {
+function organizationStatusLabel(
+  status: MemberWorkspaceAdminOrganizationSummary["organizationStatus"]
+) {
   if (status === "approved") return "Approved"
   if (status === "pending") return "Pending"
   return "N/A"
@@ -27,7 +29,7 @@ function resolveExternalHref(value: unknown) {
 }
 
 export function resolveMemberWorkspaceOrganizationHref(
-  organization: MemberWorkspaceAdminOrganizationSummary,
+  organization: MemberWorkspaceAdminOrganizationSummary
 ) {
   const website =
     resolveExternalHref(organization.profile.website) ||
@@ -50,11 +52,16 @@ export function MemberWorkspaceProjectOrganizationCard({
     organization.members[0] ??
     null
   const href = resolveMemberWorkspaceOrganizationHref(organization)
+  const membersWithCompleteness = organization.members.filter(
+    (member) => typeof member.profileCompletenessPercent === "number"
+  )
 
   return (
-    <div className="space-y-3 rounded-lg border border-border bg-card/80 p-4">
+    <div className="border-border bg-card/80 space-y-3 rounded-lg border p-4">
       <div className="flex items-center justify-between gap-2">
-        <p className="text-xs font-medium text-muted-foreground">Organization</p>
+        <p className="text-muted-foreground text-xs font-medium">
+          Organization
+        </p>
         <Badge
           variant="outline"
           className="rounded-full px-2 py-0.5 text-[11px] font-medium capitalize"
@@ -68,20 +75,79 @@ export function MemberWorkspaceProjectOrganizationCard({
             href={href}
             target="_blank"
             rel="noreferrer"
-            className="text-sm font-medium text-foreground underline-offset-2 hover:underline"
+            className="text-foreground text-sm font-medium underline-offset-2 hover:underline"
           >
             {organization.name}
           </Link>
         ) : (
-          <p className="text-sm font-medium text-foreground">{organization.name}</p>
+          <p className="text-foreground text-sm font-medium">
+            {organization.name}
+          </p>
         )}
         {contact ? (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-muted-foreground text-xs">
             {contact.name}
             {contact.email ? ` · ${contact.email}` : ""}
           </p>
         ) : null}
       </div>
+
+      <div className="border-border/70 space-y-2 border-t pt-3">
+        <div className="flex items-center justify-between gap-3 text-xs">
+          <span className="text-muted-foreground">Organization setup</span>
+          <span className="text-foreground font-medium">
+            {organization.setupProgress}%
+          </span>
+        </div>
+        <div
+          className="bg-muted h-1.5 overflow-hidden rounded-full"
+          role="progressbar"
+          aria-label="Organization setup completeness"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={organization.setupProgress}
+        >
+          <div
+            className="bg-primary h-full rounded-full"
+            style={{ width: `${organization.setupProgress}%` }}
+          />
+        </div>
+        <p className="text-muted-foreground text-[11px]">
+          {organization.setupCompletedCount} of {organization.setupTotalCount}{" "}
+          setup items complete
+        </p>
+      </div>
+
+      {membersWithCompleteness.length > 0 ? (
+        <div className="border-border/70 space-y-2 border-t pt-3">
+          <p className="text-muted-foreground text-xs font-medium">
+            User completeness
+          </p>
+          <div className="space-y-2">
+            {membersWithCompleteness.map((member) => (
+              <div key={member.userId} className="space-y-1">
+                <div className="flex items-center justify-between gap-3 text-xs">
+                  <span className="text-foreground min-w-0 truncate">
+                    {member.name}
+                  </span>
+                  <span className="text-foreground shrink-0 font-medium">
+                    {member.profileCompletenessPercent}%
+                  </span>
+                </div>
+                {member.profileMissingFields?.length ? (
+                  <p className="text-muted-foreground text-[11px] leading-4">
+                    Missing {member.profileMissingFields.join(", ")}
+                  </p>
+                ) : (
+                  <p className="text-muted-foreground text-[11px]">
+                    Profile complete
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/features/member-workspace/components/projects/member-workspace-project-task-delete-dialog.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-task-delete-dialog.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useState } from "react"
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+type TaskDeleteAction = (
+  taskId: string
+) => Promise<
+  { ok: true; taskId: string; projectId: string } | { error: string }
+>
+
+export function MemberWorkspaceProjectTaskDeleteDialog({
+  deleteTaskAction,
+  task,
+  onDeleted,
+  onOpenChange,
+}: {
+  deleteTaskAction?: TaskDeleteAction
+  task: { id: string; name: string } | null
+  onDeleted: (taskId: string) => void
+  onOpenChange: (open: boolean) => void
+}) {
+  const [pending, setPending] = useState(false)
+
+  const handleConfirm = async () => {
+    if (!deleteTaskAction || !task) return
+
+    setPending(true)
+    try {
+      const result = await deleteTaskAction(task.id)
+      if ("error" in result) {
+        toast.error(result.error)
+        return
+      }
+
+      toast.success("Task deleted")
+      onDeleted(task.id)
+    } catch {
+      toast.error("Task could not be deleted.")
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(task)}
+      onOpenChange={(open) => {
+        if (!pending) onOpenChange(open)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete task?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes “{task?.name ?? "this task"}”. This cannot
+            be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={pending}
+            onClick={(event) => {
+              event.preventDefault()
+              void handleConfirm()
+            }}
+          >
+            {pending ? <CircleNotch className="h-4 w-4 animate-spin" /> : null}
+            Delete task
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/features/member-workspace/components/projects/member-workspace-project-tasks-editor.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-tasks-editor.tsx
@@ -17,6 +17,7 @@ import type {
   ProjectTask,
 } from "@/features/platform-admin-dashboard"
 import { Button } from "@/components/ui/button"
+import { MemberWorkspaceProjectTaskDeleteDialog } from "./member-workspace-project-task-delete-dialog"
 import type {
   MemberWorkspaceCreateTaskInput,
   MemberWorkspacePersonOption,
@@ -40,7 +41,7 @@ function getProjectTasks(details: ProjectDetails): ProjectTask[] {
       projectName: details.name,
       workstreamId: group.id,
       workstreamName: group.name,
-    })),
+    }))
   )
 }
 
@@ -51,7 +52,9 @@ type MemberWorkspaceProjectTasksEditorProps = {
   ) => Promise<{ ok: true; taskId: string } | { error: string }>
   deleteTaskAction?: (
     taskId: string
-  ) => Promise<{ ok: true; taskId: string; projectId: string } | { error: string }>
+  ) => Promise<
+    { ok: true; taskId: string; projectId: string } | { error: string }
+  >
   onPendingCreateContextHandled?: () => void
   pendingCreateContext?: CreateTaskContext
   project: ProjectDetails
@@ -76,11 +79,15 @@ export function MemberWorkspaceProjectTasksEditor({
   onPendingCreateContextHandled,
 }: MemberWorkspaceProjectTasksEditorProps) {
   const router = useRouter()
-  const [tasks, setTasks] = useState<ProjectTask[]>(() => getProjectTasks(project))
+  const [tasks, setTasks] = useState<ProjectTask[]>(() =>
+    getProjectTasks(project)
+  )
   const [draftTargetId, setDraftTargetId] = useState<string | null>(null)
   const [taskDraft, setTaskDraft] = useState<TaskDraft | null>(null)
   const [savingTaskId, setSavingTaskId] = useState<string | null>(null)
-  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null)
+  const [pendingDeleteTaskId, setPendingDeleteTaskId] = useState<string | null>(
+    null
+  )
   const [movingTaskId, setMovingTaskId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -97,7 +104,7 @@ export function MemberWorkspaceProjectTasksEditor({
       buildTaskDraft({
         project,
         context: pendingCreateContext,
-      }),
+      })
     )
     onPendingCreateContextHandled?.()
   }, [onPendingCreateContextHandled, pendingCreateContext, project])
@@ -109,10 +116,10 @@ export function MemberWorkspaceProjectTasksEditor({
           [
             ...project.workstreams.map((workstream) => workstream.name.trim()),
             ...tasks.map((task) => task.workstreamName?.trim() ?? ""),
-          ].filter(Boolean),
-        ),
+          ].filter(Boolean)
+        )
       ),
-    [project.workstreams, tasks],
+    [project.workstreams, tasks]
   )
 
   const handleChangeDraftField = useCallback(
@@ -123,10 +130,10 @@ export function MemberWorkspaceProjectTasksEditor({
               ...currentDraft,
               [field]: value,
             }
-          : currentDraft,
+          : currentDraft
       )
     },
-    [],
+    []
   )
 
   const handleStartCreateTask = useCallback(
@@ -136,10 +143,10 @@ export function MemberWorkspaceProjectTasksEditor({
         buildTaskDraft({
           project,
           context,
-        }),
+        })
       )
     },
-    [project],
+    [project]
   )
 
   const handleStartEditTask = useCallback(
@@ -149,10 +156,10 @@ export function MemberWorkspaceProjectTasksEditor({
         buildTaskDraft({
           project,
           task,
-        }),
+        })
       )
     },
-    [project],
+    [project]
   )
 
   const handleCancelDraft = useCallback(() => {
@@ -188,7 +195,9 @@ export function MemberWorkspaceProjectTasksEditor({
         return
       }
 
-      toast.success(draftTargetId === NEW_TASK_ID ? "Task created" : "Task updated")
+      toast.success(
+        draftTargetId === NEW_TASK_ID ? "Task created" : "Task updated"
+      )
       handleCancelDraft()
       router.refresh()
     } finally {
@@ -203,34 +212,6 @@ export function MemberWorkspaceProjectTasksEditor({
     taskDraft,
     updateTaskAction,
   ])
-
-  const handleDeleteTask = useCallback(
-    async (taskId: string) => {
-      if (!deleteTaskAction) {
-        toast.error("Task deletion is unavailable.")
-        return
-      }
-
-      setDeletingTaskId(taskId)
-      try {
-        const result = await deleteTaskAction(taskId)
-        if ("error" in result) {
-          toast.error(result.error)
-          return
-        }
-
-        setTasks((currentTasks) => currentTasks.filter((task) => task.id !== taskId))
-        if (draftTargetId === taskId) {
-          handleCancelDraft()
-        }
-        toast.success("Task deleted")
-        router.refresh()
-      } finally {
-        setDeletingTaskId(null)
-      }
-    },
-    [deleteTaskAction, draftTargetId, handleCancelDraft, router],
-  )
 
   const handleMoveTask = useCallback(
     async (taskId: string, direction: -1 | 1) => {
@@ -253,7 +234,7 @@ export function MemberWorkspaceProjectTasksEditor({
       try {
         const result = await updateTaskOrderAction(
           project.id,
-          nextTasks.map((task) => task.id),
+          nextTasks.map((task) => task.id)
         )
 
         if ("error" in result) {
@@ -267,17 +248,18 @@ export function MemberWorkspaceProjectTasksEditor({
         setMovingTaskId(null)
       }
     },
-    [project.id, router, tasks, updateTaskOrderAction],
+    [project.id, router, tasks, updateTaskOrderAction]
   )
 
   return (
-    <section className="rounded-2xl border border-border bg-card p-4 shadow-sm sm:p-5">
+    <section className="border-border bg-card rounded-2xl border p-4 shadow-sm sm:p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-foreground">Tasks</h2>
-          <p className="text-sm leading-6 text-muted-foreground">
-            Task rows edit inline while the page stays in edit mode. Reordering uses
-            explicit up and down controls so the layout remains touch-friendly on mobile.
+          <h2 className="text-foreground text-base font-semibold">Tasks</h2>
+          <p className="text-muted-foreground text-sm leading-6">
+            Task rows edit inline while the page stays in edit mode. Reordering
+            uses explicit up and down controls so the layout remains
+            touch-friendly on mobile.
           </p>
         </div>
         <Button type="button" size="sm" onClick={() => handleStartCreateTask()}>
@@ -304,25 +286,24 @@ export function MemberWorkspaceProjectTasksEditor({
 
       <div className="mt-5 space-y-3">
         {tasks.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 px-4 py-8 text-sm text-muted-foreground">
+          <div className="border-border/70 bg-muted/20 text-muted-foreground rounded-2xl border border-dashed px-4 py-8 text-sm">
             No tasks yet. Add the first task inline without leaving the page.
           </div>
         ) : null}
 
         {tasks.map((task, index) => {
           const isEditingTask = draftTargetId === task.id && taskDraft
-          const isDeleting = deletingTaskId === task.id
           const isMoving = movingTaskId === task.id
 
           return (
             <article
               key={task.id}
-              className="rounded-2xl border border-border/70 bg-background/80 p-4"
+              className="border-border/70 bg-background/80 rounded-2xl border p-4"
             >
               <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+                    <h3 className="text-foreground min-w-0 flex-1 text-sm font-semibold">
                       {task.name}
                     </h3>
                     <TaskToneBadge
@@ -335,28 +316,38 @@ export function MemberWorkspaceProjectTasksEditor({
                       }
                     />
                     {task.workstreamName ? (
-                      <TaskToneBadge label={task.workstreamName} tone="outline" />
+                      <TaskToneBadge
+                        label={task.workstreamName}
+                        tone="outline"
+                      />
                     ) : null}
-                    {task.tag ? <TaskToneBadge label={task.tag} tone="outline" /> : null}
+                    {task.tag ? (
+                      <TaskToneBadge label={task.tag} tone="outline" />
+                    ) : null}
                   </div>
 
                   {task.description ? (
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                    <p className="text-muted-foreground mt-2 text-sm leading-6">
                       {task.description}
                     </p>
                   ) : null}
 
-                  <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+                  <div className="text-muted-foreground mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs">
                     <span>Start {formatTaskDateLabel(task.startDate)}</span>
-                    <span>Due {formatTaskDateLabel(task.endDate ?? task.startDate)}</span>
                     <span>
-                      {task.assignee ? `Assignee ${task.assignee.name}` : "Unassigned"}
+                      Due {formatTaskDateLabel(task.endDate ?? task.startDate)}
+                    </span>
+                    <span>
+                      {task.assignee
+                        ? `Assignee ${task.assignee.name}`
+                        : "Unassigned"}
                     </span>
                     <span>
                       Priority{" "}
                       {!task.priority || task.priority === "no-priority"
                         ? "None"
-                        : task.priority.charAt(0).toUpperCase() + task.priority.slice(1)}
+                        : task.priority.charAt(0).toUpperCase() +
+                          task.priority.slice(1)}
                     </span>
                   </div>
                 </div>
@@ -395,11 +386,11 @@ export function MemberWorkspaceProjectTasksEditor({
                     type="button"
                     variant="destructive"
                     size="sm"
-                    disabled={isDeleting}
-                    onClick={() => handleDeleteTask(task.id)}
+                    disabled={!deleteTaskAction}
+                    onClick={() => setPendingDeleteTaskId(task.id)}
                   >
                     <Trash className="h-4 w-4" />
-                    {isDeleting ? "Deleting..." : "Delete"}
+                    Delete
                   </Button>
                 </div>
               </div>
@@ -412,7 +403,11 @@ export function MemberWorkspaceProjectTasksEditor({
                   isSaving={savingTaskId === task.id}
                   onCancel={handleCancelDraft}
                   onChangeDraftField={handleChangeDraftField}
-                  onDelete={() => handleDeleteTask(task.id)}
+                  onDelete={
+                    deleteTaskAction
+                      ? () => setPendingDeleteTaskId(task.id)
+                      : undefined
+                  }
                   onSave={handleSaveTask}
                   workstreamSuggestions={workstreamSuggestions}
                 />
@@ -421,6 +416,22 @@ export function MemberWorkspaceProjectTasksEditor({
           )
         })}
       </div>
+
+      <MemberWorkspaceProjectTaskDeleteDialog
+        deleteTaskAction={deleteTaskAction}
+        task={tasks.find((task) => task.id === pendingDeleteTaskId) ?? null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDeleteTaskId(null)
+        }}
+        onDeleted={(taskId) => {
+          setTasks((currentTasks) =>
+            currentTasks.filter((task) => task.id !== taskId)
+          )
+          if (draftTargetId === taskId) handleCancelDraft()
+          setPendingDeleteTaskId(null)
+          router.refresh()
+        }}
+      />
     </section>
   )
 }

--- a/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
@@ -12,6 +12,7 @@ import type {
   MemberWorkspacePersonOption,
   MemberWorkspaceProjectOrganizationOption,
   MemberWorkspaceStorageMode,
+  MemberWorkspaceWorkstreamCategory,
 } from "../../types"
 import { MemberWorkspaceProjectBoardView } from "./member-workspace-project-board-view"
 import { MemberWorkspaceProjectCardsView } from "./member-workspace-project-cards-view"
@@ -60,6 +61,24 @@ export function MemberWorkspaceProjectsPage(props: {
   organizationOptions: MemberWorkspaceProjectOrganizationOption[]
   assigneeOptions: MemberWorkspacePersonOption[]
   scope: "organization" | "platform-admin"
+  workstreamCategories?: MemberWorkspaceWorkstreamCategory[]
+  createWorkstreamCategoryAction?: (
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  updateWorkstreamCategoryAction?: (
+    categoryId: string,
+    name: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  deleteWorkstreamCategoryAction?: (
+    categoryId: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
+  restoreWorkstreamDefaultsAction?: () => Promise<
+    { ok: true } | { error: string }
+  >
+  updateProjectWorkstreamAction?: (
+    projectId: string,
+    categoryId: string
+  ) => Promise<{ ok: true; id: string } | { error: string }>
 }) {
   const {
     projects,
@@ -74,6 +93,12 @@ export function MemberWorkspaceProjectsPage(props: {
     canCreateProjects,
     organizationOptions,
     scope,
+    workstreamCategories = [],
+    createWorkstreamCategoryAction,
+    updateWorkstreamCategoryAction,
+    deleteWorkstreamCategoryAction,
+    restoreWorkstreamDefaultsAction,
+    updateProjectWorkstreamAction,
   } = props
   const assigneeOptions = props.assigneeOptions ?? []
   const router = useRouter()
@@ -230,6 +255,12 @@ export function MemberWorkspaceProjectsPage(props: {
               showClosedProjects={viewOptions.showClosedProjects}
               visibleProperties={viewOptions.properties}
               updateProjectStatusAction={updateProjectStatusAction}
+              workstreamCategories={workstreamCategories}
+              createWorkstreamCategoryAction={createWorkstreamCategoryAction}
+              updateWorkstreamCategoryAction={updateWorkstreamCategoryAction}
+              deleteWorkstreamCategoryAction={deleteWorkstreamCategoryAction}
+              restoreWorkstreamDefaultsAction={restoreWorkstreamDefaultsAction}
+              updateProjectWorkstreamAction={updateProjectWorkstreamAction}
               onAddProject={
                 canCreateProjects
                   ? () => {

--- a/src/features/member-workspace/index.ts
+++ b/src/features/member-workspace/index.ts
@@ -28,6 +28,13 @@ export {
   loadMemberWorkspaceTasksPage,
 } from "./loaders"
 export {
+  createPlatformAdminWorkstreamCategoryAction,
+  deletePlatformAdminWorkstreamCategoryAction,
+  restorePlatformAdminWorkstreamDefaultsAction,
+  updatePlatformAdminProjectWorkstreamAction,
+  updatePlatformAdminWorkstreamCategoryAction,
+} from "./admin-workstream-actions"
+export {
   clearMemberWorkspaceStarterDataAction,
   createMemberWorkspaceProjectAction,
   deleteMemberWorkspaceProjectAction,
@@ -56,4 +63,5 @@ export type {
   MemberWorkspaceSection,
   MemberWorkspaceSetActiveOrganizationResult,
   MemberWorkspaceHeaderState,
+  MemberWorkspaceWorkstreamCategory,
 } from "./types"

--- a/src/features/member-workspace/server/admin-member-completeness.ts
+++ b/src/features/member-workspace/server/admin-member-completeness.ts
@@ -1,0 +1,32 @@
+function hasText(value: string | null) {
+  return Boolean(value?.trim())
+}
+
+export function buildAdminMemberCompleteness({
+  avatarUrl,
+  email,
+  headline,
+  name,
+}: {
+  avatarUrl: string | null
+  email: string | null
+  headline: string | null
+  name: string
+}) {
+  const fields = [
+    { label: "name", complete: hasText(name) && name !== "Unknown member" },
+    { label: "email", complete: hasText(email) },
+    { label: "headline", complete: hasText(headline) },
+    { label: "profile photo", complete: hasText(avatarUrl) },
+  ]
+  const completed = fields.filter((field) => field.complete).length
+
+  return {
+    profileCompletenessPercent: Math.round((completed / fields.length) * 100),
+    profileCompletedCount: completed,
+    profileTotalCount: fields.length,
+    profileMissingFields: fields
+      .filter((field) => !field.complete)
+      .map((field) => field.label),
+  }
+}

--- a/src/features/member-workspace/server/admin-organization-overview.ts
+++ b/src/features/member-workspace/server/admin-organization-overview.ts
@@ -8,12 +8,13 @@ import type {
   MemberWorkspaceAdminOrganizationMember,
   MemberWorkspaceAdminOrganizationSummary,
 } from "@/features/member-workspace/types"
-import type {
-  PlatformAdminDashboardLabPriority,
-  PlatformAdminDashboardLabProject,
-  PlatformAdminDashboardLabStatus,
-} from "@/features/platform-admin-dashboard"
+import type { PlatformAdminDashboardLabProject } from "@/features/platform-admin-dashboard"
 import { computeAdminOrganizationSetupSummary } from "./admin-organization-setup"
+import { buildAdminMemberCompleteness } from "./admin-member-completeness"
+import {
+  resolveAdminOrganizationProjectPriority,
+  resolveAdminOrganizationProjectStatus,
+} from "./admin-organization-project-state"
 import type { OrganizationProjectRecord } from "./project-starter-data"
 
 type ServerSupabase = Awaited<ReturnType<typeof createSupabaseServerClient>>
@@ -42,9 +43,14 @@ type ProfileRow = Pick<
 >
 
 type ProgramRow = {
+  id: string
   user_id: string
   title: string | null
   goal_cents: number | null
+  status_label: string | null
+  start_date: string | null
+  end_date: string | null
+  is_public: boolean
 }
 
 function toRecord(value: Json | null): Record<string, unknown> {
@@ -102,7 +108,9 @@ function resolveOrganizationOwner({
     toTrimmedString(organization.public_slug) ||
     "Organization owner"
   const avatarUrl =
-    toTrimmedString(ownerMember?.avatarUrl) || toTrimmedString(ownerProfile?.avatar_url) || null
+    toTrimmedString(ownerMember?.avatarUrl) ||
+    toTrimmedString(ownerProfile?.avatar_url) ||
+    null
 
   return { name, avatarUrl }
 }
@@ -139,26 +147,6 @@ function computeSetupSummary({
   })
 }
 
-function resolveProjectStatus({
-  organizationStatus,
-  setupProgress,
-}: {
-  organizationStatus: OrganizationRow["status"]
-  setupProgress: number
-}): PlatformAdminDashboardLabStatus {
-  if (setupProgress >= 100) return "completed"
-  if (organizationStatus === "approved" || setupProgress >= 65) return "active"
-  if (organizationStatus === "pending" || setupProgress >= 35) return "planned"
-  return "backlog"
-}
-
-function resolveProjectPriority(setupProgress: number): PlatformAdminDashboardLabPriority {
-  if (setupProgress < 35) return "urgent"
-  if (setupProgress < 60) return "high"
-  if (setupProgress < 85) return "medium"
-  return "low"
-}
-
 function buildSummaryTags({
   organization,
   setupProgress,
@@ -173,7 +161,7 @@ function buildSummaryTags({
       ? "approved"
       : organization.status === "pending"
         ? "pending"
-        : "setup",
+        : "setup"
   )
   if (organization.is_public) tags.add("public")
   if (setupProgress < 100) tags.add("onboarding")
@@ -196,49 +184,91 @@ function buildOrganizationMembers({
 
   if (memberships.length === 0 && orgPeople.length > 0) {
     return orgPeople
-      .map((person, index) => ({
-        userId:
-          toTrimmedString(person.id) ||
-          `${organization.user_id}-person-${index + 1}`,
-        name: toTrimmedString(person.name) || "Unknown member",
-        email: toTrimmedString(person.email) || null,
-        avatarUrl: toTrimmedString(person.image) || null,
-        headline: toTrimmedString(person.title) || null,
-        organizationRole: toTrimmedString(person.category) || "member",
-        platformRole: null,
-        isOwner: toTrimmedString(person.id) === organization.user_id,
-      }))
+      .map((person, index) => {
+        const name = toTrimmedString(person.name) || "Unknown member"
+        const email = toTrimmedString(person.email) || null
+        const avatarUrl = toTrimmedString(person.image) || null
+        const headline = toTrimmedString(person.title) || null
+
+        return {
+          userId:
+            toTrimmedString(person.id) ||
+            `${organization.user_id}-person-${index + 1}`,
+          name,
+          email,
+          avatarUrl,
+          headline,
+          organizationRole: toTrimmedString(person.category) || "member",
+          platformRole: null,
+          isOwner: toTrimmedString(person.id) === organization.user_id,
+          ...buildAdminMemberCompleteness({ avatarUrl, email, headline, name }),
+        }
+      })
       .sort((left, right) => {
-        const roleDiff = rolePriority(left.organizationRole) - rolePriority(right.organizationRole)
+        const roleDiff =
+          rolePriority(left.organizationRole) -
+          rolePriority(right.organizationRole)
         if (roleDiff !== 0) return roleDiff
         return left.name.localeCompare(right.name)
       })
   }
 
-  return memberships
-    .map((membership) => {
-      const profileRow = profilesById.get(membership.member_id) ?? null
-      const name =
-        toTrimmedString(profileRow?.full_name) ||
-        toTrimmedString(membership.member_email) ||
-        "Unknown member"
+  const membershipMembers = memberships.map((membership) => {
+    const profileRow = profilesById.get(membership.member_id) ?? null
+    const name =
+      toTrimmedString(profileRow?.full_name) ||
+      toTrimmedString(membership.member_email) ||
+      "Unknown member"
 
-      return {
-        userId: membership.member_id,
-        name,
-        email: toTrimmedString(profileRow?.email) || toTrimmedString(membership.member_email) || null,
-        avatarUrl: toTrimmedString(profileRow?.avatar_url) || null,
-        headline: toTrimmedString(profileRow?.headline) || null,
-        organizationRole: membership.role,
-        platformRole: profileRow?.role ?? null,
-        isOwner: membership.member_id === organization.user_id,
-      }
+    const email =
+      toTrimmedString(profileRow?.email) ||
+      toTrimmedString(membership.member_email) ||
+      null
+    const avatarUrl = toTrimmedString(profileRow?.avatar_url) || null
+    const headline = toTrimmedString(profileRow?.headline) || null
+
+    return {
+      userId: membership.member_id,
+      name,
+      email,
+      avatarUrl,
+      headline,
+      organizationRole: membership.role,
+      platformRole: profileRow?.role ?? null,
+      isOwner: membership.member_id === organization.user_id,
+      ...buildAdminMemberCompleteness({ avatarUrl, email, headline, name }),
+    }
+  })
+
+  if (!membershipMembers.some((member) => member.isOwner)) {
+    const ownerProfile = profilesById.get(organization.user_id) ?? null
+    const name =
+      toTrimmedString(ownerProfile?.full_name) ||
+      toTrimmedString(ownerProfile?.email) ||
+      "Organization owner"
+    const email = toTrimmedString(ownerProfile?.email) || null
+    const avatarUrl = toTrimmedString(ownerProfile?.avatar_url) || null
+    const headline = toTrimmedString(ownerProfile?.headline) || null
+
+    membershipMembers.push({
+      userId: organization.user_id,
+      name,
+      email,
+      avatarUrl,
+      headline,
+      organizationRole: "owner",
+      platformRole: ownerProfile?.role ?? null,
+      isOwner: true,
+      ...buildAdminMemberCompleteness({ avatarUrl, email, headline, name }),
     })
-    .sort((left, right) => {
-      const roleDiff = rolePriority(left.organizationRole) - rolePriority(right.organizationRole)
-      if (roleDiff !== 0) return roleDiff
-      return left.name.localeCompare(right.name)
-    })
+  }
+
+  return membershipMembers.sort((left, right) => {
+    const roleDiff =
+      rolePriority(left.organizationRole) - rolePriority(right.organizationRole)
+    if (roleDiff !== 0) return roleDiff
+    return left.name.localeCompare(right.name)
+  })
 }
 
 function buildOrganizationSummary({
@@ -265,7 +295,13 @@ function buildOrganizationSummary({
     ownerProfile,
     members,
   })
-  const { setupProgress, setupCompletedCount, setupTotalCount, missingSetupCount, setupItems } = computeSetupSummary({
+  const {
+    setupProgress,
+    setupCompletedCount,
+    setupTotalCount,
+    missingSetupCount,
+    setupItems,
+  } = computeSetupSummary({
     organization,
     memberCount: members.length,
     programs: programsByOrgId.get(organization.user_id) ?? [],
@@ -282,7 +318,8 @@ function buildOrganizationSummary({
     isPublic: Boolean(organization.is_public),
     createdAt: organization.created_at,
     updatedAt: organization.updated_at,
-    acceleratorProgress: acceleratorProgressByOrgId.get(organization.user_id)?.percent ?? 0,
+    acceleratorProgress:
+      acceleratorProgressByOrgId.get(organization.user_id)?.percent ?? 0,
     setupProgress,
     setupCompletedCount,
     setupTotalCount,
@@ -291,6 +328,18 @@ function buildOrganizationSummary({
     tags: buildSummaryTags({ organization, setupProgress }),
     members,
     setupItems,
+    programs: (programsByOrgId.get(organization.user_id) ?? []).map(
+      (program) => ({
+        id: program.id,
+        title: toTrimmedString(program.title) || "Untitled program",
+        statusLabel:
+          toTrimmedString(program.status_label) ||
+          (program.is_public ? "Published" : "Draft"),
+        startAt: program.start_date,
+        endAt: program.end_date,
+        isPublic: Boolean(program.is_public),
+      })
+    ),
     profile: toRecord(organization.profile),
   }
 }
@@ -311,7 +360,9 @@ async function loadProgramsByOrgId({
 
   const { data, error } = await supabase
     .from("programs")
-    .select("user_id, title, goal_cents")
+    .select(
+      "id, user_id, title, goal_cents, status_label, start_date, end_date, is_public"
+    )
     .in("user_id", uniqueIds)
     .returns<ProgramRow[]>()
 
@@ -349,7 +400,10 @@ async function loadProfilesById({
     .returns<ProfileRow[]>()
 
   if (error) {
-    throw supabaseErrorToError(error, "Unable to load platform member profiles.")
+    throw supabaseErrorToError(
+      error,
+      "Unable to load platform member profiles."
+    )
   }
 
   return new Map((data ?? []).map((profile) => [profile.id, profile] as const))
@@ -360,46 +414,57 @@ export async function loadAdminOrganizationSummaries({
 }: {
   supabase: ServerSupabase
 }) {
-  const [{ data: organizations, error: organizationsError }, { data: memberships, error: membershipsError }] =
-    await Promise.all([
-      supabase
-        .from("organizations")
-        .select("user_id, status, profile, created_at, updated_at, public_slug, is_public, location_lat, location_lng")
-        .order("updated_at", { ascending: false })
-        .returns<OrganizationRow[]>(),
-      supabase
-        .from("organization_memberships")
-        .select("org_id, member_id, role, member_email, created_at")
-        .returns<MembershipRow[]>(),
-    ])
+  const [
+    { data: organizations, error: organizationsError },
+    { data: memberships, error: membershipsError },
+  ] = await Promise.all([
+    supabase
+      .from("organizations")
+      .select(
+        "user_id, status, profile, created_at, updated_at, public_slug, is_public, location_lat, location_lng"
+      )
+      .order("updated_at", { ascending: false })
+      .returns<OrganizationRow[]>(),
+    supabase
+      .from("organization_memberships")
+      .select("org_id, member_id, role, member_email, created_at")
+      .returns<MembershipRow[]>(),
+  ])
 
   if (organizationsError) {
-    throw supabaseErrorToError(organizationsError, "Unable to load organizations.")
+    throw supabaseErrorToError(
+      organizationsError,
+      "Unable to load organizations."
+    )
   }
   if (membershipsError) {
-    throw supabaseErrorToError(membershipsError, "Unable to load organization memberships.")
+    throw supabaseErrorToError(
+      membershipsError,
+      "Unable to load organization memberships."
+    )
   }
 
   const organizationRows = organizations ?? []
   const membershipRows = memberships ?? []
-  const [profilesById, programsByOrgId, acceleratorProgressByOrgId] = await Promise.all([
-    loadProfilesById({
-      supabase,
-      ids: [
-        ...organizationRows.map((organization) => organization.user_id),
-        ...membershipRows.map((membership) => membership.member_id),
-      ],
-    }),
-    loadProgramsByOrgId({
-      supabase,
-      orgIds: organizationRows.map((organization) => organization.user_id),
-    }),
-    fetchAcceleratorProgressTotalsByUserId({
-      supabase,
-      userIds: organizationRows.map((organization) => organization.user_id),
-      isAdmin: false,
-    }),
-  ])
+  const [profilesById, programsByOrgId, acceleratorProgressByOrgId] =
+    await Promise.all([
+      loadProfilesById({
+        supabase,
+        ids: [
+          ...organizationRows.map((organization) => organization.user_id),
+          ...membershipRows.map((membership) => membership.member_id),
+        ],
+      }),
+      loadProgramsByOrgId({
+        supabase,
+        orgIds: organizationRows.map((organization) => organization.user_id),
+      }),
+      fetchAcceleratorProgressTotalsByUserId({
+        supabase,
+        userIds: organizationRows.map((organization) => organization.user_id),
+        isAdmin: false,
+      }),
+    ])
 
   const membershipsByOrgId = new Map<string, MembershipRow[]>()
   for (const membership of membershipRows) {
@@ -416,7 +481,7 @@ export async function loadAdminOrganizationSummaries({
         profilesById,
         programsByOrgId,
         acceleratorProgressByOrgId,
-      }),
+      })
     )
     .sort((left, right) => left.name.localeCompare(right.name))
 }
@@ -428,45 +493,59 @@ export async function loadAdminOrganizationSummaryById({
   supabase: ServerSupabase
   orgId: string
 }) {
-  const [{ data: organization, error: organizationError }, { data: memberships, error: membershipsError }] =
-    await Promise.all([
-      supabase
-        .from("organizations")
-        .select("user_id, status, profile, created_at, updated_at, public_slug, is_public, location_lat, location_lng")
-        .eq("user_id", orgId)
-        .maybeSingle<OrganizationRow>(),
-      supabase
-        .from("organization_memberships")
-        .select("org_id, member_id, role, member_email, created_at")
-        .eq("org_id", orgId)
-        .returns<MembershipRow[]>(),
-    ])
+  const [
+    { data: organization, error: organizationError },
+    { data: memberships, error: membershipsError },
+  ] = await Promise.all([
+    supabase
+      .from("organizations")
+      .select(
+        "user_id, status, profile, created_at, updated_at, public_slug, is_public, location_lat, location_lng"
+      )
+      .eq("user_id", orgId)
+      .maybeSingle<OrganizationRow>(),
+    supabase
+      .from("organization_memberships")
+      .select("org_id, member_id, role, member_email, created_at")
+      .eq("org_id", orgId)
+      .returns<MembershipRow[]>(),
+  ])
 
   if (organizationError) {
-    throw supabaseErrorToError(organizationError, "Unable to load organization.")
+    throw supabaseErrorToError(
+      organizationError,
+      "Unable to load organization."
+    )
   }
   if (!organization) {
     return null
   }
   if (membershipsError) {
-    throw supabaseErrorToError(membershipsError, "Unable to load organization memberships.")
+    throw supabaseErrorToError(
+      membershipsError,
+      "Unable to load organization memberships."
+    )
   }
 
-  const [profilesById, programsByOrgId, acceleratorProgressByOrgId] = await Promise.all([
-    loadProfilesById({
-      supabase,
-      ids: [organization.user_id, ...(memberships ?? []).map((membership) => membership.member_id)],
-    }),
-    loadProgramsByOrgId({
-      supabase,
-      orgIds: [organization.user_id],
-    }),
-    fetchAcceleratorProgressTotalsByUserId({
-      supabase,
-      userIds: [organization.user_id],
-      isAdmin: false,
-    }),
-  ])
+  const [profilesById, programsByOrgId, acceleratorProgressByOrgId] =
+    await Promise.all([
+      loadProfilesById({
+        supabase,
+        ids: [
+          organization.user_id,
+          ...(memberships ?? []).map((membership) => membership.member_id),
+        ],
+      }),
+      loadProgramsByOrgId({
+        supabase,
+        orgIds: [organization.user_id],
+      }),
+      fetchAcceleratorProgressTotalsByUserId({
+        supabase,
+        userIds: [organization.user_id],
+        isAdmin: false,
+      }),
+    ])
 
   return buildOrganizationSummary({
     organization,
@@ -478,7 +557,7 @@ export async function loadAdminOrganizationSummaryById({
 }
 
 export function mapAdminOrganizationSummaryToProject(
-  organization: MemberWorkspaceAdminOrganizationSummary,
+  organization: MemberWorkspaceAdminOrganizationSummary
 ): PlatformAdminDashboardLabProject {
   const now = new Date()
   const createdAt = new Date(organization.createdAt)
@@ -486,7 +565,7 @@ export function mapAdminOrganizationSummaryToProject(
     organization.setupProgress >= 100
       ? addDays(now, 14)
       : addDays(now, Math.max(21, organization.missingSetupCount * 7))
-  const status = resolveProjectStatus({
+  const status = resolveAdminOrganizationProjectStatus({
     organizationStatus: organization.organizationStatus,
     setupProgress: organization.setupProgress,
   })
@@ -497,11 +576,13 @@ export function mapAdminOrganizationSummaryToProject(
     projectKind: "organization_admin",
     name: organization.name,
     taskCount: organization.setupTotalCount,
-    progress: organization.acceleratorProgress,
+    progress: organization.setupProgress,
     startDate: createdAt,
     endDate,
     status,
-    priority: resolveProjectPriority(organization.setupProgress),
+    priority: resolveAdminOrganizationProjectPriority(
+      organization.setupProgress
+    ),
     tags: organization.tags,
     members: organization.members.slice(0, 4).map((member) => member.name),
     primaryPersonName: organization.ownerName,
@@ -533,7 +614,7 @@ export function mapAdminOrganizationSummaryToProject(
 }
 
 export function mapAdminOrganizationSummaryToProjectRecord(
-  organization: MemberWorkspaceAdminOrganizationSummary,
+  organization: MemberWorkspaceAdminOrganizationSummary
 ): OrganizationProjectRecord {
   const project = mapAdminOrganizationSummaryToProject(organization)
 

--- a/src/features/member-workspace/server/admin-organization-project-state.ts
+++ b/src/features/member-workspace/server/admin-organization-project-state.ts
@@ -1,0 +1,26 @@
+import type {
+  PlatformAdminDashboardLabPriority,
+  PlatformAdminDashboardLabStatus,
+} from "@/features/platform-admin-dashboard"
+
+export function resolveAdminOrganizationProjectStatus({
+  organizationStatus,
+  setupProgress,
+}: {
+  organizationStatus: "pending" | "approved" | "n/a"
+  setupProgress: number
+}): PlatformAdminDashboardLabStatus {
+  if (setupProgress >= 100) return "completed"
+  if (organizationStatus === "approved" || setupProgress >= 65) return "active"
+  if (organizationStatus === "pending" || setupProgress >= 35) return "planned"
+  return "backlog"
+}
+
+export function resolveAdminOrganizationProjectPriority(
+  setupProgress: number
+): PlatformAdminDashboardLabPriority {
+  if (setupProgress < 35) return "urgent"
+  if (setupProgress < 60) return "high"
+  if (setupProgress < 85) return "medium"
+  return "low"
+}

--- a/src/features/member-workspace/server/admin-projects.ts
+++ b/src/features/member-workspace/server/admin-projects.ts
@@ -47,7 +47,7 @@ function buildCanonicalAdminOrganizationProjectFields(
     duration_label: project.durationLabel ?? null,
     tags: project.tags,
     member_labels: project.members,
-    task_count: project.taskCount,
+    task_count: 0,
     created_source: "system",
   } as const
 }
@@ -65,11 +65,18 @@ export function buildCanonicalAdminOrganizationProject(
 function buildCanonicalAdminOrganizationProjectUpdate(
   organization: MemberWorkspaceAdminOrganizationSummary
 ): OrganizationProjectUpdate {
-  const { description: _description, ...syncedFields } =
-    buildCanonicalAdminOrganizationProjectFields(organization)
+  const desired = buildCanonicalAdminOrganizationProjectFields(organization)
 
   return {
-    ...syncedFields,
+    org_id: desired.org_id,
+    canonical_org_id: desired.canonical_org_id,
+    project_kind: desired.project_kind,
+    name: desired.name,
+    progress: desired.progress,
+    client_name: desired.client_name,
+    type_label: desired.type_label,
+    tags: desired.tags,
+    created_source: desired.created_source,
     updated_by: organization.orgId,
   }
 }
@@ -89,21 +96,11 @@ function canonicalAdminProjectNeedsRefresh({
       (desired.canonical_org_id ?? null) ||
     existing.project_kind !== desired.project_kind ||
     existing.name !== desired.name ||
-    existing.status !== desired.status ||
-    existing.priority !== desired.priority ||
     existing.progress !== desired.progress ||
-    existing.start_date !== desired.start_date ||
-    existing.end_date !== desired.end_date ||
     (existing.client_name ?? null) !== (desired.client_name ?? null) ||
     (existing.type_label ?? null) !== (desired.type_label ?? null) ||
-    (existing.duration_label ?? null) !== (desired.duration_label ?? null) ||
-    existing.task_count !== desired.task_count ||
     existing.created_source !== desired.created_source ||
-    !stringArraysEqual(existing.tags ?? [], desired.tags ?? []) ||
-    !stringArraysEqual(
-      existing.member_labels ?? [],
-      desired.member_labels ?? []
-    )
+    !stringArraysEqual(existing.tags ?? [], desired.tags ?? [])
   )
 }
 

--- a/src/features/member-workspace/server/admin-workstreams.ts
+++ b/src/features/member-workspace/server/admin-workstreams.ts
@@ -1,0 +1,460 @@
+import { revalidatePath } from "next/cache"
+
+import type { Database } from "@/lib/supabase"
+import type { MemberWorkspaceWorkstreamCategory } from "../types"
+import { resolveMemberWorkspaceActorContext } from "./member-workspace-actor-context"
+
+type CategoryRow =
+  Database["public"]["Tables"]["platform_admin_workstream_categories"]["Row"]
+type StateRow =
+  Database["public"]["Tables"]["platform_admin_project_workstream_states"]["Row"]
+type WorkstreamMutationResult = { ok: true; id: string } | { error: string }
+type WorkstreamRestoreResult = { ok: true } | { error: string }
+type PlatformAdminActor = Awaited<
+  ReturnType<typeof resolveMemberWorkspaceActorContext>
+>
+
+const DEFAULT_CATEGORIES = [
+  {
+    default_key: "backlog",
+    name: "New Intake",
+    color: "slate",
+    position: 0,
+  },
+  {
+    default_key: "planned",
+    name: "Coach Action",
+    color: "amber",
+    position: 1,
+  },
+  {
+    default_key: "waiting_on_organization",
+    name: "Waiting on Organization",
+    color: "rose",
+    position: 2,
+  },
+  {
+    default_key: "review_approval",
+    name: "Review & Approval",
+    color: "blue",
+    position: 3,
+  },
+  {
+    default_key: "active",
+    name: "Ongoing Support",
+    color: "violet",
+    position: 4,
+  },
+  {
+    default_key: "completed",
+    name: "Complete",
+    color: "emerald",
+    position: 5,
+  },
+] as const
+
+function isMissingTableError(error: unknown) {
+  const code = (error as { code?: string } | null)?.code
+  return code === "42P01" || code === "PGRST205"
+}
+
+function mapCategory(row: CategoryRow): MemberWorkspaceWorkstreamCategory {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    position: row.position,
+    defaultKey: row.default_key,
+  }
+}
+
+async function requirePlatformAdminActor(): Promise<
+  { ok: true; actor: PlatformAdminActor } | { ok: false; error: string }
+> {
+  const actor = await resolveMemberWorkspaceActorContext()
+  if (!actor.isAdmin) {
+    return {
+      ok: false,
+      error: "Only platform admins can manage workstream categories.",
+    }
+  }
+  return { ok: true, actor }
+}
+
+async function loadCategoryRows({
+  ownerId,
+  supabase,
+}: {
+  ownerId: string
+  supabase: Awaited<
+    ReturnType<typeof resolveMemberWorkspaceActorContext>
+  >["supabase"]
+}) {
+  return supabase
+    .from("platform_admin_workstream_categories")
+    .select(
+      "id, owner_id, name, color, position, default_key, created_at, updated_at"
+    )
+    .eq("owner_id", ownerId)
+    .order("position", { ascending: true })
+    .order("created_at", { ascending: true })
+    .returns<CategoryRow[]>()
+}
+
+async function ensureDefaultCategoryRows({
+  ownerId,
+  supabase,
+}: {
+  ownerId: string
+  supabase: Awaited<
+    ReturnType<typeof resolveMemberWorkspaceActorContext>
+  >["supabase"]
+}) {
+  const initial = await loadCategoryRows({ ownerId, supabase })
+  if (initial.error) {
+    if (isMissingTableError(initial.error)) return null
+    throw new Error("Unable to load workstream categories.")
+  }
+
+  const existingKeys = new Set(
+    (initial.data ?? []).map((row) => row.default_key).filter(Boolean)
+  )
+  const missingDefaults = DEFAULT_CATEGORIES.filter(
+    (category) => !existingKeys.has(category.default_key)
+  )
+
+  if (missingDefaults.length > 0) {
+    const { error } = await supabase
+      .from("platform_admin_workstream_categories")
+      .insert(
+        missingDefaults.map((category) => ({ owner_id: ownerId, ...category }))
+      )
+
+    if (error) {
+      if (isMissingTableError(error)) return null
+      throw new Error(
+        error.code === "23505"
+          ? "A custom category conflicts with a default workstream category."
+          : "Unable to create default workstream categories."
+      )
+    }
+  }
+
+  const refreshed = await loadCategoryRows({ ownerId, supabase })
+  if (refreshed.error) {
+    if (isMissingTableError(refreshed.error)) return null
+    throw new Error("Unable to load workstream categories.")
+  }
+
+  return refreshed.data ?? []
+}
+
+export async function loadPlatformAdminWorkstreamConfiguration({
+  actor,
+  projectIds,
+}: {
+  actor: PlatformAdminActor
+  projectIds: string[]
+}) {
+  if (!actor.isAdmin) return null
+  const categoryRows = await ensureDefaultCategoryRows({
+    ownerId: actor.userId,
+    supabase: actor.supabase,
+  })
+  if (!categoryRows) return null
+
+  const categories = categoryRows.map(mapCategory)
+  const uniqueProjectIds = Array.from(
+    new Set(projectIds.map((projectId) => projectId.trim()).filter(Boolean))
+  )
+
+  if (uniqueProjectIds.length === 0) {
+    return { categories, categoryIdByProjectId: new Map<string, string>() }
+  }
+
+  const { data, error } = await actor.supabase
+    .from("platform_admin_project_workstream_states")
+    .select(
+      "owner_id, project_id, category_id, started_at, created_at, updated_at"
+    )
+    .eq("owner_id", actor.userId)
+    .in("project_id", uniqueProjectIds)
+    .returns<StateRow[]>()
+
+  if (error) {
+    if (isMissingTableError(error)) return null
+    throw new Error("Unable to load organization workstream stages.")
+  }
+
+  return {
+    categories,
+    categoryIdByProjectId: new Map(
+      (data ?? []).map((row) => [row.project_id, row.category_id] as const)
+    ),
+  }
+}
+
+function normalizeCategoryName(
+  value: string
+): { ok: true; name: string } | { ok: false; error: string } {
+  const name = value.trim().replace(/\s+/g, " ")
+  if (!name) return { ok: false, error: "Category name is required." }
+  if (name.length > 48) {
+    return {
+      ok: false,
+      error: "Category names must be 48 characters or fewer.",
+    }
+  }
+  return { ok: true, name }
+}
+
+export async function createPlatformAdminWorkstreamCategoryAction(
+  name: string
+): Promise<WorkstreamMutationResult> {
+  "use server"
+
+  const resolved = await requirePlatformAdminActor()
+  if (!resolved.ok) return { error: resolved.error }
+  const normalized = normalizeCategoryName(name)
+  if (!normalized.ok) return { error: normalized.error }
+  const { actor } = resolved
+
+  const { data: lastCategory, error: positionError } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .select("position")
+    .eq("owner_id", actor.userId)
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle<{ position: number }>()
+
+  if (positionError) return { error: "Unable to create category." } as const
+
+  const { data, error } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .insert({
+      owner_id: actor.userId,
+      name: normalized.name,
+      color: "violet",
+      position: (lastCategory?.position ?? -1) + 1,
+    })
+    .select("id")
+    .single<{ id: string }>()
+
+  if (error || !data) {
+    return {
+      error:
+        error?.code === "23505"
+          ? "A category with that name already exists."
+          : "Unable to create category.",
+    } as const
+  }
+
+  revalidatePath("/organizations")
+  return { ok: true as const, id: data.id }
+}
+
+export async function updatePlatformAdminWorkstreamCategoryAction(
+  categoryId: string,
+  name: string
+): Promise<WorkstreamMutationResult> {
+  "use server"
+
+  const resolved = await requirePlatformAdminActor()
+  if (!resolved.ok) return { error: resolved.error }
+  const normalized = normalizeCategoryName(name)
+  if (!normalized.ok) return { error: normalized.error }
+  const { actor } = resolved
+
+  const { data, error } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .update({ name: normalized.name })
+    .eq("id", categoryId)
+    .eq("owner_id", actor.userId)
+    .select("id")
+    .maybeSingle<{ id: string }>()
+
+  if (error || !data) {
+    return {
+      error:
+        error?.code === "23505"
+          ? "A category with that name already exists."
+          : "Unable to rename category.",
+    } as const
+  }
+
+  revalidatePath("/organizations")
+  return { ok: true as const, id: data.id }
+}
+
+export async function deletePlatformAdminWorkstreamCategoryAction(
+  categoryId: string
+): Promise<WorkstreamMutationResult> {
+  "use server"
+
+  const resolved = await requirePlatformAdminActor()
+  if (!resolved.ok) return { error: resolved.error }
+  const { actor } = resolved
+  const normalizedCategoryId = categoryId.trim()
+  if (!normalizedCategoryId) {
+    return { error: "Choose a category to delete." } as const
+  }
+
+  const { data: category, error: categoryError } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .select("id, default_key")
+    .eq("id", normalizedCategoryId)
+    .eq("owner_id", actor.userId)
+    .maybeSingle<{ id: string; default_key: string | null }>()
+
+  if (categoryError) return { error: "Unable to delete category." } as const
+  if (!category) {
+    return { error: "That category is no longer available." } as const
+  }
+  if (category.default_key) {
+    return {
+      error:
+        "Default workstream categories cannot be deleted. Rename them or restore their original names.",
+    } as const
+  }
+
+  const { data: deletedCategory, error } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .delete()
+    .eq("id", normalizedCategoryId)
+    .eq("owner_id", actor.userId)
+    .select("id")
+    .maybeSingle<{ id: string }>()
+
+  if (error) return { error: "Unable to delete category." } as const
+  if (!deletedCategory) {
+    return { error: "That category is no longer available." } as const
+  }
+
+  revalidatePath("/organizations")
+  return { ok: true as const, id: deletedCategory.id }
+}
+
+export async function restorePlatformAdminWorkstreamDefaultsAction(): Promise<WorkstreamRestoreResult> {
+  "use server"
+
+  const resolved = await requirePlatformAdminActor()
+  if (!resolved.ok) return { error: resolved.error }
+  const { actor } = resolved
+  const result = await loadCategoryRows({
+    ownerId: actor.userId,
+    supabase: actor.supabase,
+  })
+
+  if (result.error) {
+    return {
+      error: isMissingTableError(result.error)
+        ? "Workstream categories need the latest database migration."
+        : "Unable to load workstream categories.",
+    } as const
+  }
+
+  const rows = result.data ?? []
+  const defaultNames = new Set(
+    DEFAULT_CATEGORIES.map((category) => category.name.toLowerCase())
+  )
+  const conflictingCustomCategory = rows.find(
+    (row) => !row.default_key && defaultNames.has(row.name.trim().toLowerCase())
+  )
+  if (conflictingCustomCategory) {
+    return {
+      error: `Rename the custom “${conflictingCustomCategory.name}” category before restoring defaults.`,
+    } as const
+  }
+
+  const rowsByDefaultKey = new Map(
+    rows
+      .filter((row) => row.default_key)
+      .map((row) => [row.default_key, row] as const)
+  )
+  const missingDefaults = DEFAULT_CATEGORIES.filter(
+    (category) => !rowsByDefaultKey.has(category.default_key)
+  )
+  if (missingDefaults.length > 0) {
+    return {
+      error: `Default workstream categories are missing: ${missingDefaults
+        .map((category) => category.name)
+        .join(", ")}. Reload the page before restoring defaults.`,
+    } as const
+  }
+
+  const defaultPayload = DEFAULT_CATEGORIES.map((category) => ({
+    id: rowsByDefaultKey.get(category.default_key)!.id,
+    owner_id: actor.userId,
+    ...category,
+  }))
+  const { error } = await actor.supabase
+    .from("platform_admin_workstream_categories")
+    .upsert(defaultPayload, { onConflict: "id" })
+
+  if (error) {
+    return {
+      error:
+        error.code === "23505"
+          ? "A custom category now uses a default name. Rename it before restoring defaults."
+          : "Unable to restore default workstream categories.",
+    } as const
+  }
+
+  revalidatePath("/organizations")
+  return { ok: true as const }
+}
+
+export async function updatePlatformAdminProjectWorkstreamAction(
+  projectId: string,
+  categoryId: string
+): Promise<WorkstreamMutationResult> {
+  "use server"
+
+  const resolved = await requirePlatformAdminActor()
+  if (!resolved.ok) return { error: resolved.error }
+  const { actor } = resolved
+  const normalizedProjectId = projectId.trim()
+  const normalizedCategoryId = categoryId.trim()
+  if (!normalizedProjectId || !normalizedCategoryId) {
+    return { error: "Choose a project and category." } as const
+  }
+
+  const [{ data: project }, { data: category }] = await Promise.all([
+    actor.supabase
+      .from("organization_projects")
+      .select("id")
+      .eq("id", normalizedProjectId)
+      .maybeSingle<{ id: string }>(),
+    actor.supabase
+      .from("platform_admin_workstream_categories")
+      .select("id")
+      .eq("id", normalizedCategoryId)
+      .eq("owner_id", actor.userId)
+      .maybeSingle<{ id: string }>(),
+  ])
+
+  if (!project || !category) {
+    return {
+      error: "That project or category is no longer available.",
+    } as const
+  }
+
+  const now = new Date().toISOString()
+  const { error } = await actor.supabase
+    .from("platform_admin_project_workstream_states")
+    .upsert(
+      {
+        owner_id: actor.userId,
+        project_id: normalizedProjectId,
+        category_id: normalizedCategoryId,
+        started_at: now,
+        updated_at: now,
+      },
+      { onConflict: "owner_id,project_id" }
+    )
+
+  if (error) return { error: "Unable to move organization." } as const
+
+  revalidatePath("/organizations")
+  return { ok: true as const, id: normalizedProjectId }
+}

--- a/src/features/member-workspace/server/project-activity.ts
+++ b/src/features/member-workspace/server/project-activity.ts
@@ -1,0 +1,70 @@
+import { formatDistanceStrict } from "date-fns"
+
+import type { Database } from "@/lib/supabase"
+import type { ProjectActivityItem } from "@/features/platform-admin-dashboard"
+import { isMissingMemberWorkspaceTableError } from "./table-errors"
+import { resolveMemberWorkspaceActorContext } from "./member-workspace-actor-context"
+
+type ActivityRow =
+  Database["public"]["Tables"]["organization_project_activity_events"]["Row"]
+
+export async function loadOrganizationProjectActivity({
+  orgId,
+  projectId,
+  supabase,
+}: {
+  orgId: string
+  projectId: string
+  supabase: Awaited<
+    ReturnType<typeof resolveMemberWorkspaceActorContext>
+  >["supabase"]
+}): Promise<ProjectActivityItem[]> {
+  const { data, error } = await supabase
+    .from("organization_project_activity_events")
+    .select(
+      "id, org_id, project_id, entity_type, entity_id, event_type, title, from_status, to_status, actor_id, metadata, occurred_at"
+    )
+    .eq("org_id", orgId)
+    .or(`project_id.eq.${projectId},entity_type.eq.program`)
+    .order("occurred_at", { ascending: true })
+    .limit(200)
+    .returns<ActivityRow[]>()
+
+  if (error) {
+    if (
+      isMissingMemberWorkspaceTableError(
+        error,
+        "organization_project_activity_events"
+      )
+    ) {
+      return []
+    }
+    throw new Error("Unable to load organization activity.")
+  }
+
+  const previousByEntity = new Map<string, ActivityRow>()
+  const items = (data ?? []).map((row) => {
+    const entityKey = `${row.entity_type}:${row.entity_id}`
+    const previous = previousByEntity.get(entityKey)
+    previousByEntity.set(entityKey, row)
+    const previousDate = previous ? new Date(previous.occurred_at) : null
+    const currentDate = new Date(row.occurred_at)
+    const durationLabel =
+      previousDate && currentDate.getTime() >= previousDate.getTime()
+        ? formatDistanceStrict(previousDate, currentDate)
+        : null
+
+    return {
+      id: row.id,
+      entityType: row.entity_type as ProjectActivityItem["entityType"],
+      eventType: row.event_type,
+      title: row.title,
+      fromStatus: row.from_status,
+      toStatus: row.to_status,
+      occurredAt: currentDate,
+      durationLabel,
+    }
+  })
+
+  return items.reverse()
+}

--- a/src/features/member-workspace/server/project-detail-actions.ts
+++ b/src/features/member-workspace/server/project-detail-actions.ts
@@ -48,9 +48,6 @@ type OrganizationProjectQuickLinkInsert =
 type OrganizationProjectQuickLinkUpdate =
   Database["public"]["Tables"]["organization_project_quick_links"]["Update"]
 
-const PLATFORM_ADMIN_PROJECT_DETAIL_MUTATION_ERROR =
-  "Platform admins can view organization project details here, but cannot edit them."
-
 function normalizeProjectNoteTitle(value: string) {
   return value.trim()
 }
@@ -77,10 +74,6 @@ async function resolveProjectForDetailMutation({
 }): Promise<
   { ok: true; project: ProjectNoteMutationProjectRow } | { error: string }
 > {
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_PROJECT_DETAIL_MUTATION_ERROR }
-  }
-
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
@@ -104,13 +97,13 @@ async function resolveProjectForDetailMutation({
     return { error: "Unable to find that project." }
   }
 
-  if (project.org_id !== actor.activeOrg.orgId) {
+  if (!actor.isAdmin && project.org_id !== actor.activeOrg.orgId) {
     return {
       error: "You can only manage project details for the active organization.",
     }
   }
 
-  if (!actor.canEdit) {
+  if (!actor.isAdmin && !actor.canEdit) {
     return { error: "Only organization editors can manage project details." }
   }
 

--- a/src/features/member-workspace/server/project-detail-loader.ts
+++ b/src/features/member-workspace/server/project-detail-loader.ts
@@ -16,6 +16,7 @@ import { buildMemberWorkspaceProjectDetails } from "./project-detail-view-model"
 import { ensureStarterProjectsForOrg } from "./project-persistence"
 import { organizationProjectSelectFields } from "./project-select"
 import { loadProjectOverviewDocument } from "./project-overview-documents"
+import { loadOrganizationProjectActivity } from "./project-activity"
 import { type OrganizationProjectRecord } from "./project-starter-data"
 import { loadMemberWorkspacePersonOptionsForOrganizations } from "./person-options"
 import { ensureStarterTasksForOrg } from "./task-persistence"
@@ -404,6 +405,7 @@ async function buildReadyProjectDetailResult({
     quickLinks,
     assets,
     overviewDocument,
+    activity,
   ] = await Promise.all([
     loadMemberWorkspacePersonOptionsForOrganizations({
       orgIds: [project.org_id],
@@ -439,6 +441,11 @@ async function buildReadyProjectDetailResult({
       projectId: project.id,
       supabase: actor.supabase,
     }),
+    loadOrganizationProjectActivity({
+      orgId: project.org_id,
+      projectId: project.id,
+      supabase: actor.supabase,
+    }),
   ])
 
   return {
@@ -455,6 +462,7 @@ async function buildReadyProjectDetailResult({
       assets,
       assigneeOptions,
       overviewDocument,
+      activity,
     }),
   }
 }

--- a/src/features/member-workspace/server/project-detail-view-model.ts
+++ b/src/features/member-workspace/server/project-detail-view-model.ts
@@ -6,6 +6,7 @@ import type {
   NoteStatus,
   NoteType,
   ProjectDetails,
+  ProjectActivityItem,
   ProjectFile,
   ProjectMeta,
   ProjectNote,
@@ -410,6 +411,7 @@ export function buildMemberWorkspaceProjectDetails({
   assets,
   assigneeOptions = [],
   overviewDocument,
+  activity,
 }: {
   project: OrganizationProjectRecord
   tasks: MemberWorkspaceProjectTaskRecord[]
@@ -418,6 +420,7 @@ export function buildMemberWorkspaceProjectDetails({
   assets?: MemberWorkspaceProjectAssetRecord[]
   assigneeOptions?: MemberWorkspacePersonOption[]
   overviewDocument?: MemberWorkspaceProjectOverviewDocumentRecord | null
+  activity?: ProjectActivityItem[]
 }): ProjectDetails {
   const members = buildUsers(project.member_labels ?? [], assigneeOptions)
   const files = buildProjectFiles(assets ?? [])
@@ -452,6 +455,7 @@ export function buildMemberWorkspaceProjectDetails({
     quickLinks: explicitQuickLinks,
     files,
     notes: buildProjectNotes(notes ?? []),
+    activity: activity ?? [],
     source: mapOrganizationProjectToViewModel(project),
   }
 }

--- a/src/features/member-workspace/server/project-loaders.ts
+++ b/src/features/member-workspace/server/project-loaders.ts
@@ -20,6 +20,7 @@ import {
   isMissingOrganizationProjectsTableError,
   toMemberWorkspaceDataError,
 } from "./table-errors"
+import { loadPlatformAdminWorkstreamConfiguration } from "./admin-workstreams"
 
 async function loadAdminStandardOrganizationProjects({
   orgIds,
@@ -97,6 +98,7 @@ export async function loadMemberWorkspaceProjectsPage() {
         scope: "platform-admin" as const,
         organizationOptions,
         assigneeOptions,
+        workstreamCategories: [],
       }
     }
 
@@ -105,14 +107,52 @@ export async function loadMemberWorkspaceProjectsPage() {
         canonicalProjects,
         organizations,
       })
+    const organizationByProjectId = new Map(
+      organizationsWithProjectIds.map((organization) => [
+        organization.canonicalProjectId,
+        organization,
+      ])
+    )
+
+    const projects = [
+      ...canonicalProjects.map((project) => {
+        const viewModel = mapOrganizationProjectToViewModel(project)
+        const organization = organizationByProjectId.get(project.id)
+        if (!organization) return viewModel
+
+        return {
+          ...viewModel,
+          progress: organization.setupProgress,
+          primaryPersonName: organization.ownerName,
+          primaryPersonAvatarUrl: organization.ownerAvatarUrl,
+          taskSummaryLabel: "Tasks",
+        }
+      }),
+      ...standardProjects.map(mapOrganizationProjectToViewModel),
+    ]
+    const workstreamConfiguration =
+      await loadPlatformAdminWorkstreamConfiguration({
+        actor,
+        projectIds: projects.map((project) => project.id),
+      })
+    const workstreamCategories = workstreamConfiguration?.categories ?? []
+    const fallbackCategory = workstreamCategories[0] ?? null
+    const projectsWithWorkstreams = projects.map((project) => {
+      const storedCategoryId =
+        workstreamConfiguration?.categoryIdByProjectId.get(project.id)
+      const statusCategory = workstreamCategories.find(
+        (category) => category.defaultKey === project.status
+      )
+
+      return {
+        ...project,
+        workstreamCategoryId:
+          storedCategoryId ?? statusCategory?.id ?? fallbackCategory?.id,
+      }
+    })
 
     return {
-      projects: [
-        ...organizationsWithProjectIds.map(
-          mapAdminOrganizationSummaryToProject
-        ),
-        ...standardProjects.map(mapOrganizationProjectToViewModel),
-      ],
+      projects: projectsWithWorkstreams,
       storageMode: "custom" as const,
       starterProjectCount: 0,
       hasUserProjects:
@@ -122,6 +162,7 @@ export async function loadMemberWorkspaceProjectsPage() {
       scope: "platform-admin" as const,
       organizationOptions,
       assigneeOptions,
+      workstreamCategories,
     }
   }
 
@@ -176,6 +217,7 @@ export async function loadMemberWorkspaceProjectsPage() {
         scope: "organization" as const,
         organizationOptions,
         assigneeOptions,
+        workstreamCategories: [],
       }
     }
     throw toMemberWorkspaceDataError(
@@ -202,5 +244,6 @@ export async function loadMemberWorkspaceProjectsPage() {
     scope: "organization" as const,
     organizationOptions,
     assigneeOptions,
+    workstreamCategories: [],
   }
 }

--- a/src/features/member-workspace/server/table-errors.ts
+++ b/src/features/member-workspace/server/table-errors.ts
@@ -1,6 +1,9 @@
 import { supabaseErrorToError } from "@/lib/supabase/errors"
 
-function isMissingMemberWorkspaceTableError(error: unknown, tableName: string) {
+export function isMissingMemberWorkspaceTableError(
+  error: unknown,
+  tableName: string
+) {
   if (!error || typeof error !== "object") return false
   const record = error as Record<string, unknown>
   if (record.code === "42P01" || record.code === "PGRST205") return true

--- a/src/features/member-workspace/server/task-action-helpers.ts
+++ b/src/features/member-workspace/server/task-action-helpers.ts
@@ -21,9 +21,6 @@ export const VALID_TASK_PRIORITIES = new Set<
   NonNullable<MemberWorkspaceCreateTaskInput["priority"]>
 >(["no-priority", "low", "medium", "high", "urgent"])
 
-export const PLATFORM_ADMIN_TASK_MUTATION_ERROR =
-  "Platform admins can view organization tasks here, but cannot edit them."
-
 export function toDateOnly(input: string) {
   return new Date(`${input}T00:00:00.000Z`)
 }
@@ -75,10 +72,12 @@ export async function resolveTaskTargetProject({
     } as const
   }
 
-  if (
-    project.project_kind !== "standard" ||
-    project.created_source === "system"
-  ) {
+  const isStandardUserProject =
+    project.project_kind === "standard" && project.created_source !== "system"
+  const isCanonicalAdminProject =
+    actor.isAdmin && project.project_kind === "organization_admin"
+
+  if (!isStandardUserProject && !isCanonicalAdminProject) {
     return { error: "Choose a valid project." } as const
   }
 

--- a/src/features/member-workspace/server/task-actions.ts
+++ b/src/features/member-workspace/server/task-actions.ts
@@ -10,7 +10,6 @@ import type {
 import { ensureMemberWorkspaceFeatureAccess } from "./access"
 import { resolveMemberWorkspaceActorContext } from "./member-workspace-actor-context"
 import {
-  PLATFORM_ADMIN_TASK_MUTATION_ERROR,
   VALID_TASK_PRIORITIES,
   VALID_TASK_STATUSES,
   adjustProjectTaskCount,
@@ -45,13 +44,10 @@ export async function createMemberWorkspaceTaskAction(
   input: MemberWorkspaceCreateTaskInput
 ): Promise<MemberWorkspaceCreateTaskResult> {
   const actor = await resolveMemberWorkspaceActorContext()
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_TASK_MUTATION_ERROR }
-  }
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
-  if (!actor.canEdit) {
+  if (!actor.isAdmin && !actor.canEdit) {
     return { error: "You do not have access to create tasks." }
   }
 
@@ -170,13 +166,10 @@ export async function updateMemberWorkspaceTaskAction(
   input: MemberWorkspaceCreateTaskInput
 ): Promise<MemberWorkspaceUpdateTaskResult> {
   const actor = await resolveMemberWorkspaceActorContext()
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_TASK_MUTATION_ERROR }
-  }
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
-  if (!actor.canEdit) {
+  if (!actor.isAdmin && !actor.canEdit) {
     return { error: "You do not have access to edit tasks." }
   }
 
@@ -238,6 +231,16 @@ export async function updateMemberWorkspaceTaskAction(
     return projectResult
   }
   const { project } = projectResult
+
+  if (existingTask.project_id !== project.id) {
+    const existingProjectResult = await resolveTaskTargetProject({
+      actor,
+      projectId: existingTask.project_id,
+    })
+    if ("error" in existingProjectResult) {
+      return existingProjectResult
+    }
+  }
 
   const assigneeResult = await resolveAssignableUserId({
     actor,
@@ -327,13 +330,10 @@ export async function updateMemberWorkspaceTaskStatusAction(
   }
 
   const actor = await resolveMemberWorkspaceActorContext()
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_TASK_MUTATION_ERROR }
-  }
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
-  let canUpdateTask = actor.canEdit
+  let canUpdateTask = actor.isAdmin || actor.canEdit
 
   if (!canUpdateTask) {
     const { data: assignment, error: assignmentError } = await actor.supabase
@@ -360,17 +360,30 @@ export async function updateMemberWorkspaceTaskStatusAction(
     .select("id, org_id, project_id, status")
     .eq("id", normalizedTaskId)
 
-  const { data: task, error: taskError } = await taskQuery
-    .eq("org_id", actor.activeOrg.orgId)
-    .maybeSingle<{
-      id: string
-      org_id: string
-      project_id: string
-      status: string
-    }>()
+  const { data: task, error: taskError } = await (actor.isAdmin
+    ? taskQuery.maybeSingle<{
+        id: string
+        org_id: string
+        project_id: string
+        status: string
+      }>()
+    : taskQuery.eq("org_id", actor.activeOrg.orgId).maybeSingle<{
+        id: string
+        org_id: string
+        project_id: string
+        status: string
+      }>())
 
   if (taskError || !task) {
     return { error: "Task not found." }
+  }
+
+  const projectResult = await resolveTaskTargetProject({
+    actor,
+    projectId: task.project_id,
+  })
+  if ("error" in projectResult) {
+    return projectResult
   }
 
   if (task.status === nextStatus) {
@@ -403,14 +416,10 @@ export async function updateMemberWorkspaceTaskOrderAction(
   orderedTaskIds: string[]
 ): Promise<MemberWorkspaceUpdateTaskOrderResult> {
   const actor = await resolveMemberWorkspaceActorContext()
-
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_TASK_MUTATION_ERROR }
-  }
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
-  if (!actor.canEdit) {
+  if (!actor.isAdmin && !actor.canEdit) {
     return { error: "You do not have access to reorder tasks." }
   }
 
@@ -486,14 +495,10 @@ export async function deleteMemberWorkspaceTaskAction(
   taskId: string
 ): Promise<MemberWorkspaceDeleteTaskResult> {
   const actor = await resolveMemberWorkspaceActorContext()
-
-  if (actor.isAdmin) {
-    return { error: PLATFORM_ADMIN_TASK_MUTATION_ERROR }
-  }
   const featureAccess = ensureMemberWorkspaceFeatureAccess(actor)
   if (featureAccess) return featureAccess
 
-  if (!actor.canEdit) {
+  if (!actor.isAdmin && !actor.canEdit) {
     return { error: "You do not have access to delete tasks." }
   }
 
@@ -507,12 +512,26 @@ export async function deleteMemberWorkspaceTaskAction(
     .select("id, org_id, project_id")
     .eq("id", normalizedTaskId)
 
-  const { data: task, error: taskError } = await taskQuery
-    .eq("org_id", actor.activeOrg.orgId)
-    .maybeSingle<{ id: string; org_id: string; project_id: string }>()
+  const { data: task, error: taskError } = await (actor.isAdmin
+    ? taskQuery.maybeSingle<{
+        id: string
+        org_id: string
+        project_id: string
+      }>()
+    : taskQuery
+        .eq("org_id", actor.activeOrg.orgId)
+        .maybeSingle<{ id: string; org_id: string; project_id: string }>())
 
   if (taskError || !task) {
     return { error: "Task not found." }
+  }
+
+  const projectResult = await resolveTaskTargetProject({
+    actor,
+    projectId: task.project_id,
+  })
+  if ("error" in projectResult) {
+    return projectResult
   }
 
   const admin = createSupabaseAdminClient()

--- a/src/features/member-workspace/server/task-loaders.ts
+++ b/src/features/member-workspace/server/task-loaders.ts
@@ -21,29 +21,33 @@ import {
 type OrganizationTaskAssignmentRow =
   Database["public"]["Tables"]["organization_task_assignees"]["Row"]
 
-type TaskAssignmentQueryRow = Pick<OrganizationTaskAssignmentRow, "task_id" | "user_id"> & {
+type TaskAssignmentQueryRow = Pick<
+  OrganizationTaskAssignmentRow,
+  "task_id" | "user_id"
+> & {
   organization_tasks:
     | (OrganizationTaskRecord & {
-        organization_projects:
-          | {
-              id: string
-              name: string
-              client_name: string | null
-              status: string
-              priority: string
-              tags: string[] | null
-              member_labels: string[] | null
-              type_label: string | null
-              duration_label: string | null
-              start_date: string
-              end_date: string
-            }
-          | null
+        organization_projects: {
+          id: string
+          name: string
+          client_name: string | null
+          status: string
+          priority: string
+          tags: string[] | null
+          member_labels: string[] | null
+          type_label: string | null
+          duration_label: string | null
+          start_date: string
+          end_date: string
+        } | null
       })
     | null
 }
 
-function compareTaskItems(left: MemberWorkspaceTaskItem, right: MemberWorkspaceTaskItem) {
+function compareTaskItems(
+  left: MemberWorkspaceTaskItem,
+  right: MemberWorkspaceTaskItem
+) {
   const dateDiff = left.startDate.localeCompare(right.startDate)
   if (dateDiff !== 0) return dateDiff
   return left.title.localeCompare(right.title)
@@ -52,7 +56,7 @@ function compareTaskItems(left: MemberWorkspaceTaskItem, right: MemberWorkspaceT
 function mapTaskAssignmentRowsToItems(
   rows: TaskAssignmentQueryRow[],
   assigneeByTaskId: Map<string, TaskAssigneeProfile>,
-  canUpdate: boolean,
+  canUpdate: boolean
 ): MemberWorkspaceTaskItem[] {
   return rows
     .flatMap((row) => {
@@ -66,9 +70,12 @@ function mapTaskAssignmentRowsToItems(
           projectId: task.project_id,
           projectName: project?.name ?? "Unassigned Project",
           projectClient: project?.client_name ?? null,
-          projectStatus: (project?.status as MemberWorkspaceTaskItem["projectStatus"]) ?? "planned",
+          projectStatus:
+            (project?.status as MemberWorkspaceTaskItem["projectStatus"]) ??
+            "planned",
           projectPriority:
-            (project?.priority as MemberWorkspaceTaskItem["projectPriority"]) ?? "medium",
+            (project?.priority as MemberWorkspaceTaskItem["projectPriority"]) ??
+            "medium",
           projectTags: project?.tags ?? [],
           projectMembers: project?.member_labels ?? [],
           projectTypeLabel: project?.type_label ?? null,
@@ -82,7 +89,8 @@ function mapTaskAssignmentRowsToItems(
           startDate: task.start_date,
           endDate: task.end_date,
           priority:
-            (task.priority as MemberWorkspaceTaskItem["priority"]) ?? "no-priority",
+            (task.priority as MemberWorkspaceTaskItem["priority"]) ??
+            "no-priority",
           tagLabel: task.tag_label ?? null,
           workstreamName: task.workstream_name ?? null,
           assignee: assigneeByTaskId.get(task.id) ?? null,
@@ -110,27 +118,25 @@ type AdminTaskQueryRow = Pick<
   | "sort_order"
   | "created_source"
 > & {
-  organization_projects:
-    | {
-        id: string
-        name: string
-        client_name: string | null
-        status: string
-        priority: string
-        tags: string[] | null
-        member_labels: string[] | null
-        type_label: string | null
-        duration_label: string | null
-        start_date: string
-        end_date: string
-      }
-    | null
+  organization_projects: {
+    id: string
+    name: string
+    client_name: string | null
+    status: string
+    priority: string
+    tags: string[] | null
+    member_labels: string[] | null
+    type_label: string | null
+    duration_label: string | null
+    start_date: string
+    end_date: string
+  } | null
 }
 
 function mapAdminTaskRowsToItems(
   rows: AdminTaskQueryRow[],
   assigneeByTaskId: Map<string, TaskAssigneeProfile>,
-  canUpdate: boolean,
+  canUpdate: boolean
 ): MemberWorkspaceTaskItem[] {
   return rows
     .map((task) => {
@@ -140,9 +146,12 @@ function mapAdminTaskRowsToItems(
         projectId: task.project_id,
         projectName: project?.name ?? "Organization project",
         projectClient: project?.client_name ?? null,
-        projectStatus: (project?.status as MemberWorkspaceTaskItem["projectStatus"]) ?? "planned",
+        projectStatus:
+          (project?.status as MemberWorkspaceTaskItem["projectStatus"]) ??
+          "planned",
         projectPriority:
-          (project?.priority as MemberWorkspaceTaskItem["projectPriority"]) ?? "medium",
+          (project?.priority as MemberWorkspaceTaskItem["projectPriority"]) ??
+          "medium",
         projectTags: project?.tags ?? [],
         projectMembers: project?.member_labels ?? [],
         projectTypeLabel: project?.type_label ?? null,
@@ -156,7 +165,8 @@ function mapAdminTaskRowsToItems(
         startDate: task.start_date,
         endDate: task.end_date,
         priority:
-          (task.priority as MemberWorkspaceTaskItem["priority"]) ?? "no-priority",
+          (task.priority as MemberWorkspaceTaskItem["priority"]) ??
+          "no-priority",
         tagLabel: task.tag_label ?? null,
         workstreamName: task.workstream_name ?? null,
         assignee: assigneeByTaskId.get(task.id) ?? null,
@@ -170,24 +180,37 @@ export async function loadMemberWorkspaceTasksPage() {
   const actor = await resolveMemberWorkspaceActorContext()
 
   if (actor.isAdmin) {
-    const [{ data: orgRows, error: orgRowsError }, { data: detailRows, error: detailError }] =
-      await Promise.all([
-        actor.supabase
-          .from("organization_projects")
-          .select("org_id")
-          .returns<Array<Pick<OrganizationTaskRecord, "org_id">>>(),
-        actor.supabase
-          .from("organization_tasks")
-          .select(
-            "id, org_id, project_id, title, description, task_type, status, start_date, end_date, priority, tag_label, workstream_name, sort_order, created_source, organization_projects(id, name, client_name, status, priority, tags, member_labels, type_label, duration_label, start_date, end_date)",
-          )
-          .order("start_date", { ascending: true })
-          .order("sort_order", { ascending: true })
-          .returns<AdminTaskQueryRow[]>(),
-      ])
+    const [
+      { data: orgRows, error: orgRowsError },
+      { data: detailRows, error: detailError },
+      taskProjectScope,
+    ] = await Promise.all([
+      actor.supabase
+        .from("organization_projects")
+        .select("org_id")
+        .returns<Array<Pick<OrganizationTaskRecord, "org_id">>>(),
+      actor.supabase
+        .from("organization_tasks")
+        .select(
+          "id, org_id, project_id, title, description, task_type, status, start_date, end_date, priority, tag_label, workstream_name, sort_order, created_source, organization_projects(id, name, client_name, status, priority, tags, member_labels, type_label, duration_label, start_date, end_date)"
+        )
+        .order("start_date", { ascending: true })
+        .order("sort_order", { ascending: true })
+        .returns<AdminTaskQueryRow[]>(),
+      loadTaskProjectScope({
+        includeOrganizationAdmin: true,
+        supabase: actor.supabase,
+      }),
+    ])
 
-    if (orgRowsError && !isMissingOrganizationProjectsTableError(orgRowsError)) {
-      throw toMemberWorkspaceDataError(orgRowsError, "Unable to load task assignees.")
+    if (
+      orgRowsError &&
+      !isMissingOrganizationProjectsTableError(orgRowsError)
+    ) {
+      throw toMemberWorkspaceDataError(
+        orgRowsError,
+        "Unable to load task assignees."
+      )
     }
 
     if (detailError) {
@@ -201,25 +224,29 @@ export async function loadMemberWorkspaceTasksPage() {
           starterTaskCount: 0,
           hasAnyOrgTasks: false,
           canResetStarterData: false,
-          canManageTasks: false,
+          canManageTasks: true,
           scope: "platform-admin" as const,
           assigneeOptions: [],
           projectOptions: [],
         }
       }
-      throw toMemberWorkspaceDataError(detailError, "Unable to load workspace tasks.")
+      throw toMemberWorkspaceDataError(
+        detailError,
+        "Unable to load workspace tasks."
+      )
     }
 
-    const rows = detailRows ?? []
-    const adminOrgIds = Array.from(new Set((orgRows ?? []).map((row) => row.org_id)))
-    const [assigneeOptions, projectOptions, assigneeByTaskId] = await Promise.all([
+    const rows = (detailRows ?? []).filter((task) =>
+      taskProjectScope.projectIds.has(task.project_id)
+    )
+    const adminOrgIds = Array.from(
+      new Set((orgRows ?? []).map((row) => row.org_id))
+    )
+    const [assigneeOptions, assigneeByTaskId] = await Promise.all([
       loadMemberWorkspacePersonOptionsForOrganizations({
         orgIds: adminOrgIds,
         supabase: actor.supabase,
         includePlatformAdmins: true,
-      }),
-      loadTaskProjectScope({
-        supabase: actor.supabase,
       }),
       loadTaskAssigneeMap({
         supabase: actor.supabase,
@@ -229,16 +256,18 @@ export async function loadMemberWorkspaceTasksPage() {
 
     return {
       taskGroups: mapTaskRowsToGroups(
-        mapAdminTaskRowsToItems(rows, assigneeByTaskId, false),
+        mapAdminTaskRowsToItems(rows, assigneeByTaskId, true)
       ),
       storageMode: resolveMemberWorkspaceStorageMode(rows),
-      starterTaskCount: rows.filter((task) => task.created_source === "starter_seed").length,
+      starterTaskCount: rows.filter(
+        (task) => task.created_source === "starter_seed"
+      ).length,
       hasAnyOrgTasks: rows.length > 0,
       canResetStarterData: false,
-      canManageTasks: false,
+      canManageTasks: true,
       scope: "platform-admin" as const,
       assigneeOptions,
-      projectOptions: projectOptions.projectOptions,
+      projectOptions: taskProjectScope.projectOptions,
     }
   }
 
@@ -275,41 +304,47 @@ export async function loadMemberWorkspaceTasksPage() {
     }
   }
 
-  const [{ data: organizationTaskRows, error: organizationTasksError }, { data: assignedRows, error: assignedRowsError }] =
-    await Promise.all([
-      actor.supabase
-        .from("organization_tasks")
-        .select("id, project_id, created_source")
-        .eq("org_id", actor.activeOrg.orgId)
-        .neq("created_source", "system")
-        .returns<Array<Pick<OrganizationTaskRecord, "id" | "project_id" | "created_source">>>(),
-      actor.supabase
-        .from("organization_task_assignees")
-        .select(
-          "task_id, user_id, organization_tasks!inner(id, org_id, project_id, title, description, task_type, status, start_date, end_date, priority, tag_label, workstream_name, sort_order, created_source, starter_seed_key, starter_seed_version, created_by, updated_by, created_at, updated_at, organization_projects(id, name, client_name, status, priority, tags, member_labels, type_label, duration_label, start_date, end_date))",
-        )
-        .eq("org_id", actor.activeOrg.orgId)
-        .eq("user_id", actor.userId)
-        .returns<TaskAssignmentQueryRow[]>(),
-    ])
+  const [
+    { data: organizationTaskRows, error: organizationTasksError },
+    { data: assignedRows, error: assignedRowsError },
+  ] = await Promise.all([
+    actor.supabase
+      .from("organization_tasks")
+      .select("id, project_id, created_source")
+      .eq("org_id", actor.activeOrg.orgId)
+      .neq("created_source", "system")
+      .returns<
+        Array<
+          Pick<OrganizationTaskRecord, "id" | "project_id" | "created_source">
+        >
+      >(),
+    actor.supabase
+      .from("organization_task_assignees")
+      .select(
+        "task_id, user_id, organization_tasks!inner(id, org_id, project_id, title, description, task_type, status, start_date, end_date, priority, tag_label, workstream_name, sort_order, created_source, starter_seed_key, starter_seed_version, created_by, updated_by, created_at, updated_at, organization_projects(id, name, client_name, status, priority, tags, member_labels, type_label, duration_label, start_date, end_date))"
+      )
+      .eq("org_id", actor.activeOrg.orgId)
+      .eq("user_id", actor.userId)
+      .returns<TaskAssignmentQueryRow[]>(),
+  ])
 
   if (organizationTasksError) {
     if (isMissingOrganizationTasksTableError(organizationTasksError)) {
-        return {
-          taskGroups: [],
-          storageMode: "empty" as const,
-          starterTaskCount: 0,
-          hasAnyOrgTasks: false,
-          canResetStarterData: false,
-          canManageTasks: actor.canEdit,
-          scope: "organization" as const,
-          assigneeOptions,
-          projectOptions,
-        }
+      return {
+        taskGroups: [],
+        storageMode: "empty" as const,
+        starterTaskCount: 0,
+        hasAnyOrgTasks: false,
+        canResetStarterData: false,
+        canManageTasks: actor.canEdit,
+        scope: "organization" as const,
+        assigneeOptions,
+        projectOptions,
       }
-      throw toMemberWorkspaceDataError(
+    }
+    throw toMemberWorkspaceDataError(
       organizationTasksError,
-      "Unable to load workspace tasks.",
+      "Unable to load workspace tasks."
     )
   }
 
@@ -333,29 +368,29 @@ export async function loadMemberWorkspaceTasksPage() {
     }
     throw toMemberWorkspaceDataError(
       assignedRowsError,
-      "Unable to load assigned workspace tasks.",
+      "Unable to load assigned workspace tasks."
     )
   }
 
   const taskRows = (organizationTaskRows ?? []).filter((task) =>
-    projectIds.has(task.project_id),
+    projectIds.has(task.project_id)
   )
   const scopedAssignedRows = (assignedRows ?? []).filter((row) =>
-    projectIds.has(row.organization_tasks?.project_id ?? ""),
+    projectIds.has(row.organization_tasks?.project_id ?? "")
   )
   const assigneeByTaskId = new Map(
     scopedAssignedRows
       .map((row) => row.organization_tasks?.id)
       .filter((id): id is string => Boolean(id))
-      .map((taskId) => [taskId, actor.currentUser] as const),
+      .map((taskId) => [taskId, actor.currentUser] as const)
   )
   const taskItems = mapTaskAssignmentRowsToItems(
     scopedAssignedRows,
     assigneeByTaskId,
-    actor.canEdit,
+    actor.canEdit
   )
   const starterTaskCount = taskRows.filter(
-    (task) => task.created_source === "starter_seed",
+    (task) => task.created_source === "starter_seed"
   ).length
 
   return {

--- a/src/features/member-workspace/server/task-project-scope.ts
+++ b/src/features/member-workspace/server/task-project-scope.ts
@@ -5,7 +5,9 @@ import {
   toMemberWorkspaceDataError,
 } from "./table-errors"
 
-type ServerSupabaseClient = Awaited<ReturnType<typeof createSupabaseServerClient>>
+type ServerSupabaseClient = Awaited<
+  ReturnType<typeof createSupabaseServerClient>
+>
 
 export type TaskProjectOption = {
   id: string
@@ -13,24 +15,35 @@ export type TaskProjectOption = {
 }
 
 export async function loadTaskProjectScope({
+  includeOrganizationAdmin = false,
   orgId,
   supabase,
 }: {
+  includeOrganizationAdmin?: boolean
   orgId?: string
   supabase: ServerSupabaseClient
 }): Promise<{ projectIds: Set<string>; projectOptions: TaskProjectOption[] }> {
   let query = supabase
     .from("organization_projects")
-    .select("id, name")
-    .eq("project_kind", "standard")
-    .neq("created_source", "system")
+    .select("id, name, project_kind, created_source")
     .order("name", { ascending: true })
+
+  query = includeOrganizationAdmin
+    ? query.in("project_kind", ["standard", "organization_admin"])
+    : query.eq("project_kind", "standard").neq("created_source", "system")
 
   if (orgId) {
     query = query.eq("org_id", orgId)
   }
 
-  const { data, error } = await query.returns<Array<{ id: string; name: string }>>()
+  const { data, error } = await query.returns<
+    Array<{
+      id: string
+      name: string
+      project_kind: string
+      created_source: string
+    }>
+  >()
 
   if (error) {
     if (isMissingOrganizationProjectsTableError(error)) {
@@ -42,7 +55,13 @@ export async function loadTaskProjectScope({
     throw toMemberWorkspaceDataError(error, "Unable to load task projects.")
   }
 
-  const rows = data ?? []
+  const rows = (data ?? []).filter(
+    (project) =>
+      (project.project_kind === "standard" &&
+        project.created_source !== "system") ||
+      (includeOrganizationAdmin &&
+        project.project_kind === "organization_admin")
+  )
 
   return {
     projectIds: new Set(rows.map((project) => project.id)),

--- a/src/features/member-workspace/types.ts
+++ b/src/features/member-workspace/types.ts
@@ -45,6 +45,14 @@ export type MemberWorkspaceStorageMode =
   | "mixed"
   | "custom"
 
+export type MemberWorkspaceWorkstreamCategory = {
+  id: string
+  name: string
+  color: string
+  position: number
+  defaultKey: string | null
+}
+
 export type MemberWorkspaceTaskStatus = "todo" | "in-progress" | "done"
 
 export type MemberWorkspaceTaskType = "bug" | "improvement" | "task"
@@ -166,6 +174,19 @@ export type MemberWorkspaceAdminOrganizationMember = {
   organizationRole: string
   platformRole: string | null
   isOwner: boolean
+  profileCompletenessPercent?: number
+  profileCompletedCount?: number
+  profileTotalCount?: number
+  profileMissingFields?: string[]
+}
+
+export type MemberWorkspaceAdminOrganizationProgram = {
+  id: string
+  title: string
+  statusLabel: string
+  startAt: string | null
+  endAt: string | null
+  isPublic: boolean
 }
 
 export type MemberWorkspaceAdminOrganizationSetupItem = {
@@ -194,6 +215,7 @@ export type MemberWorkspaceAdminOrganizationSummary = {
   tags: string[]
   members: MemberWorkspaceAdminOrganizationMember[]
   setupItems: MemberWorkspaceAdminOrganizationSetupItem[]
+  programs?: MemberWorkspaceAdminOrganizationProgram[]
   profile: Record<string, unknown>
 }
 

--- a/src/features/platform-admin-dashboard/index.ts
+++ b/src/features/platform-admin-dashboard/index.ts
@@ -73,6 +73,7 @@ export type {
   KeyFeatures,
   NoteStatus,
   NoteType,
+  ProjectActivityItem,
   ProjectDetails,
   ProjectFile,
   ProjectMeta,

--- a/src/features/platform-admin-dashboard/types.ts
+++ b/src/features/platform-admin-dashboard/types.ts
@@ -14,9 +14,16 @@ export type PlatformAdminDashboardLabStatus =
   | "cancelled"
   | "completed"
 
-export type PlatformAdminDashboardLabPriority = "urgent" | "high" | "medium" | "low"
+export type PlatformAdminDashboardLabPriority =
+  | "urgent"
+  | "high"
+  | "medium"
+  | "low"
 
-export type PlatformAdminDashboardLabTaskStatus = "todo" | "in-progress" | "done"
+export type PlatformAdminDashboardLabTaskStatus =
+  | "todo"
+  | "in-progress"
+  | "done"
 
 export type PlatformAdminDashboardLabTask = {
   id: string
@@ -32,6 +39,7 @@ export type PlatformAdminDashboardLabProject = {
   id: string
   organizationId?: string
   projectKind?: "standard" | "organization_admin"
+  workstreamCategoryId?: string
   name: string
   description?: string
   taskCount: number

--- a/src/features/platform-admin-dashboard/upstream/components/projects/WorkstreamTab.tsx
+++ b/src/features/platform-admin-dashboard/upstream/components/projects/WorkstreamTab.tsx
@@ -1,7 +1,11 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { CaretDown, DotsSixVertical, Plus } from "@phosphor-icons/react/dist/ssr"
+import {
+  CaretDown,
+  DotsSixVertical,
+  Plus,
+} from "@phosphor-icons/react/dist/ssr"
 import {
   DndContext,
   type DragEndEvent,
@@ -21,11 +25,24 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
+import { toast } from "sonner"
 
-import type { WorkstreamGroup, WorkstreamTask } from "@/features/platform-admin-dashboard/upstream/lib/data/project-details"
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/features/platform-admin-dashboard/upstream/components/ui/accordion"
+import type {
+  WorkstreamGroup,
+  WorkstreamTask,
+} from "@/features/platform-admin-dashboard/upstream/lib/data/project-details"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/features/platform-admin-dashboard/upstream/components/ui/accordion"
 import { Button } from "@/features/platform-admin-dashboard/upstream/components/ui/button"
-import { Avatar, AvatarFallback, AvatarImage } from "@/features/platform-admin-dashboard/upstream/components/ui/avatar"
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/features/platform-admin-dashboard/upstream/components/ui/avatar"
 import { Separator } from "@/features/platform-admin-dashboard/upstream/components/ui/separator"
 import { ProgressCircle } from "@/features/platform-admin-dashboard/upstream/components/progress-circle"
 import { cn } from "@/features/platform-admin-dashboard/upstream/lib/utils"
@@ -37,6 +54,13 @@ type WorkstreamTabProps = {
   canReorder?: boolean
   canToggleTasks?: boolean
   onCreateTask?: (context?: CreateTaskContext) => void
+  onUpdateTaskStatus?: (
+    taskId: string,
+    nextStatus: WorkstreamTask["status"]
+  ) => Promise<
+    | { ok: true; taskId: string; status: WorkstreamTask["status"] }
+    | { error: string }
+  >
 }
 
 export function WorkstreamTab({
@@ -44,18 +68,22 @@ export function WorkstreamTab({
   canReorder = true,
   canToggleTasks = true,
   onCreateTask,
+  onUpdateTaskStatus,
 }: WorkstreamTabProps) {
   const [state, setState] = useState<WorkstreamGroup[]>(() => workstreams ?? [])
   const [openValues, setOpenValues] = useState<string[]>(() =>
-    workstreams && workstreams.length ? [workstreams[0].id] : [],
+    workstreams && workstreams.length ? [workstreams[0].id] : []
   )
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null)
   const [overTaskId, setOverTaskId] = useState<string | null>(null)
+  const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(
+    () => new Set()
+  )
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 6 },
-    }),
+    })
   )
 
   const allIds = useMemo(() => state.map((group) => group.id), [state])
@@ -71,28 +99,56 @@ export function WorkstreamTab({
 
   const activeTask = findTaskById(activeTaskId)
 
-  const toggleTask = (groupId: string, taskId: string) => {
-    if (!canToggleTasks) {
+  const toggleTask = async (groupId: string, taskId: string) => {
+    if (!canToggleTasks || !onUpdateTaskStatus || pendingTaskIds.has(taskId)) {
       return
     }
 
-    setState((prev) =>
-      prev.map((group) =>
-        group.id === groupId
-          ? {
-            ...group,
-            tasks: group.tasks.map((task) =>
-              task.id === taskId
-                ? {
-                  ...task,
-                  status: task.status === "done" ? "todo" : "done",
-                }
-                : task,
-            ),
-          }
-          : group,
-      ),
-    )
+    const currentTask = state
+      .find((group) => group.id === groupId)
+      ?.tasks.find((task) => task.id === taskId)
+    if (!currentTask) return
+
+    const previousStatus = currentTask.status
+    const nextStatus = previousStatus === "done" ? "todo" : "done"
+    const setTaskStatus = (status: WorkstreamTask["status"]) => {
+      setState((currentGroups) =>
+        currentGroups.map((group) =>
+          group.id === groupId
+            ? {
+                ...group,
+                tasks: group.tasks.map((task) =>
+                  task.id === taskId ? { ...task, status } : task
+                ),
+              }
+            : group
+        )
+      )
+    }
+
+    setTaskStatus(nextStatus)
+    setPendingTaskIds((currentIds) => new Set(currentIds).add(taskId))
+
+    try {
+      const result = await onUpdateTaskStatus(taskId, nextStatus)
+      if ("error" in result) {
+        setTaskStatus(previousStatus)
+        toast.error(result.error)
+        return
+      }
+
+      setTaskStatus(result.status)
+      toast.success(nextStatus === "done" ? "Task completed" : "Task reopened")
+    } catch {
+      setTaskStatus(previousStatus)
+      toast.error("Task status could not be updated.")
+    } finally {
+      setPendingTaskIds((currentIds) => {
+        const nextIds = new Set(currentIds)
+        nextIds.delete(taskId)
+        return nextIds
+      })
+    }
   }
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -160,7 +216,11 @@ export function WorkstreamTab({
 
       // Reorder within the same workstream
       if (sourceGroupIndex === targetGroupIndex) {
-        const reordered = arrayMove(sourceGroup.tasks, sourceTaskIndex, targetTaskIndex)
+        const reordered = arrayMove(
+          sourceGroup.tasks,
+          sourceTaskIndex,
+          targetTaskIndex
+        )
         next[sourceGroupIndex] = { ...sourceGroup, tasks: reordered }
         return next
       }
@@ -188,10 +248,10 @@ export function WorkstreamTab({
   if (!state.length) {
     return (
       <section>
-        <h2 className="text-sm font-semibold tracking-normal text-foreground uppercase">
-          WORKSTEAM BREAKDOWN
+        <h2 className="text-foreground text-sm font-semibold tracking-normal uppercase">
+          WORKSTREAM BREAKDOWN
         </h2>
-        <div className="mt-4 rounded-lg border border-dashed border-border/70 p-6 text-sm text-muted-foreground">
+        <div className="border-border/70 text-muted-foreground mt-4 rounded-lg border border-dashed p-6 text-sm">
           No workstreams defined yet.
         </div>
       </section>
@@ -201,12 +261,12 @@ export function WorkstreamTab({
   const canCreateTask = Boolean(onCreateTask)
 
   return (
-    <section className="rounded-2xl border border-border bg-muted shadow-[var(--shadow-workstream)] p-3 space-y-3">
+    <section className="border-border bg-muted space-y-3 rounded-2xl border p-3 shadow-[var(--shadow-workstream)]">
       <div className="flex items-center justify-between gap-3 px-2">
-        <h2 className="flex-1 min-w-0 truncate text-sm font-semibold tracking-normal text-foreground uppercase">
-          WORKSTEAM BREAKDOWN
+        <h2 className="text-foreground min-w-0 flex-1 truncate text-sm font-semibold tracking-normal uppercase">
+          WORKSTREAM BREAKDOWN
         </h2>
-        <div className="flex items-center gap-1 opacity-60 shrink-0">
+        <div className="flex shrink-0 items-center gap-1 opacity-60">
           <Button
             variant="ghost"
             size="icon-sm"
@@ -243,27 +303,37 @@ export function WorkstreamTab({
             type="multiple"
             value={openValues}
             onValueChange={(values) =>
-              setOpenValues(Array.isArray(values) ? values : values ? [values] : [])
+              setOpenValues(
+                Array.isArray(values) ? values : values ? [values] : []
+              )
             }
           >
             {state.map((group) => (
               <AccordionItem
                 key={group.id}
                 value={group.id}
-                className="mb-2 overflow-hidden rounded-xl border border-border bg-background last:mb-0"
+                className="border-border bg-background mb-2 overflow-hidden rounded-xl border last:mb-0"
               >
                 <AccordionTrigger className="bg-background">
                   <div className="flex w-full items-center justify-between gap-2">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <CaretDown className="h-4 w-4 text-muted-foreground hover:cursor-pointer" aria-hidden="true" />
-                      <span className="flex-1 truncate text-left text-sm font-medium text-foreground hover:cursor-pointer">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <CaretDown
+                        className="text-muted-foreground h-4 w-4 hover:cursor-pointer"
+                        aria-hidden="true"
+                      />
+                      <span className="text-foreground flex-1 truncate text-left text-sm font-medium hover:cursor-pointer">
                         {group.name}
                       </span>
                     </div>
-                    <div className="hidden sm:flex items-center gap-2 text-xs text-muted-foreground shrink-0">
+                    <div className="text-muted-foreground hidden shrink-0 items-center gap-2 text-xs sm:flex">
                       {canCreateTask ? (
                         <>
-                          <Button asChild size="icon-sm" variant="ghost" className="size-6 rounded-md">
+                          <Button
+                            asChild
+                            size="icon-sm"
+                            variant="ghost"
+                            className="size-6 rounded-md"
+                          >
                             <span
                               role="button"
                               aria-label="Add task"
@@ -291,7 +361,9 @@ export function WorkstreamTab({
                   activeTaskId={activeTaskId}
                   overTaskId={overTaskId}
                   canReorder={canReorder}
-                  onToggleTask={(taskId) => toggleTask(group.id, taskId)}
+                  canToggleTasks={canToggleTasks && Boolean(onUpdateTaskStatus)}
+                  pendingTaskIds={pendingTaskIds}
+                  onToggleTask={(taskId) => void toggleTask(group.id, taskId)}
                 />
               </AccordionItem>
             ))}
@@ -299,8 +371,10 @@ export function WorkstreamTab({
 
           <DragOverlay>
             {activeTask ? (
-              <div className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm bg-background shadow-md">
-                <span className="flex-1 truncate text-left">{activeTask.name}</span>
+              <div className="bg-background flex items-center gap-3 rounded-lg px-3 py-2 text-sm shadow-md">
+                <span className="flex-1 truncate text-left">
+                  {activeTask.name}
+                </span>
               </div>
             ) : null}
           </DragOverlay>
@@ -322,7 +396,7 @@ function GroupSummary({ group }: GroupSummaryProps) {
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground">
+      <span className="text-muted-foreground text-xs">
         {done}/{total}
       </span>
       <ProgressCircle progress={percent} color={color} size={18} />
@@ -342,6 +416,8 @@ type WorkstreamTasksProps = {
   activeTaskId: string | null
   overTaskId: string | null
   canReorder?: boolean
+  canToggleTasks: boolean
+  pendingTaskIds: Set<string>
   onToggleTask: (taskId: string) => void
 }
 
@@ -350,13 +426,18 @@ function WorkstreamTasks({
   activeTaskId,
   overTaskId,
   canReorder = true,
+  canToggleTasks,
+  pendingTaskIds,
   onToggleTask,
 }: WorkstreamTasksProps) {
   const { setNodeRef } = useDroppable({ id: `group:${group.id}` })
 
   return (
-    <AccordionContent className="border-t border-border bg-background/60 px-1.5">
-      <SortableContext items={group.tasks.map((task) => task.id)} strategy={verticalListSortingStrategy}>
+    <AccordionContent className="border-border bg-background/60 border-t px-1.5">
+      <SortableContext
+        items={group.tasks.map((task) => task.id)}
+        strategy={verticalListSortingStrategy}
+      >
         <div ref={setNodeRef} className="space-y-1 py-2">
           {group.tasks.map((task) => (
             <TaskRow
@@ -366,6 +447,7 @@ function WorkstreamTasks({
               activeTaskId={activeTaskId}
               overTaskId={overTaskId}
               canReorder={canReorder}
+              canToggle={canToggleTasks && !pendingTaskIds.has(task.id)}
             />
           ))}
         </div>
@@ -380,6 +462,7 @@ type TaskRowProps = {
   activeTaskId: string | null
   overTaskId: string | null
   canReorder?: boolean
+  canToggle: boolean
 }
 
 function TaskRow({
@@ -388,10 +471,19 @@ function TaskRow({
   activeTaskId,
   overTaskId,
   canReorder = true,
+  canToggle,
 }: TaskRowProps) {
   const isDone = task.status === "done"
 
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging, isOver } = useSortable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({
     id: task.id,
     disabled: !canReorder,
   })
@@ -405,9 +497,10 @@ function TaskRow({
 
   return (
     <div ref={setNodeRef} style={style} className="space-y-1">
-      {showDropLine && <div className="h-px w-full rounded-full bg-primary" />}
+      {showDropLine && <div className="bg-primary h-px w-full rounded-full" />}
       <TaskRowBase
         checked={isDone}
+        disabled={!canToggle}
         title={task.name}
         onCheckedChange={onToggle}
         titleAriaLabel={task.name}
@@ -418,7 +511,7 @@ function TaskRow({
                 className={cn(
                   "text-muted-foreground",
                   task.dueTone === "danger" && "text-red-500",
-                  task.dueTone === "warning" && "text-amber-500",
+                  task.dueTone === "warning" && "text-amber-500"
                 )}
               >
                 {task.dueLabel}
@@ -427,9 +520,14 @@ function TaskRow({
             {task.assignee && (
               <Avatar className="size-6">
                 {task.assignee.avatarUrl && (
-                  <AvatarImage src={task.assignee.avatarUrl} alt={task.assignee.name} />
+                  <AvatarImage
+                    src={task.assignee.avatarUrl}
+                    alt={task.assignee.name}
+                  />
                 )}
-                <AvatarFallback>{task.assignee.name.charAt(0).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>
+                  {task.assignee.name.charAt(0).toUpperCase()}
+                </AvatarFallback>
               </Avatar>
             )}
             {canReorder ? (
@@ -437,7 +535,7 @@ function TaskRow({
                 type="button"
                 size="icon-sm"
                 variant="ghost"
-                className="size-7 rounded-md text-muted-foreground cursor-grab active:cursor-grabbing"
+                className="text-muted-foreground size-7 cursor-grab rounded-md active:cursor-grabbing"
                 aria-label="Reorder task"
                 onClick={(event) => event.stopPropagation()}
                 onKeyDown={(event) => event.stopPropagation()}

--- a/src/features/platform-admin-dashboard/upstream/components/tasks/TaskRowBase.tsx
+++ b/src/features/platform-admin-dashboard/upstream/components/tasks/TaskRowBase.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/features/platform-admin-dashboard/upstream/lib/utils"
 
 export type TaskRowBaseProps = {
   checked: boolean
+  disabled?: boolean
   title: string
   onCheckedChange?: () => void
   titleAriaLabel?: string
@@ -18,6 +19,7 @@ export type TaskRowBaseProps = {
 
 export function TaskRowBase({
   checked,
+  disabled = false,
   title,
   onCheckedChange,
   titleAriaLabel,
@@ -29,24 +31,25 @@ export function TaskRowBase({
   return (
     <div
       className={cn(
-        "flex items-center gap-3 rounded-lg px-3 py-2 text-sm hover:bg-muted/60",
-        className,
+        "hover:bg-muted/60 flex items-center gap-3 rounded-lg px-3 py-2 text-sm",
+        className
       )}
     >
       <Checkbox
         checked={checked}
+        disabled={disabled}
         onCheckedChange={onCheckedChange}
         onClick={(event) => event.stopPropagation()}
         onKeyDown={(event) => event.stopPropagation()}
         aria-label={titleAriaLabel ?? title}
-        className="rounded-full border-border bg-background data-[state=checked]:border-teal-600 data-[state=checked]:bg-teal-600 hover:cursor-pointer"
+        className="border-border bg-background rounded-full enabled:hover:cursor-pointer data-[state=checked]:border-teal-600 data-[state=checked]:bg-teal-600"
       />
-      <div className="flex-1 min-w-0">
+      <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span
             className={cn(
-              "flex-1 truncate text-left max-w-[60vw] sm:max-w-none",
-              checked && "line-through text-muted-foreground",
+              "max-w-[60vw] flex-1 truncate text-left sm:max-w-none",
+              checked && "text-muted-foreground line-through"
             )}
           >
             {title}
@@ -56,15 +59,15 @@ export function TaskRowBase({
         {subtitle && (
           <div
             className={cn(
-              "mt-0.5 text-xs text-muted-foreground truncate",
-              checked && "line-through opacity-70",
+              "text-muted-foreground mt-0.5 truncate text-xs",
+              checked && "line-through opacity-70"
             )}
           >
             {subtitle}
           </div>
         )}
       </div>
-      <div className="flex items-center gap-3 text-xs shrink-0 ml-2">
+      <div className="ml-2 flex shrink-0 items-center gap-3 text-xs">
         {meta}
       </div>
     </div>

--- a/src/features/platform-admin-dashboard/upstream/lib/data/project-details.ts
+++ b/src/features/platform-admin-dashboard/upstream/lib/data/project-details.ts
@@ -109,6 +109,17 @@ export type ProjectFile = QuickLink & {
   attachments?: QuickLink[]
 }
 
+export type ProjectActivityItem = {
+  id: string
+  entityType: "project" | "task" | "program" | "fiscal_application"
+  eventType: string
+  title: string
+  fromStatus: string | null
+  toStatus: string | null
+  occurredAt: Date
+  durationLabel: string | null
+}
+
 export type NoteType = "general" | "meeting" | "audio"
 export type NoteStatus = "completed" | "processing"
 
@@ -155,6 +166,7 @@ export type ProjectDetails = {
   quickLinks: QuickLink[]
   files: ProjectFile[]
   notes: ProjectNote[]
+  activity?: ProjectActivityItem[]
   source?: ProjectListItem
 }
 

--- a/src/lib/supabase/schema/tables/index.ts
+++ b/src/lib/supabase/schema/tables/index.ts
@@ -47,8 +47,11 @@ import type { OrganizationProjectNotesTable } from "./organization_project_notes
 import type { OrganizationProjectOverviewDocumentsTable } from "./organization_project_overview_documents"
 import type { OrganizationProjectsTable } from "./organization_projects"
 import type { OrganizationProjectQuickLinksTable } from "./organization_project_quick_links"
+import type { OrganizationProjectActivityEventsTable } from "./organization_project_activity_events"
 import type { OrganizationTaskAssigneesTable } from "./organization_task_assignees"
 import type { OrganizationTasksTable } from "./organization_tasks"
+import type { PlatformAdminProjectWorkstreamStatesTable } from "./platform_admin_project_workstream_states"
+import type { PlatformAdminWorkstreamCategoriesTable } from "./platform_admin_workstream_categories"
 import type { OrganizationWorkspaceBoardsTable } from "./organization_workspace_boards"
 import type { OrganizationWorkspaceCommunicationChannelsTable } from "./organization_workspace_communication_channels"
 import type { OrganizationWorkspaceCommunicationDeliveriesTable } from "./organization_workspace_communication_deliveries"
@@ -134,8 +137,11 @@ export type { OrganizationProjectNotesTable } from "./organization_project_notes
 export type { OrganizationProjectOverviewDocumentsTable } from "./organization_project_overview_documents"
 export type { OrganizationProjectsTable } from "./organization_projects"
 export type { OrganizationProjectQuickLinksTable } from "./organization_project_quick_links"
+export type { OrganizationProjectActivityEventsTable } from "./organization_project_activity_events"
 export type { OrganizationTaskAssigneesTable } from "./organization_task_assignees"
 export type { OrganizationTasksTable } from "./organization_tasks"
+export type { PlatformAdminProjectWorkstreamStatesTable } from "./platform_admin_project_workstream_states"
+export type { PlatformAdminWorkstreamCategoriesTable } from "./platform_admin_workstream_categories"
 export type { OrganizationWorkspaceBoardsTable } from "./organization_workspace_boards"
 export type { OrganizationWorkspaceCommunicationChannelsTable } from "./organization_workspace_communication_channels"
 export type { OrganizationWorkspaceCommunicationDeliveriesTable } from "./organization_workspace_communication_deliveries"
@@ -222,8 +228,11 @@ export type PublicTables = {
   organization_project_overview_documents: OrganizationProjectOverviewDocumentsTable
   organization_projects: OrganizationProjectsTable
   organization_project_quick_links: OrganizationProjectQuickLinksTable
+  organization_project_activity_events: OrganizationProjectActivityEventsTable
   organization_task_assignees: OrganizationTaskAssigneesTable
   organization_tasks: OrganizationTasksTable
+  platform_admin_project_workstream_states: PlatformAdminProjectWorkstreamStatesTable
+  platform_admin_workstream_categories: PlatformAdminWorkstreamCategoriesTable
   organization_workspace_boards: OrganizationWorkspaceBoardsTable
   organization_workspace_communication_channels: OrganizationWorkspaceCommunicationChannelsTable
   organization_workspace_communication_deliveries: OrganizationWorkspaceCommunicationDeliveriesTable

--- a/src/lib/supabase/schema/tables/organization_project_activity_events.ts
+++ b/src/lib/supabase/schema/tables/organization_project_activity_events.ts
@@ -1,0 +1,66 @@
+import type { Json } from "../../types"
+
+export type OrganizationProjectActivityEventsTable = {
+  Row: {
+    id: string
+    org_id: string
+    project_id: string | null
+    entity_type: string
+    entity_id: string
+    event_type: string
+    title: string
+    from_status: string | null
+    to_status: string | null
+    actor_id: string | null
+    metadata: Json
+    occurred_at: string
+  }
+  Insert: {
+    id?: string
+    org_id: string
+    project_id?: string | null
+    entity_type: string
+    entity_id: string
+    event_type: string
+    title: string
+    from_status?: string | null
+    to_status?: string | null
+    actor_id?: string | null
+    metadata?: Json
+    occurred_at?: string
+  }
+  Update: {
+    id?: string
+    org_id?: string
+    project_id?: string | null
+    entity_type?: string
+    entity_id?: string
+    event_type?: string
+    title?: string
+    from_status?: string | null
+    to_status?: string | null
+    actor_id?: string | null
+    metadata?: Json
+    occurred_at?: string
+  }
+  Relationships: [
+    {
+      foreignKeyName: "organization_project_activity_events_org_id_fkey"
+      columns: ["org_id"]
+      referencedRelation: "organizations"
+      referencedColumns: ["user_id"]
+    },
+    {
+      foreignKeyName: "organization_project_activity_events_project_id_fkey"
+      columns: ["project_id"]
+      referencedRelation: "organization_projects"
+      referencedColumns: ["id"]
+    },
+    {
+      foreignKeyName: "organization_project_activity_events_actor_id_fkey"
+      columns: ["actor_id"]
+      referencedRelation: "profiles"
+      referencedColumns: ["id"]
+    },
+  ]
+}

--- a/src/lib/supabase/schema/tables/platform_admin_project_workstream_states.ts
+++ b/src/lib/supabase/schema/tables/platform_admin_project_workstream_states.ts
@@ -1,0 +1,46 @@
+export type PlatformAdminProjectWorkstreamStatesTable = {
+  Row: {
+    owner_id: string
+    project_id: string
+    category_id: string
+    started_at: string
+    created_at: string
+    updated_at: string
+  }
+  Insert: {
+    owner_id: string
+    project_id: string
+    category_id: string
+    started_at?: string
+    created_at?: string
+    updated_at?: string
+  }
+  Update: {
+    owner_id?: string
+    project_id?: string
+    category_id?: string
+    started_at?: string
+    created_at?: string
+    updated_at?: string
+  }
+  Relationships: [
+    {
+      foreignKeyName: "platform_admin_project_workstream_states_owner_id_fkey"
+      columns: ["owner_id"]
+      referencedRelation: "profiles"
+      referencedColumns: ["id"]
+    },
+    {
+      foreignKeyName: "platform_admin_project_workstream_states_project_id_fkey"
+      columns: ["project_id"]
+      referencedRelation: "organization_projects"
+      referencedColumns: ["id"]
+    },
+    {
+      foreignKeyName: "platform_admin_project_workstream_states_category_fkey"
+      columns: ["owner_id", "category_id"]
+      referencedRelation: "platform_admin_workstream_categories"
+      referencedColumns: ["owner_id", "id"]
+    },
+  ]
+}

--- a/src/lib/supabase/schema/tables/platform_admin_workstream_categories.ts
+++ b/src/lib/supabase/schema/tables/platform_admin_workstream_categories.ts
@@ -1,0 +1,40 @@
+export type PlatformAdminWorkstreamCategoriesTable = {
+  Row: {
+    id: string
+    owner_id: string
+    name: string
+    color: string
+    position: number
+    default_key: string | null
+    created_at: string
+    updated_at: string
+  }
+  Insert: {
+    id?: string
+    owner_id: string
+    name: string
+    color?: string
+    position?: number
+    default_key?: string | null
+    created_at?: string
+    updated_at?: string
+  }
+  Update: {
+    id?: string
+    owner_id?: string
+    name?: string
+    color?: string
+    position?: number
+    default_key?: string | null
+    created_at?: string
+    updated_at?: string
+  }
+  Relationships: [
+    {
+      foreignKeyName: "platform_admin_workstream_categories_owner_id_fkey"
+      columns: ["owner_id"]
+      referencedRelation: "profiles"
+      referencedColumns: ["id"]
+    },
+  ]
+}

--- a/supabase/migrations/20260717143300_harden_admin_organization_operations.sql
+++ b/supabase/migrations/20260717143300_harden_admin_organization_operations.sql
@@ -1,0 +1,45 @@
+set check_function_bodies = off;
+set search_path = public;
+
+revoke all privileges
+  on table
+    public.platform_admin_workstream_categories,
+    public.platform_admin_project_workstream_states,
+    public.organization_project_activity_events
+  from anon, authenticated;
+
+grant select, insert, update, delete
+  on table public.platform_admin_workstream_categories
+  to authenticated;
+
+grant select, insert, update, delete
+  on table public.platform_admin_project_workstream_states
+  to authenticated;
+
+grant select
+  on table public.organization_project_activity_events
+  to authenticated;
+
+create index if not exists platform_admin_project_workstream_states_project_idx
+  on public.platform_admin_project_workstream_states (project_id);
+
+create index if not exists organization_project_activity_events_actor_idx
+  on public.organization_project_activity_events (actor_id)
+  where actor_id is not null;
+
+-- Apply only after canonical project synchronization stops overwriting task_count.
+with canonical_task_counts as (
+  select
+    project.id as project_id,
+    count(task.id)::integer as task_count
+  from public.organization_projects as project
+  left join public.organization_tasks as task
+    on task.project_id = project.id
+  where project.project_kind = 'organization_admin'
+  group by project.id
+)
+update public.organization_projects as project
+set task_count = counts.task_count
+from canonical_task_counts as counts
+where project.id = counts.project_id
+  and project.task_count is distinct from counts.task_count;

--- a/supabase/tests/rls.test.mjs
+++ b/supabase/tests/rls.test.mjs
@@ -594,6 +594,8 @@ async function run() {
   let memberWorkspaceStarterStateTableAvailable = false
   let memberWorkspaceTasksTableAvailable = false
   let memberWorkspaceTaskAssigneesTableAvailable = false
+  let platformAdminWorkstreamTablesAvailable = false
+  let organizationProjectActivityTableAvailable = false
   let memberWorkspaceProjectId = null
   let memberWorkspaceSubscriptionId = null
 
@@ -633,6 +635,22 @@ async function run() {
       results.push({
         name: "member workspace starter state table available",
         passed: memberWorkspaceStarterStateTableAvailable,
+      })
+
+      platformAdminWorkstreamTablesAvailable =
+        (await tableExists("platform_admin_workstream_categories")) &&
+        (await tableExists("platform_admin_project_workstream_states"))
+      results.push({
+        name: "platform admin workstream tables available",
+        passed: platformAdminWorkstreamTablesAvailable,
+      })
+
+      organizationProjectActivityTableAvailable = await tableExists(
+        "organization_project_activity_events"
+      )
+      results.push({
+        name: "organization project activity table available",
+        passed: organizationProjectActivityTableAvailable,
       })
     }
   }
@@ -738,6 +756,89 @@ async function run() {
     results.push({
       name: "platform admin can read organization projects",
       passed: !!adminReadsProject && !adminReadsProjectError,
+    })
+  }
+
+  if (
+    orgAccessReady &&
+    platformAdminWorkstreamTablesAvailable &&
+    memberWorkspaceProjectId
+  ) {
+    const categoryId = randomUUID()
+    const { data: adminCategory, error: adminCategoryError } =
+      await adminSessionClient
+        .from("platform_admin_workstream_categories")
+        .insert({
+          id: categoryId,
+          owner_id: admin.id,
+          name: `Needs review ${suffix}`,
+          color: "violet",
+          position: 7,
+        })
+        .select("id")
+        .maybeSingle()
+    results.push({
+      name: "platform admin can create a personal workstream category",
+      passed: !!adminCategory && !adminCategoryError,
+    })
+
+    const {
+      data: deniedAnonCategory,
+      error: deniedAnonCategoryError,
+    } = await anonClient
+      .from("platform_admin_workstream_categories")
+      .select("id")
+      .eq("id", categoryId)
+    results.push({
+      name: "anonymous users have no workstream category table privileges",
+      passed:
+        deniedAnonCategoryError?.code === "42501" ||
+        /permission denied/i.test(deniedAnonCategoryError?.message ?? "") ||
+        (Array.isArray(deniedAnonCategory) && deniedAnonCategory.length === 0),
+    })
+
+    const { data: deniedMemberCategory, error: deniedMemberCategoryError } =
+      await memberClient
+        .from("platform_admin_workstream_categories")
+        .insert({
+          owner_id: member.id,
+          name: `Member category ${suffix}`,
+          color: "slate",
+          position: 0,
+        })
+        .select("id")
+    results.push({
+      name: "non-admin cannot create workstream categories",
+      passed:
+        !!deniedMemberCategoryError ||
+        (Array.isArray(deniedMemberCategory) &&
+          deniedMemberCategory.length === 0),
+    })
+
+    const { data: memberReadsAdminCategory, error: memberCategoryReadError } =
+      await memberClient
+        .from("platform_admin_workstream_categories")
+        .select("id")
+        .eq("id", categoryId)
+        .maybeSingle()
+    results.push({
+      name: "coach workstream categories stay private to their owner",
+      passed: !memberReadsAdminCategory && !memberCategoryReadError,
+    })
+
+    const { data: adminWorkstreamState, error: adminWorkstreamStateError } =
+      await adminSessionClient
+        .from("platform_admin_project_workstream_states")
+        .insert({
+          owner_id: admin.id,
+          project_id: memberWorkspaceProjectId,
+          category_id: categoryId,
+        })
+        .select("project_id")
+        .maybeSingle()
+    results.push({
+      name: "platform admin can place an organization in a personal workstream",
+      passed: !!adminWorkstreamState && !adminWorkstreamStateError,
     })
   }
 
@@ -949,6 +1050,94 @@ async function run() {
       name: "platform admin can read organization tasks",
       passed: !!adminReadsTask && !adminReadsTaskError,
     })
+
+    const adminTaskId = randomUUID()
+    const { data: adminTask, error: adminTaskError } = await adminSessionClient
+      .from("organization_tasks")
+      .insert({
+        id: adminTaskId,
+        org_id: member.id,
+        project_id: memberWorkspaceProjectId,
+        title: "Coach follow-up",
+        task_type: "task",
+        status: "todo",
+        start_date: "2026-01-14",
+        end_date: "2026-01-16",
+        created_source: "user",
+        created_by: admin.id,
+        updated_by: admin.id,
+      })
+      .select("id")
+      .maybeSingle()
+    results.push({
+      name: "platform admin can create organization tasks",
+      passed: !!adminTask && !adminTaskError,
+    })
+
+    const { data: adminUpdatedTask, error: adminUpdatedTaskError } =
+      await adminSessionClient
+        .from("organization_tasks")
+        .update({ status: "done", updated_by: admin.id })
+        .eq("id", adminTaskId)
+        .select("id")
+    results.push({
+      name: "platform admin can complete organization tasks",
+      passed:
+        !adminUpdatedTaskError &&
+        Array.isArray(adminUpdatedTask) &&
+        adminUpdatedTask.length === 1,
+    })
+
+    if (organizationProjectActivityTableAvailable) {
+      const { data: taskActivity, error: taskActivityError } =
+        await adminSessionClient
+          .from("organization_project_activity_events")
+          .select("id")
+          .eq("entity_type", "task")
+          .eq("entity_id", adminTaskId)
+          .eq("event_type", "completed")
+          .maybeSingle()
+      results.push({
+        name: "task completion appears in the organization activity timeline",
+        passed: !!taskActivity && !taskActivityError,
+      })
+
+      const { data: deniedActivityInsert, error: deniedActivityInsertError } =
+        await adminSessionClient
+          .from("organization_project_activity_events")
+          .insert({
+            org_id: member.id,
+            project_id: memberWorkspaceProjectId,
+            entity_type: "task",
+            entity_id: adminTaskId,
+            event_type: "updated",
+            title: "Forged activity",
+            actor_id: admin.id,
+          })
+          .select("id")
+      results.push({
+        name: "platform admins cannot forge organization activity events",
+        passed:
+          deniedActivityInsertError?.code === "42501" ||
+          /permission denied/i.test(deniedActivityInsertError?.message ?? "") ||
+          (Array.isArray(deniedActivityInsert) &&
+            deniedActivityInsert.length === 0),
+      })
+
+      const { data: deniedAnonActivity, error: deniedAnonActivityReadError } =
+        await anonClient
+          .from("organization_project_activity_events")
+          .select("id")
+          .limit(1)
+      results.push({
+        name: "anonymous users have no organization activity table privileges",
+        passed:
+          deniedAnonActivityReadError?.code === "42501" ||
+          /permission denied/i.test(deniedAnonActivityReadError?.message ?? "") ||
+          (Array.isArray(deniedAnonActivity) &&
+            deniedAnonActivity.length === 0),
+      })
+    }
   }
 
   if (
@@ -1021,6 +1210,25 @@ async function run() {
     results.push({
       name: "platform admin can read organization project notes",
       passed: !!adminReadsNote && !adminReadsNoteError,
+    })
+
+    const { data: adminNote, error: adminNoteError } = await adminSessionClient
+      .from("organization_project_notes")
+      .insert({
+        org_id: member.id,
+        project_id: memberWorkspaceProjectId,
+        title: "Coach note",
+        content: "Follow up with the organization next week.",
+        note_type: "general",
+        status: "completed",
+        created_by: admin.id,
+        updated_by: admin.id,
+      })
+      .select("id")
+      .maybeSingle()
+    results.push({
+      name: "platform admin can create organization project notes",
+      passed: !!adminNote && !adminNoteError,
     })
   }
 
@@ -1272,6 +1480,26 @@ async function run() {
     results.push({
       name: "platform admin can read organization project assets",
       passed: !!adminReadsAsset && !adminReadsAssetError,
+    })
+
+    const { data: adminAsset, error: adminAssetError } =
+      await adminSessionClient
+        .from("organization_project_assets")
+        .insert({
+          org_id: member.id,
+          project_id: memberWorkspaceProjectId,
+          name: "Coach review notes.pdf",
+          description: "Uploaded by a platform admin",
+          asset_type: "pdf",
+          external_url: "https://example.com/coach-review-notes.pdf",
+          created_by: admin.id,
+          updated_by: admin.id,
+        })
+        .select("id")
+        .maybeSingle()
+    results.push({
+      name: "platform admin can add organization project assets",
+      passed: !!adminAsset && !adminAssetError,
     })
 
     if (

--- a/tests/acceptance/member-workspace-admin-operations.test.ts
+++ b/tests/acceptance/member-workspace-admin-operations.test.ts
@@ -1,0 +1,264 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { MemberWorkspaceProjectActivityTimeline } from "@/features/member-workspace/components/projects/member-workspace-project-activity-timeline"
+import { MemberWorkspaceProjectOrganizationCard } from "@/features/member-workspace/components/projects/member-workspace-project-organization-card"
+import { getProjectDetailsById } from "@/features/platform-admin-dashboard/upstream/lib/data/project-details"
+import type { MemberWorkspaceAdminOrganizationSummary } from "@/features/member-workspace/types"
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260716203000_add_admin_organization_operations.sql"
+  ),
+  "utf8"
+)
+
+const hardeningMigration = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260717143300_harden_admin_organization_operations.sql"
+  ),
+  "utf8"
+)
+
+const organizationSummary: MemberWorkspaceAdminOrganizationSummary = {
+  orgId: "org-1",
+  canonicalProjectId: "project-1",
+  name: "Coach House",
+  ownerName: "Alex Rivera",
+  ownerAvatarUrl: null,
+  publicSlug: "coach-house",
+  organizationStatus: "approved",
+  isPublic: true,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-02T00:00:00.000Z",
+  acceleratorProgress: 64,
+  setupProgress: 75,
+  setupCompletedCount: 9,
+  setupTotalCount: 12,
+  missingSetupCount: 3,
+  memberCount: 1,
+  tags: [],
+  members: [
+    {
+      userId: "user-1",
+      name: "Alex Rivera",
+      email: "alex@example.com",
+      avatarUrl: null,
+      headline: null,
+      organizationRole: "owner",
+      platformRole: "member",
+      isOwner: true,
+      profileCompletenessPercent: 50,
+      profileCompletedCount: 2,
+      profileTotalCount: 4,
+      profileMissingFields: ["headline", "profile photo"],
+    },
+  ],
+  setupItems: [],
+  programs: [
+    {
+      id: "program-1",
+      title: "Neighborhood grants",
+      statusLabel: "Active",
+      startAt: "2026-07-01T00:00:00.000Z",
+      endAt: "2026-07-31T00:00:00.000Z",
+      isPublic: true,
+    },
+  ],
+  profile: {},
+}
+
+describe("member workspace admin operations", () => {
+  it("stores per-admin workstream categories and immutable system activity", () => {
+    expect(migration).toContain(
+      "create table if not exists public.platform_admin_workstream_categories"
+    )
+    expect(migration).toContain(
+      "create table if not exists public.platform_admin_project_workstream_states"
+    )
+    expect(migration).toContain(
+      "create table if not exists public.organization_project_activity_events"
+    )
+    expect(migration).toContain(
+      "owner_id = (select auth.uid()) and (select public.is_admin())"
+    )
+    expect(migration).toContain(
+      "revoke insert, update, delete on public.organization_project_activity_events"
+    )
+    expect(migration).toContain("record_organization_task_activity")
+    expect(migration).toContain("record_organization_program_activity")
+    expect(migration).toContain(
+      "record_fiscal_sponsorship_application_activity"
+    )
+  })
+
+  it("hardens admin-operation privileges and repairs canonical task counts", () => {
+    expect(hardeningMigration).toContain("revoke all privileges")
+    expect(hardeningMigration).toContain("from anon, authenticated")
+    expect(hardeningMigration).toContain(
+      "grant select, insert, update, delete\n  on table public.platform_admin_workstream_categories\n  to authenticated"
+    )
+    expect(hardeningMigration).toContain(
+      "grant select, insert, update, delete\n  on table public.platform_admin_project_workstream_states\n  to authenticated"
+    )
+    expect(hardeningMigration).toContain(
+      "grant select\n  on table public.organization_project_activity_events\n  to authenticated"
+    )
+    expect(hardeningMigration).not.toContain("to anon")
+    expect(hardeningMigration).toContain(
+      "platform_admin_project_workstream_states_project_idx"
+    )
+    expect(hardeningMigration).toContain(
+      "organization_project_activity_events_actor_idx"
+    )
+    expect(hardeningMigration).toContain(
+      "where project.project_kind = 'organization_admin'"
+    )
+    expect(hardeningMigration).toContain(
+      "project.task_count is distinct from counts.task_count"
+    )
+  })
+
+  it("provides real category management and removes the dead column menu", () => {
+    const source = [
+      "member-workspace-project-board-view.tsx",
+      "member-workspace-project-board-category-controls.tsx",
+    ]
+      .map((fileName) =>
+        readFileSync(
+          join(
+            process.cwd(),
+            "src/features/member-workspace/components/projects",
+            fileName
+          ),
+          "utf8"
+        )
+      )
+      .join("\n")
+
+    expect(source).toContain("Add category")
+    expect(source).toContain("Save name")
+    expect(source).toContain("Delete category")
+    expect(source).toContain("Restore defaults")
+    expect(source).toContain("Restore default categories?")
+    expect(source).toContain(
+      "Default categories can be renamed but cannot be deleted."
+    )
+    expect(source).toContain("Cannot be deleted")
+    expect(source).toContain("updateProjectWorkstreamAction")
+    expect(source).toContain("overflow-x-auto")
+    expect(source).toContain("aria-label={`Manage ${category.name} category`}")
+    expect(source).not.toContain("disabled={isPending || !canManageBoard}")
+
+    const workstreamSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/member-workspace/server/admin-workstreams.ts"
+      ),
+      "utf8"
+    )
+    for (const category of [
+      "New Intake",
+      "Coach Action",
+      "Waiting on Organization",
+      "Review & Approval",
+      "Ongoing Support",
+      "Complete",
+    ]) {
+      expect(workstreamSource).toContain(`name: "${category}"`)
+    }
+    expect(workstreamSource).toContain('default_key: "waiting_on_organization"')
+    expect(workstreamSource).toContain('default_key: "review_approval"')
+    expect(workstreamSource).toContain("...category")
+    expect(workstreamSource).toContain(".upsert(defaultPayload")
+    expect(workstreamSource).toContain(
+      "Default workstream categories cannot be deleted"
+    )
+    expect(workstreamSource).toContain('.select("id")')
+    expect(workstreamSource).toContain("if (!deletedCategory)")
+
+    const loaderSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/member-workspace/server/project-loaders.ts"
+      ),
+      "utf8"
+    )
+    expect(loaderSource).toContain(
+      "loadPlatformAdminWorkstreamConfiguration({\n        actor,"
+    )
+  })
+
+  it("keeps operational project fields while synchronizing real readiness", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/member-workspace/server/admin-projects.ts"
+      ),
+      "utf8"
+    )
+    const updateStart = source.indexOf(
+      "function buildCanonicalAdminOrganizationProjectUpdate"
+    )
+    const refreshStart = source.indexOf(
+      "function canonicalAdminProjectNeedsRefresh"
+    )
+    const updateSource = source.slice(updateStart, refreshStart)
+
+    expect(updateSource).toContain("progress: desired.progress")
+    expect(updateSource).not.toContain("status: desired.status")
+    expect(updateSource).not.toContain("task_count: desired.task_count")
+    expect(updateSource).not.toContain("member_labels: desired.member_labels")
+    expect(migration).toContain("set task_count = (")
+  })
+
+  it("renders organization and user completeness from real summary values", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(MemberWorkspaceProjectOrganizationCard, {
+        organization: organizationSummary,
+      })
+    )
+
+    expect(markup).toContain("Organization setup")
+    expect(markup).toContain("75%")
+    expect(markup).toContain("9 of 12 setup items complete")
+    expect(markup).toContain("User completeness")
+    expect(markup).toContain("Missing headline, profile photo")
+  })
+
+  it("renders program duration and recorded step transitions", () => {
+    const project = {
+      ...getProjectDetailsById("project-1"),
+      activity: [
+        {
+          id: "event-1",
+          entityType: "task" as const,
+          eventType: "completed",
+          title: "Review application",
+          fromStatus: "in-progress",
+          toStatus: "done",
+          occurredAt: new Date("2026-07-16T15:00:00.000Z"),
+          durationLabel: "2 days",
+        },
+      ],
+    }
+    const markup = renderToStaticMarkup(
+      React.createElement(MemberWorkspaceProjectActivityTimeline, {
+        organizationSummary,
+        project,
+      })
+    )
+
+    expect(markup).toContain("Program timelines")
+    expect(markup).toContain("Neighborhood grants")
+    expect(markup).toContain("31 days scheduled")
+    expect(markup).toContain("Review application")
+    expect(markup).toContain("In Progress to Done")
+    expect(markup).toContain("2 days in the prior step")
+  })
+})

--- a/tests/acceptance/member-workspace-admin-projects.test.ts
+++ b/tests/acceptance/member-workspace-admin-projects.test.ts
@@ -4,7 +4,7 @@ import { ensureCanonicalAdminProjects } from "@/features/member-workspace/server
 import type { MemberWorkspaceAdminOrganizationSummary } from "@/features/member-workspace/types"
 
 describe("ensureCanonicalAdminProjects", () => {
-  it("refreshes stale canonical organization-admin rows with current organization metadata", async () => {
+  it("refreshes organization metadata without overwriting coach-managed project state", async () => {
     const organization: MemberWorkspaceAdminOrganizationSummary = {
       orgId: "org-1",
       canonicalProjectId: "project-1",
@@ -37,7 +37,11 @@ describe("ensureCanonicalAdminProjects", () => {
       ],
       setupItems: [
         { id: "mission", label: "Add mission statement", complete: true },
-        { id: "roadmap-program", label: "Complete roadmap: Program", complete: false },
+        {
+          id: "roadmap-program",
+          label: "Complete roadmap: Program",
+          complete: false,
+        },
       ],
       profile: {},
     }
@@ -55,7 +59,7 @@ describe("ensureCanonicalAdminProjects", () => {
               canonical_org_id: "org-1",
               project_kind: "organization_admin",
               name: "Acme Corp",
-              description: null,
+              description: "Coach-authored operating notes",
               status: "planned",
               priority: "low",
               progress: 12,
@@ -77,7 +81,7 @@ describe("ensureCanonicalAdminProjects", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -99,18 +103,18 @@ describe("ensureCanonicalAdminProjects", () => {
               canonical_org_id: "org-1",
               project_kind: "organization_admin",
               name: "Community Builders",
-              description: null,
-              status: "active",
-              priority: "medium",
-              progress: 42,
+              description: "Coach-authored operating notes",
+              status: "planned",
+              priority: "low",
+              progress: 68,
               start_date: "2026-01-01",
-              end_date: "2026-04-28",
+              end_date: "2026-01-14",
               client_name: "/community-builders",
               type_label: "Approved nonprofit",
-              duration_label: "3 members",
+              duration_label: "1 member",
               tags: ["organization", "approved"],
-              member_labels: ["Paula Founder"],
-              task_count: 10,
+              member_labels: ["Jason D"],
+              task_count: 1,
               created_source: "system",
               starter_seed_key: null,
               starter_seed_version: null,
@@ -121,7 +125,7 @@ describe("ensureCanonicalAdminProjects", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -136,7 +140,9 @@ describe("ensureCanonicalAdminProjects", () => {
         if (organizationProjectsCalls === 1) return initialSelectQuery
         if (organizationProjectsCalls === 2) return updateQuery
         if (organizationProjectsCalls === 3) return refreshedSelectQuery
-        throw new Error(`Unexpected organization_projects call #${organizationProjectsCalls}`)
+        throw new Error(
+          `Unexpected organization_projects call #${organizationProjectsCalls}`
+        )
       }),
     }
 
@@ -148,14 +154,21 @@ describe("ensureCanonicalAdminProjects", () => {
     expect(updateQuery.update).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "Community Builders",
+        progress: 68,
         client_name: "/community-builders",
         type_label: "Approved nonprofit",
-        duration_label: "3 members",
-        task_count: 10,
-        member_labels: ["Paula Founder"],
         tags: ["organization", "approved"],
-      }),
+      })
     )
+    const updatePayload = updateQuery.update.mock.calls[0]?.[0]
+    expect(updatePayload).not.toHaveProperty("description")
+    expect(updatePayload).not.toHaveProperty("status")
+    expect(updatePayload).not.toHaveProperty("priority")
+    expect(updatePayload).not.toHaveProperty("start_date")
+    expect(updatePayload).not.toHaveProperty("end_date")
+    expect(updatePayload).not.toHaveProperty("duration_label")
+    expect(updatePayload).not.toHaveProperty("member_labels")
+    expect(updatePayload).not.toHaveProperty("task_count")
     expect(updateQuery.eq).toHaveBeenCalledWith("id", "project-1")
     expect(result).toEqual([
       expect.objectContaining({

--- a/tests/acceptance/member-workspace-admin-workstreams.test.ts
+++ b/tests/acceptance/member-workspace-admin-workstreams.test.ts
@@ -1,0 +1,277 @@
+import "./test-utils"
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { revalidatePathMock, resetTestMocks } from "./test-utils"
+
+const { resolveMemberWorkspaceActorContextMock } = vi.hoisted(() => ({
+  resolveMemberWorkspaceActorContextMock: vi.fn(),
+}))
+
+vi.mock(
+  "@/features/member-workspace/server/member-workspace-actor-context",
+  () => ({
+    resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
+  })
+)
+
+import {
+  deletePlatformAdminWorkstreamCategoryAction,
+  restorePlatformAdminWorkstreamDefaultsAction,
+} from "@/features/member-workspace/server/admin-workstreams"
+
+type CategoryRow = {
+  id: string
+  owner_id: string
+  name: string
+  color: string
+  position: number
+  default_key: string | null
+  created_at: string
+  updated_at: string
+}
+
+const defaultCategoryValues = [
+  ["backlog", "New Intake", "slate", 0],
+  ["planned", "Coach Action", "amber", 1],
+  ["waiting_on_organization", "Waiting on Organization", "rose", 2],
+  ["review_approval", "Review & Approval", "blue", 3],
+  ["active", "Ongoing Support", "violet", 4],
+  ["completed", "Complete", "emerald", 5],
+] as const
+
+const defaultRows: CategoryRow[] = defaultCategoryValues.map(
+  ([defaultKey, name, color, position]) => ({
+    id: `category-${defaultKey}`,
+    owner_id: "admin-1",
+    name,
+    color,
+    position,
+    default_key: defaultKey,
+    created_at: "2026-07-17T00:00:00.000Z",
+    updated_at: "2026-07-17T00:00:00.000Z",
+  })
+)
+
+function mockAdminActor(supabase: { from: ReturnType<typeof vi.fn> }) {
+  resolveMemberWorkspaceActorContextMock.mockResolvedValue({
+    supabase,
+    userId: "admin-1",
+    isAdmin: true,
+    activeOrg: { orgId: "org-1", role: "owner" },
+    canEdit: true,
+  })
+}
+
+function createCategoryLookupQuery(
+  category: {
+    id: string
+    default_key: string | null
+  } | null
+) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: category, error: null }),
+  }
+}
+
+function createCategoryRowsQuery(rows = defaultRows) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    returns: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+}
+
+describe("platform admin workstream category actions", () => {
+  beforeEach(() => {
+    resetTestMocks()
+    resolveMemberWorkspaceActorContextMock.mockReset()
+  })
+
+  it("rejects deletion of a default category before issuing a delete", async () => {
+    const lookupQuery = createCategoryLookupQuery({
+      id: "category-backlog",
+      default_key: "backlog",
+    })
+    const supabase = { from: vi.fn(() => lookupQuery) }
+    mockAdminActor(supabase)
+
+    await expect(
+      deletePlatformAdminWorkstreamCategoryAction("category-backlog")
+    ).resolves.toEqual({
+      error:
+        "Default workstream categories cannot be deleted. Rename them or restore their original names.",
+    })
+
+    expect(supabase.from).toHaveBeenCalledTimes(1)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+
+  it("reports a stale custom deletion when no row was deleted", async () => {
+    const lookupQuery = createCategoryLookupQuery({
+      id: "category-custom",
+      default_key: null,
+    })
+    const deleteQuery = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    let categoryCall = 0
+    const supabase = {
+      from: vi.fn(() => {
+        categoryCall += 1
+        return categoryCall === 1 ? lookupQuery : deleteQuery
+      }),
+    }
+    mockAdminActor(supabase)
+
+    await expect(
+      deletePlatformAdminWorkstreamCategoryAction("category-custom")
+    ).resolves.toEqual({ error: "That category is no longer available." })
+
+    expect(deleteQuery.select).toHaveBeenCalledWith("id")
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+
+  it("returns the verified row for a successful custom deletion", async () => {
+    const lookupQuery = createCategoryLookupQuery({
+      id: "category-custom",
+      default_key: null,
+    })
+    const deleteQuery = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { id: "category-custom" },
+        error: null,
+      }),
+    }
+    let categoryCall = 0
+    const supabase = {
+      from: vi.fn(() => {
+        categoryCall += 1
+        return categoryCall === 1 ? lookupQuery : deleteQuery
+      }),
+    }
+    mockAdminActor(supabase)
+
+    await expect(
+      deletePlatformAdminWorkstreamCategoryAction("category-custom")
+    ).resolves.toEqual({ ok: true, id: "category-custom" })
+    expect(revalidatePathMock).toHaveBeenCalledWith("/organizations")
+  })
+
+  it("restores all six defaults with one multi-row upsert", async () => {
+    const rowsQuery = createCategoryRowsQuery()
+    const upsertQuery = {
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    }
+    let categoryCall = 0
+    const supabase = {
+      from: vi.fn(() => {
+        categoryCall += 1
+        return categoryCall === 1 ? rowsQuery : upsertQuery
+      }),
+    }
+    mockAdminActor(supabase)
+
+    await expect(
+      restorePlatformAdminWorkstreamDefaultsAction()
+    ).resolves.toEqual({ ok: true })
+
+    expect(upsertQuery.upsert).toHaveBeenCalledTimes(1)
+    expect(upsertQuery.upsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "category-backlog",
+          default_key: "backlog",
+          name: "New Intake",
+          position: 0,
+        }),
+        expect.objectContaining({
+          id: "category-completed",
+          default_key: "completed",
+          name: "Complete",
+          position: 5,
+        }),
+      ]),
+      { onConflict: "id" }
+    )
+    expect(upsertQuery.upsert.mock.calls[0]?.[0]).toHaveLength(6)
+    expect(revalidatePathMock).toHaveBeenCalledWith("/organizations")
+  })
+
+  it("fails before mutation when a default category is missing", async () => {
+    const rowsQuery = createCategoryRowsQuery(defaultRows.slice(0, -1))
+    const supabase = { from: vi.fn(() => rowsQuery) }
+    mockAdminActor(supabase)
+
+    await expect(
+      restorePlatformAdminWorkstreamDefaultsAction()
+    ).resolves.toEqual({
+      error:
+        "Default workstream categories are missing: Complete. Reload the page before restoring defaults.",
+    })
+
+    expect(supabase.from).toHaveBeenCalledTimes(1)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+
+  it("fails clearly when a custom category occupies a default name", async () => {
+    const rows = [
+      ...defaultRows.map((row) =>
+        row.default_key === "completed"
+          ? { ...row, name: "Finished work" }
+          : row
+      ),
+      {
+        ...defaultRows[0],
+        id: "category-custom-complete",
+        default_key: null,
+        name: "Complete",
+        position: 6,
+      },
+    ]
+    const rowsQuery = createCategoryRowsQuery(rows)
+    const supabase = { from: vi.fn(() => rowsQuery) }
+    mockAdminActor(supabase)
+
+    await expect(
+      restorePlatformAdminWorkstreamDefaultsAction()
+    ).resolves.toEqual({
+      error: "Rename the custom “Complete” category before restoring defaults.",
+    })
+
+    expect(supabase.from).toHaveBeenCalledTimes(1)
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces an atomic upsert conflict without reporting success", async () => {
+    const rowsQuery = createCategoryRowsQuery()
+    const upsertQuery = {
+      upsert: vi.fn().mockResolvedValue({ error: { code: "23505" } }),
+    }
+    let categoryCall = 0
+    const supabase = {
+      from: vi.fn(() => {
+        categoryCall += 1
+        return categoryCall === 1 ? rowsQuery : upsertQuery
+      }),
+    }
+    mockAdminActor(supabase)
+
+    await expect(
+      restorePlatformAdminWorkstreamDefaultsAction()
+    ).resolves.toEqual({
+      error:
+        "A custom category now uses a default name. Rename it before restoring defaults.",
+    })
+    expect(revalidatePathMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/acceptance/member-workspace-loaders.test.ts
+++ b/tests/acceptance/member-workspace-loaders.test.ts
@@ -16,68 +16,76 @@ const { loadAccessibleOrganizationsMock } = vi.hoisted(() => ({
   loadAccessibleOrganizationsMock: vi.fn(),
 }))
 
-const { loadMemberWorkspacePersonOptionsForOrganizationsMock } = vi.hoisted(() => ({
-  loadMemberWorkspacePersonOptionsForOrganizationsMock: vi.fn(),
-}))
+const { loadMemberWorkspacePersonOptionsForOrganizationsMock } = vi.hoisted(
+  () => ({
+    loadMemberWorkspacePersonOptionsForOrganizationsMock: vi.fn(),
+  })
+)
 
 const { ensureStarterTasksForOrgMock } = vi.hoisted(() => ({
   ensureStarterTasksForOrgMock: vi.fn(),
 }))
 
-vi.mock("@/features/member-workspace/server/member-workspace-actor-context", () => ({
-  resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
-}))
+vi.mock(
+  "@/features/member-workspace/server/member-workspace-actor-context",
+  () => ({
+    resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
+  })
+)
 
-vi.mock("@/features/member-workspace/server/admin-organization-overview", () => ({
-  loadAdminOrganizationSummaries: loadAdminOrganizationSummariesMock,
-  mapAdminOrganizationSummaryToProject: (organization: {
-    orgId: string
-    canonicalProjectId: string | null
-    name: string
-    acceleratorProgress: number
-    setupProgress: number
-    setupCompletedCount: number
-    setupTotalCount: number
-    missingSetupCount: number
-    tags: string[]
-    members: Array<{ name: string }>
-    ownerName: string
-    ownerAvatarUrl: string | null
-    setupItems: Array<{ id: string; label: string; complete: boolean }>
-    publicSlug: string | null
-    isPublic: boolean
-    organizationStatus: string
-    createdAt: string
-  }) => ({
-    id: organization.canonicalProjectId ?? organization.orgId,
-    organizationId: organization.orgId,
-    projectKind: "organization_admin",
-    name: organization.name,
-    taskCount: organization.setupTotalCount,
-    progress: organization.acceleratorProgress,
-    startDate: new Date(organization.createdAt),
-    endDate: new Date(organization.createdAt),
-    status: "active",
-    priority: "medium",
-    tags: organization.tags,
-    members: organization.members.map((member) => member.name),
-    primaryPersonName: organization.ownerName,
-    primaryPersonAvatarUrl: organization.ownerAvatarUrl,
-    client: organization.publicSlug,
-    typeLabel: organization.organizationStatus,
-    durationLabel: null,
-    taskSummaryLabel: "Setup items",
-    tasks: organization.setupItems.map((item) => ({
-      id: item.id,
-      name: item.label,
-      type: "task",
-      assignee: organization.ownerName,
-      status: item.complete ? "done" : "todo",
+vi.mock(
+  "@/features/member-workspace/server/admin-organization-overview",
+  () => ({
+    loadAdminOrganizationSummaries: loadAdminOrganizationSummariesMock,
+    mapAdminOrganizationSummaryToProject: (organization: {
+      orgId: string
+      canonicalProjectId: string | null
+      name: string
+      acceleratorProgress: number
+      setupProgress: number
+      setupCompletedCount: number
+      setupTotalCount: number
+      missingSetupCount: number
+      tags: string[]
+      members: Array<{ name: string }>
+      ownerName: string
+      ownerAvatarUrl: string | null
+      setupItems: Array<{ id: string; label: string; complete: boolean }>
+      publicSlug: string | null
+      isPublic: boolean
+      organizationStatus: string
+      createdAt: string
+    }) => ({
+      id: organization.canonicalProjectId ?? organization.orgId,
+      organizationId: organization.orgId,
+      projectKind: "organization_admin",
+      name: organization.name,
+      taskCount: organization.setupTotalCount,
+      progress: organization.acceleratorProgress,
       startDate: new Date(organization.createdAt),
       endDate: new Date(organization.createdAt),
-    })),
-  }),
-}))
+      status: "active",
+      priority: "medium",
+      tags: organization.tags,
+      members: organization.members.map((member) => member.name),
+      primaryPersonName: organization.ownerName,
+      primaryPersonAvatarUrl: organization.ownerAvatarUrl,
+      client: organization.publicSlug,
+      typeLabel: organization.organizationStatus,
+      durationLabel: null,
+      taskSummaryLabel: "Setup items",
+      tasks: organization.setupItems.map((item) => ({
+        id: item.id,
+        name: item.label,
+        type: "task",
+        assignee: organization.ownerName,
+        status: item.complete ? "done" : "todo",
+        startDate: new Date(organization.createdAt),
+        endDate: new Date(organization.createdAt),
+      })),
+    }),
+  })
+)
 
 vi.mock("@/features/member-workspace/server/admin-projects", () => ({
   ensureCanonicalAdminProjects: ensureCanonicalAdminProjectsMock,
@@ -85,23 +93,34 @@ vi.mock("@/features/member-workspace/server/admin-projects", () => ({
     canonicalProjects,
     organizations,
   }: {
-    canonicalProjects: Array<{ id: string; canonical_org_id?: string | null; org_id: string }>
+    canonicalProjects: Array<{
+      id: string
+      canonical_org_id?: string | null
+      org_id: string
+    }>
     organizations: Array<Record<string, unknown>>
   }) => {
     const projectIdByOrgId = new Map(
-      canonicalProjects.map((project) => [project.canonical_org_id ?? project.org_id, project.id]),
+      canonicalProjects.map((project) => [
+        project.canonical_org_id ?? project.org_id,
+        project.id,
+      ])
     )
 
     return organizations.map((organization) => ({
       ...organization,
-      canonicalProjectId: projectIdByOrgId.get(String(organization.orgId)) ?? null,
+      canonicalProjectId:
+        projectIdByOrgId.get(String(organization.orgId)) ?? null,
     }))
   },
 }))
 
-vi.mock("@/features/member-workspace/server/load-accessible-organizations", () => ({
-  loadAccessibleOrganizations: loadAccessibleOrganizationsMock,
-}))
+vi.mock(
+  "@/features/member-workspace/server/load-accessible-organizations",
+  () => ({
+    loadAccessibleOrganizations: loadAccessibleOrganizationsMock,
+  })
+)
 
 vi.mock("@/features/member-workspace/server/person-options", () => ({
   loadMemberWorkspacePersonOptionsForOrganizations:
@@ -136,7 +155,7 @@ function createProjectsMissingTableSupabase() {
       Promise.resolve({
         count: null,
         error: missingProjectsTableError,
-      }),
+      })
     ),
   }
 
@@ -149,7 +168,7 @@ function createProjectsMissingTableSupabase() {
       Promise.resolve({
         data: null,
         error: missingProjectsTableError,
-      }),
+      })
     ),
   }
 
@@ -174,7 +193,7 @@ function createTasksMissingTableSupabase() {
       Promise.resolve({
         data: null,
         error: missingTasksTableError,
-      }),
+      })
     ),
   }
 
@@ -188,7 +207,7 @@ function createTasksMissingTableSupabase() {
           code: "42P01",
           message: 'relation "organization_task_assignees" does not exist',
         },
-      }),
+      })
     ),
   }
 
@@ -201,7 +220,7 @@ function createTasksMissingTableSupabase() {
       Promise.resolve({
         data: [],
         error: null,
-      }),
+      })
     ),
   }
 
@@ -256,6 +275,7 @@ describe("member workspace loaders", () => {
       scope: "organization",
       organizationOptions: [{ orgId: "org-1", name: "Org One" }],
       assigneeOptions: [],
+      workstreamCategories: [],
     })
   })
 
@@ -276,7 +296,11 @@ describe("member workspace loaders", () => {
         members: [{ name: "Paula" }],
         setupItems: [
           { id: "mission", label: "Add mission statement", complete: true },
-          { id: "roadmap-program", label: "Complete roadmap: Program", complete: false },
+          {
+            id: "roadmap-program",
+            label: "Complete roadmap: Program",
+            complete: false,
+          },
         ],
         publicSlug: "community-builders",
         isPublic: true,
@@ -321,7 +345,18 @@ describe("member workspace loaders", () => {
         Promise.resolve({
           data: [],
           error: null,
-        }),
+        })
+      ),
+    }
+    const missingWorkstreamCategoriesQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      returns: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          error: { code: "42P01" },
+        })
       ),
     }
 
@@ -330,6 +365,9 @@ describe("member workspace loaders", () => {
         from: vi.fn((table: string) => {
           if (table === "organization_projects") {
             return standardProjectsQuery
+          }
+          if (table === "platform_admin_workstream_categories") {
+            return missingWorkstreamCategoriesQuery
           }
           throw new Error(`Unexpected table query: ${table}`)
         }),
@@ -353,15 +391,15 @@ describe("member workspace loaders", () => {
         expect.objectContaining({
           id: "project-1",
           name: "Community Builders",
-          progress: 42,
-          taskCount: 10,
+          progress: 68,
+          taskCount: 2,
           projectKind: "organization_admin",
         }),
       ],
     })
   })
 
-  it("returns platform-admin task views in read-only mode", async () => {
+  it("returns manageable platform-admin task views for real projects", async () => {
     let organizationProjectsCalls = 0
     const orgRowsQuery = {
       select: vi.fn().mockReturnThis(),
@@ -369,19 +407,27 @@ describe("member workspace loaders", () => {
         Promise.resolve({
           data: [{ org_id: "org-1" }],
           error: null,
-        }),
+        })
       ),
     }
     const adminProjectOptionsQuery = {
       select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       neq: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       returns: vi.fn(() =>
         Promise.resolve({
-          data: [{ id: "project-standard", name: "Client Migration" }],
+          data: [
+            {
+              id: "project-standard",
+              name: "Client Migration",
+              project_kind: "standard",
+              created_source: "user",
+            },
+          ],
           error: null,
-        }),
+        })
       ),
     }
     const adminTaskRowsQuery = {
@@ -389,10 +435,62 @@ describe("member workspace loaders", () => {
       order: vi.fn().mockReturnThis(),
       returns: vi.fn(() =>
         Promise.resolve({
-          data: [],
+          data: [
+            {
+              id: "task-standard",
+              org_id: "org-1",
+              project_id: "project-standard",
+              title: "Prepare launch",
+              description: null,
+              task_type: "task",
+              status: "todo",
+              start_date: "2026-04-01",
+              end_date: "2026-04-02",
+              priority: "medium",
+              tag_label: null,
+              workstream_name: null,
+              sort_order: 0,
+              created_source: "user",
+              organization_projects: {
+                id: "project-standard",
+                name: "Client Migration",
+                client_name: null,
+                status: "planned",
+                priority: "medium",
+                tags: [],
+                member_labels: [],
+                type_label: null,
+                duration_label: null,
+                start_date: "2026-04-01",
+                end_date: "2026-04-30",
+              },
+            },
+            {
+              id: "task-system",
+              org_id: "org-1",
+              project_id: "project-system",
+              title: "Internal system task",
+              description: null,
+              task_type: "task",
+              status: "todo",
+              start_date: "2026-04-01",
+              end_date: "2026-04-02",
+              priority: "medium",
+              tag_label: null,
+              workstream_name: null,
+              sort_order: 0,
+              created_source: "system",
+              organization_projects: null,
+            },
+          ],
           error: null,
-        }),
+        })
       ),
+    }
+    const taskAssigneesQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      returns: vi.fn(() => Promise.resolve({ data: [], error: null })),
     }
 
     resolveMemberWorkspaceActorContextMock.mockResolvedValue({
@@ -400,10 +498,15 @@ describe("member workspace loaders", () => {
         from: vi.fn((table: string) => {
           if (table === "organization_projects") {
             organizationProjectsCalls += 1
-            return organizationProjectsCalls === 1 ? orgRowsQuery : adminProjectOptionsQuery
+            return organizationProjectsCalls === 1
+              ? orgRowsQuery
+              : adminProjectOptionsQuery
           }
           if (table === "organization_tasks") {
             return adminTaskRowsQuery
+          }
+          if (table === "organization_task_assignees") {
+            return taskAssigneesQuery
           }
           throw new Error(`Unexpected table query: ${table}`)
         }),
@@ -416,13 +519,25 @@ describe("member workspace loaders", () => {
 
     await expect(loadMemberWorkspaceTasksPage()).resolves.toMatchObject({
       scope: "platform-admin",
-      canManageTasks: false,
+      canManageTasks: true,
       projectOptions: [{ id: "project-standard", label: "Client Migration" }],
-      taskGroups: [],
+      taskGroups: [
+        expect.objectContaining({
+          projectId: "project-standard",
+          tasks: [
+            expect.objectContaining({
+              id: "task-standard",
+              canUpdate: true,
+            }),
+          ],
+        }),
+      ],
     })
 
-    expect(adminProjectOptionsQuery.eq).toHaveBeenCalledWith("project_kind", "standard")
-    expect(adminProjectOptionsQuery.neq).toHaveBeenCalledWith("created_source", "system")
+    expect(adminProjectOptionsQuery.in).toHaveBeenCalledWith("project_kind", [
+      "standard",
+      "organization_admin",
+    ])
   })
 
   it("returns an empty tasks state when member workspace task tables are missing", async () => {
@@ -455,10 +570,15 @@ describe("member workspace loaders", () => {
       returns: vi.fn(() =>
         Promise.resolve({
           data: [
-            { id: "project-standard", name: "Client Migration" },
+            {
+              id: "project-standard",
+              name: "Client Migration",
+              project_kind: "standard",
+              created_source: "user",
+            },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -470,7 +590,7 @@ describe("member workspace loaders", () => {
         Promise.resolve({
           data: [],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -481,7 +601,7 @@ describe("member workspace loaders", () => {
         Promise.resolve({
           data: [],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -501,7 +621,13 @@ describe("member workspace loaders", () => {
         }),
       },
       userId: "user-1",
-      currentUser: { id: "user-1", name: "Owner", email: null, avatarUrl: null, displayImage: null },
+      currentUser: {
+        id: "user-1",
+        name: "Owner",
+        email: null,
+        avatarUrl: null,
+        displayImage: null,
+      },
       activeOrg: { orgId: "org-1", role: "owner" },
       isAdmin: false,
       canEdit: true,
@@ -512,9 +638,16 @@ describe("member workspace loaders", () => {
       projectOptions: [{ id: "project-standard", label: "Client Migration" }],
     })
 
-    expect(projectOptionsQuery.eq).toHaveBeenNthCalledWith(1, "project_kind", "standard")
+    expect(projectOptionsQuery.eq).toHaveBeenNthCalledWith(
+      1,
+      "project_kind",
+      "standard"
+    )
     expect(projectOptionsQuery.eq).toHaveBeenNthCalledWith(2, "org_id", "org-1")
-    expect(projectOptionsQuery.neq).toHaveBeenCalledWith("created_source", "system")
+    expect(projectOptionsQuery.neq).toHaveBeenCalledWith(
+      "created_source",
+      "system"
+    )
   })
 
   it("ignores org tasks that belong to admin/system projects outside the member-workspace scope", async () => {
@@ -525,9 +658,16 @@ describe("member workspace loaders", () => {
       neq: vi.fn().mockReturnThis(),
       returns: vi.fn(() =>
         Promise.resolve({
-          data: [{ id: "project-standard", name: "Client Migration" }],
+          data: [
+            {
+              id: "project-standard",
+              name: "Client Migration",
+              project_kind: "standard",
+              created_source: "user",
+            },
+          ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -550,7 +690,7 @@ describe("member workspace loaders", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -640,7 +780,7 @@ describe("member workspace loaders", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -680,7 +820,12 @@ describe("member workspace loaders", () => {
       taskGroups: [
         expect.objectContaining({
           projectId: "project-standard",
-          tasks: [expect.objectContaining({ id: "task-allowed", title: "Starter task" })],
+          tasks: [
+            expect.objectContaining({
+              id: "task-allowed",
+              title: "Starter task",
+            }),
+          ],
         }),
       ],
     })

--- a/tests/acceptance/member-workspace-project-actions.test.ts
+++ b/tests/acceptance/member-workspace-project-actions.test.ts
@@ -314,7 +314,7 @@ describe("member workspace project actions", () => {
     expect(loaderSource).toContain("canCreateProjects: true")
   })
 
-  it("preserves user-authored canonical organization overview documents during sync", () => {
+  it("preserves coach-managed canonical organization fields during profile sync", () => {
     const adminProjectsSource = readFileSync(
       join(
         process.cwd(),
@@ -324,14 +324,23 @@ describe("member workspace project actions", () => {
     )
 
     expect(adminProjectsSource).toContain(
-      "const { description: _description, ...syncedFields }"
+      "function buildCanonicalAdminOrganizationProjectUpdate("
+    )
+    expect(adminProjectsSource).toContain("name: desired.name")
+    expect(adminProjectsSource).not.toContain(
+      "description: desired.description"
+    )
+    expect(adminProjectsSource).not.toContain("status: desired.status")
+    expect(adminProjectsSource).not.toContain("priority: desired.priority")
+    expect(adminProjectsSource).not.toContain("start_date: desired.start_date")
+    expect(adminProjectsSource).not.toContain("end_date: desired.end_date")
+    expect(adminProjectsSource).not.toContain(
+      "duration_label: desired.duration_label"
     )
     expect(adminProjectsSource).not.toContain(
-      "(existing.description ?? null) !== (desired.description ?? null)"
+      "member_labels: desired.member_labels"
     )
-    expect(adminProjectsSource).not.toContain(
-      "...buildCanonicalAdminOrganizationProjectFields(organization),\n    updated_by"
-    )
+    expect(adminProjectsSource).not.toContain("task_count: desired.task_count")
   })
 
   it("keeps rich overview documents in a dedicated table instead of overloading project description", () => {

--- a/tests/acceptance/member-workspace-project-detail-page.test.ts
+++ b/tests/acceptance/member-workspace-project-detail-page.test.ts
@@ -681,6 +681,12 @@ describe("MemberWorkspaceProjectDetailPage", () => {
       "requireMemberWorkspacePageAccess"
     )
     expect(organizationDetailRouteSource).toContain(
+      'const canManageProjectTasks =\n    result.scope === "organization" || result.scope === "platform-admin"'
+    )
+    expect(organizationDetailRouteSource).toContain(
+      "canManageProjectTasks ? deleteMemberWorkspaceTaskAction : undefined"
+    )
+    expect(organizationDetailRouteSource).toContain(
       "connectFiscalSponsorshipDocumentAsset"
     )
     expect(organizationDetailRouteSource).toContain(

--- a/tests/acceptance/member-workspace-project-fiscal-documents.test.ts
+++ b/tests/acceptance/member-workspace-project-fiscal-documents.test.ts
@@ -1,0 +1,201 @@
+import React from "react"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import {
+  getMemberWorkspaceProjectFiscalDocumentAssetIds,
+  MemberWorkspaceProjectFiscalDocuments,
+} from "@/features/member-workspace/components/projects/member-workspace-project-fiscal-documents"
+import type { FiscalSponsorshipProjectWorkflowSummary } from "@/features/fiscal-sponsorship"
+
+function buildWorkflowSummary(
+  override?: Partial<FiscalSponsorshipProjectWorkflowSummary>
+): FiscalSponsorshipProjectWorkflowSummary {
+  return {
+    applicationId: "application-1",
+    applicationStatus: "countersigned",
+    events: [],
+    latestAgreementDocument: null,
+    latestAuditCertificateDocument: null,
+    latestExecutedAgreementDocument: null,
+    latestSignaturePacket: null,
+    legalEntityType: "corporation",
+    requiredDocuments: [],
+    reviewedAt: null,
+    submittedAt: null,
+    ...override,
+  }
+}
+
+describe("MemberWorkspaceProjectFiscalDocuments", () => {
+  it("keeps both download paths behind server-side authorization", () => {
+    const projectAssetRouteSource = readFileSync(
+      join(process.cwd(), "src/app/api/account/project-assets/route.ts"),
+      "utf8"
+    )
+    const fiscalDocumentRouteSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/app/api/fiscal-sponsorship/documents/[documentId]/route.ts"
+      ),
+      "utf8"
+    )
+
+    expect(projectAssetRouteSource).toContain("canAccessProjectOrg({")
+    expect(projectAssetRouteSource).toContain("createSignedUrl(")
+    expect(fiscalDocumentRouteSource).toContain("supabase.auth.getUser()")
+    expect(fiscalDocumentRouteSource).toContain(
+      '.from("fiscal_sponsorship_documents")'
+    )
+    expect(fiscalDocumentRouteSource).toContain(
+      "actualSha256 !== document.file_sha256"
+    )
+    expect(fiscalDocumentRouteSource).toContain(
+      '"Cache-Control": "private, no-store, max-age=0"'
+    )
+  })
+
+  it("keeps executed fiscal records out of generic asset edit and delete controls", () => {
+    const detailTabsSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/member-workspace/components/projects/member-workspace-project-detail-tabs.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(detailTabsSource).toContain(
+      "getMemberWorkspaceProjectFiscalDocumentAssetIds("
+    )
+    expect(detailTabsSource).toContain("!fiscalDocumentAssetIds.has(file.id)")
+    expect(detailTabsSource).toContain("files={generalProjectFiles}")
+    expect(detailTabsSource).toContain("<MemberWorkspaceProjectFiscalDocuments")
+  })
+
+  it("shows legacy DocuSeal files through authorized project asset routes", () => {
+    const workflowSummary = buildWorkflowSummary({
+      latestExecutedAgreementDocument: {
+        assetId: "asset-docuseal",
+        documentKey: null,
+        downloadHref:
+          "/api/account/project-assets?assetId=asset-docuseal&projectId=project-1&download=1",
+        generatedAt: "2026-07-16T15:00:00.000Z",
+        id: "document-docuseal",
+        kind: "executed_agreement",
+        reviewNotes: null,
+        reviewedAt: null,
+        reviewStatus: "accepted",
+        status: "executed",
+        storagePath: "org-1/project-1/private-docuseal-file.pdf",
+        title: "Executed fiscal sponsorship agreement",
+        uploadedAt: null,
+        version: 1,
+        viewHref:
+          "/api/account/project-assets?assetId=asset-docuseal&projectId=project-1",
+      },
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(MemberWorkspaceProjectFiscalDocuments, {
+        workflowSummary,
+      })
+    )
+
+    expect(markup).toContain("Signed fiscal sponsorship documents")
+    expect(markup).toContain("Executed fiscal sponsorship agreement")
+    expect(markup).toContain(
+      "/api/account/project-assets?assetId=asset-docuseal&amp;projectId=project-1"
+    )
+    expect(markup).not.toContain("private-docuseal-file.pdf")
+    expect(
+      getMemberWorkspaceProjectFiscalDocumentAssetIds(workflowSummary)
+    ).toEqual(new Set(["asset-docuseal"]))
+  })
+
+  it("shows native executed and audit PDFs through hash-verifying routes", () => {
+    const workflowSummary = buildWorkflowSummary({
+      latestAuditCertificateDocument: {
+        assetId: null,
+        documentKey: null,
+        downloadHref:
+          "/api/fiscal-sponsorship/documents/document-audit?download=1",
+        generatedAt: "2026-07-16T16:00:00.000Z",
+        id: "document-audit",
+        kind: "audit_certificate",
+        reviewNotes: null,
+        reviewedAt: null,
+        reviewStatus: "accepted",
+        status: "executed",
+        storagePath: "org-1/project-1/private-native-audit.pdf",
+        title: "Form B Execution Certificate",
+        uploadedAt: null,
+        version: 1,
+        viewHref: "/api/fiscal-sponsorship/documents/document-audit",
+      },
+      latestExecutedAgreementDocument: {
+        assetId: null,
+        documentKey: null,
+        downloadHref:
+          "/api/fiscal-sponsorship/documents/document-executed?download=1",
+        generatedAt: "2026-07-16T16:00:00.000Z",
+        id: "document-executed",
+        kind: "executed_agreement",
+        reviewNotes: null,
+        reviewedAt: null,
+        reviewStatus: "accepted",
+        status: "executed",
+        storagePath: "org-1/project-1/private-native-executed.pdf",
+        title: "Executed Form B Fiscal Sponsorship Agreement",
+        uploadedAt: null,
+        version: 2,
+        viewHref: "/api/fiscal-sponsorship/documents/document-executed",
+      },
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(MemberWorkspaceProjectFiscalDocuments, {
+        workflowSummary,
+      })
+    )
+
+    expect(markup).toContain("Executed Form B Fiscal Sponsorship Agreement")
+    expect(markup).toContain("Form B Execution Certificate")
+    expect(markup).toContain(
+      "/api/fiscal-sponsorship/documents/document-executed?download=1"
+    )
+    expect(markup).toContain(
+      "/api/fiscal-sponsorship/documents/document-audit?download=1"
+    )
+    expect(markup).not.toContain("private-native-executed.pdf")
+    expect(markup).not.toContain("private-native-audit.pdf")
+  })
+
+  it("does not expose unfinished or inaccessible fiscal records", () => {
+    const workflowSummary = buildWorkflowSummary({
+      latestExecutedAgreementDocument: {
+        assetId: null,
+        documentKey: null,
+        downloadHref: null,
+        generatedAt: "2026-07-16T16:00:00.000Z",
+        id: "document-draft",
+        kind: "executed_agreement",
+        reviewNotes: null,
+        reviewedAt: null,
+        reviewStatus: "pending",
+        status: "generated",
+        storagePath: "org-1/project-1/private-draft.pdf",
+        title: "Draft agreement",
+        uploadedAt: null,
+        version: 1,
+        viewHref: null,
+      },
+    })
+    const markup = renderToStaticMarkup(
+      React.createElement(MemberWorkspaceProjectFiscalDocuments, {
+        workflowSummary,
+      })
+    )
+
+    expect(markup).toBe("")
+  })
+})

--- a/tests/acceptance/member-workspace-project-note-actions.test.ts
+++ b/tests/acceptance/member-workspace-project-note-actions.test.ts
@@ -8,9 +8,12 @@ const { resolveMemberWorkspaceActorContextMock } = vi.hoisted(() => ({
   resolveMemberWorkspaceActorContextMock: vi.fn(),
 }))
 
-vi.mock("@/features/member-workspace/server/member-workspace-actor-context", () => ({
-  resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
-}))
+vi.mock(
+  "@/features/member-workspace/server/member-workspace-actor-context",
+  () => ({
+    resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
+  })
+)
 
 import {
   createMemberWorkspaceProjectNoteAction,
@@ -35,15 +38,30 @@ describe("member workspace project note actions", () => {
     resolveMemberWorkspaceActorContextMock.mockReset()
   })
 
-  it("rejects platform admins when they try to create organization notes", async () => {
+  it("allows platform admins to create organization notes", async () => {
     const projectQuery = createProjectQuery({
       id: "project-1",
       org_id: "org-1",
     })
+    const insertedPayloads: unknown[] = []
+    const notesTable = {
+      insert: vi.fn((payload: unknown) => {
+        insertedPayloads.push(payload)
+        return notesTable
+      }),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: "note-admin-1" },
+        error: null,
+      }),
+    }
     const supabase = {
       from: vi.fn((table: string) => {
         if (table === "organization_projects") {
           return projectQuery
+        }
+        if (table === "organization_project_notes") {
+          return notesTable
         }
         throw new Error(`Unexpected table query: ${table}`)
       }),
@@ -62,11 +80,20 @@ describe("member workspace project note actions", () => {
         projectId: "project-1",
         title: "Internal notes",
         content: "Keep this private to admins",
-      }),
+      })
     ).resolves.toEqual({
-      error:
-        "Platform admins can view organization project details here, but cannot edit them.",
+      ok: true,
+      noteId: "note-admin-1",
     })
+
+    expect(insertedPayloads[0]).toMatchObject({
+      org_id: "org-1",
+      project_id: "project-1",
+      title: "Internal notes",
+      created_by: "platform-admin-1",
+    })
+    expect(revalidatePathMock).toHaveBeenCalledWith("/organizations")
+    expect(revalidatePathMock).toHaveBeenCalledWith("/organizations/project-1")
   })
 
   it("rejects free users before loading project detail mutations", async () => {
@@ -88,7 +115,7 @@ describe("member workspace project note actions", () => {
         projectId: "project-1",
         title: "Free notes",
         content: "Should not write",
-      }),
+      })
     ).resolves.toEqual({ error: MEMBER_WORKSPACE_UPGRADE_MESSAGE })
 
     expect(supabase.from).not.toHaveBeenCalled()
@@ -137,7 +164,7 @@ describe("member workspace project note actions", () => {
         title: "Board recording",
         content: "<p>Attached recording</p>",
         noteType: "audio",
-      }),
+      })
     ).resolves.toEqual({
       ok: true,
       noteId: "note-1",
@@ -193,7 +220,7 @@ describe("member workspace project note actions", () => {
         title: "Board recording",
         content: "<p>Updated with a recording link</p>",
         noteType: "audio",
-      }),
+      })
     ).resolves.toEqual({
       ok: true,
       noteId: "note-1",

--- a/tests/acceptance/member-workspace-project-task-interactions.test.ts
+++ b/tests/acceptance/member-workspace-project-task-interactions.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+function readProjectComponent(fileName: string) {
+  return readFileSync(
+    join(
+      process.cwd(),
+      "src/features/member-workspace/components/projects",
+      fileName
+    ),
+    "utf8"
+  )
+}
+
+describe("member workspace project task interactions", () => {
+  it("persists workstream status changes and rolls back failed optimistic updates", () => {
+    const workstreamSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/platform-admin-dashboard/upstream/components/projects/WorkstreamTab.tsx"
+      ),
+      "utf8"
+    )
+    const detailTabsSource = readProjectComponent(
+      "member-workspace-project-detail-tabs.tsx"
+    )
+
+    expect(detailTabsSource).toContain(
+      "onUpdateTaskStatus={updateTaskStatusAction}"
+    )
+    expect(workstreamSource).toContain(
+      "const result = await onUpdateTaskStatus(taskId, nextStatus)"
+    )
+    expect(workstreamSource).toContain("setTaskStatus(previousStatus)")
+    expect(workstreamSource).toContain("toast.error(result.error)")
+    expect(workstreamSource).toContain("disabled={!canToggle}")
+    expect(workstreamSource).toContain("WORKSTREAM BREAKDOWN")
+    expect(workstreamSource).not.toContain("WORKSTEAM BREAKDOWN")
+  })
+
+  it("requires confirmation before either task delete control mutates data", () => {
+    const editorSource = readProjectComponent(
+      "member-workspace-project-tasks-editor.tsx"
+    )
+    const dialogSource = readProjectComponent(
+      "member-workspace-project-task-delete-dialog.tsx"
+    )
+
+    expect(editorSource).toContain("<MemberWorkspaceProjectTaskDeleteDialog")
+    expect(dialogSource).toContain("<AlertDialog")
+    expect(dialogSource).toContain(
+      "<AlertDialogTitle>Delete task?</AlertDialogTitle>"
+    )
+    expect(dialogSource).toContain("This cannot")
+    expect(dialogSource).toContain("be undone.")
+    expect(editorSource).toContain(
+      "onClick={() => setPendingDeleteTaskId(task.id)}"
+    )
+    expect(editorSource).toContain("? () => setPendingDeleteTaskId(task.id)")
+    expect(dialogSource).toContain("await deleteTaskAction(task.id)")
+    expect(dialogSource).toContain("event.preventDefault()")
+    expect(editorSource).not.toContain(
+      "onClick={() => handleDeleteTask(task.id)}"
+    )
+    expect(editorSource).not.toContain(
+      "onDelete={() => handleDeleteTask(task.id)}"
+    )
+  })
+})

--- a/tests/acceptance/member-workspace-task-actions.test.ts
+++ b/tests/acceptance/member-workspace-task-actions.test.ts
@@ -12,9 +12,12 @@ const { createSupabaseAdminClientMock } = vi.hoisted(() => ({
   createSupabaseAdminClientMock: vi.fn(),
 }))
 
-vi.mock("@/features/member-workspace/server/member-workspace-actor-context", () => ({
-  resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
-}))
+vi.mock(
+  "@/features/member-workspace/server/member-workspace-actor-context",
+  () => ({
+    resolveMemberWorkspaceActorContext: resolveMemberWorkspaceActorContextMock,
+  })
+)
 
 vi.mock("@/lib/supabase/admin", () => ({
   createSupabaseAdminClient: createSupabaseAdminClientMock,
@@ -24,6 +27,8 @@ import {
   createMemberWorkspaceTaskAction,
   deleteMemberWorkspaceTaskAction,
   updateMemberWorkspaceTaskAction,
+  updateMemberWorkspaceTaskOrderAction,
+  updateMemberWorkspaceTaskStatusAction,
 } from "@/features/member-workspace/server/task-actions"
 import { MEMBER_WORKSPACE_UPGRADE_MESSAGE } from "@/features/member-workspace/server/access"
 
@@ -41,7 +46,7 @@ function createProjectQuery(project: {
       Promise.resolve({
         data: project,
         error: null,
-      }),
+      })
     ),
   }
 }
@@ -53,9 +58,19 @@ describe("member workspace task actions", () => {
     createSupabaseAdminClientMock.mockReset()
   })
 
-  it("rejects platform admins when they try to create organization tasks", async () => {
+  it("validates the target project before a platform-admin task mutation", async () => {
+    const projectQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(() =>
+        Promise.resolve({
+          data: null,
+          error: null,
+        })
+      ),
+    }
     const supabase = {
-      from: vi.fn(),
+      from: vi.fn(() => projectQuery),
     }
 
     resolveMemberWorkspaceActorContextMock.mockResolvedValue({
@@ -63,7 +78,7 @@ describe("member workspace task actions", () => {
       userId: "platform-admin-1",
       isAdmin: true,
       activeOrg: { orgId: "org-1", role: "owner" },
-      canEdit: true,
+      canEdit: false,
     })
 
     await expect(
@@ -73,12 +88,10 @@ describe("member workspace task actions", () => {
         status: "todo",
         startDate: "2026-04-09",
         endDate: "2026-04-10",
-      }),
-    ).resolves.toEqual({
-      error: "Platform admins can view organization tasks here, but cannot edit them.",
-    })
+      })
+    ).resolves.toEqual({ error: "Choose a valid project." })
 
-    expect(supabase.from).not.toHaveBeenCalled()
+    expect(supabase.from).toHaveBeenCalledWith("organization_projects")
     expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
   })
 
@@ -103,7 +116,7 @@ describe("member workspace task actions", () => {
         status: "todo",
         startDate: "2026-04-09",
         endDate: "2026-04-10",
-      }),
+      })
     ).resolves.toEqual({ error: MEMBER_WORKSPACE_UPGRADE_MESSAGE })
 
     expect(supabase.from).not.toHaveBeenCalled()
@@ -142,7 +155,7 @@ describe("member workspace task actions", () => {
         status: "todo",
         startDate: "2026-04-09",
         endDate: "2026-04-10",
-      }),
+      })
     ).resolves.toEqual({
       error: "Choose a valid project.",
     })
@@ -163,7 +176,7 @@ describe("member workspace task actions", () => {
             project_id: "project-standard",
           },
           error: null,
-        }),
+        })
       ),
     }
 
@@ -201,7 +214,7 @@ describe("member workspace task actions", () => {
         status: "todo",
         startDate: "2026-04-09",
         endDate: "2026-04-10",
-      }),
+      })
     ).resolves.toEqual({
       error: "Choose a valid project.",
     })
@@ -226,7 +239,7 @@ describe("member workspace task actions", () => {
         Promise.resolve({
           data: [{ user_id: "org-1" }],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -244,7 +257,7 @@ describe("member workspace task actions", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -270,7 +283,7 @@ describe("member workspace task actions", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -307,7 +320,7 @@ describe("member workspace task actions", () => {
         startDate: "2026-04-09",
         endDate: "2026-04-10",
         assigneeUserId: "platform-admin-2",
-      }),
+      })
     ).resolves.toEqual({
       error: "Choose a valid assignee.",
     })
@@ -315,13 +328,13 @@ describe("member workspace task actions", () => {
     expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
   })
 
-  it("rejects platform admins even when they try to assign other platform admins", async () => {
+  it("allows platform admins to create tasks on canonical organization workstreams", async () => {
     const projectQuery = createProjectQuery({
-      id: "project-standard",
+      id: "project-organization",
       org_id: "org-1",
       task_count: 3,
-      project_kind: "standard",
-      created_source: "user",
+      project_kind: "organization_admin",
+      created_source: "system",
     })
 
     const organizationsQuery = {
@@ -331,7 +344,7 @@ describe("member workspace task actions", () => {
         Promise.resolve({
           data: [{ user_id: "org-1" }],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -349,7 +362,7 @@ describe("member workspace task actions", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -375,7 +388,7 @@ describe("member workspace task actions", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -415,7 +428,7 @@ describe("member workspace task actions", () => {
             },
           ],
           error: null,
-        }),
+        })
       ),
     }
 
@@ -442,23 +455,61 @@ describe("member workspace task actions", () => {
       userId: "platform-admin-1",
       isAdmin: true,
       activeOrg: { orgId: "org-1", role: "owner" },
-      canEdit: true,
+      canEdit: false,
+    })
+
+    const taskInsertQuery = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn(() =>
+        Promise.resolve({ data: { id: "task-admin-created" }, error: null })
+      ),
+    }
+    const assigneeMutationQuery = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    }
+    const projectUpdateQuery = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+
+    createSupabaseAdminClientMock.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "organization_tasks") return taskInsertQuery
+        if (table === "organization_task_assignees") {
+          return assigneeMutationQuery
+        }
+        if (table === "organization_projects") return projectUpdateQuery
+        throw new Error(`Unexpected admin table query: ${table}`)
+      }),
     })
 
     await expect(
       createMemberWorkspaceTaskAction({
-        projectId: "project-standard",
+        projectId: "project-organization",
         title: "Review grant timeline",
         status: "todo",
         startDate: "2026-04-09",
         endDate: "2026-04-10",
         assigneeUserId: "platform-admin-2",
-      }),
-    ).resolves.toEqual({
-      error: "Platform admins can view organization tasks here, but cannot edit them.",
-    })
+      })
+    ).resolves.toEqual({ ok: true, taskId: "task-admin-created" })
 
-    expect(createSupabaseAdminClientMock).not.toHaveBeenCalled()
+    expect(taskInsertQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_id: "org-1",
+        project_id: "project-organization",
+        created_by: "platform-admin-1",
+      })
+    )
+    expect(assigneeMutationQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task_id: "task-admin-created",
+        user_id: "platform-admin-2",
+      })
+    )
   })
 
   it("deletes a task and revalidates the project surfaces", async () => {
@@ -473,7 +524,7 @@ describe("member workspace task actions", () => {
             project_id: "project-standard",
           },
           error: null,
-        }),
+        })
       ),
     }
 
@@ -498,7 +549,7 @@ describe("member workspace task actions", () => {
             task_count: 2,
           },
           error: null,
-        }),
+        })
       ),
     }
 
@@ -507,19 +558,30 @@ describe("member workspace task actions", () => {
       eq: vi.fn().mockReturnThis(),
     }
 
+    const actorProjectQuery = createProjectQuery({
+      id: "project-standard",
+      org_id: "org-1",
+      task_count: 2,
+      project_kind: "standard",
+      created_source: "user",
+    })
+
     resolveMemberWorkspaceActorContextMock.mockResolvedValue({
       supabase: {
         from: vi.fn((table: string) => {
           if (table === "organization_tasks") {
             return taskQuery
           }
+          if (table === "organization_projects") {
+            return actorProjectQuery
+          }
           throw new Error(`Unexpected table query: ${table}`)
         }),
       },
-      userId: "user-1",
-      isAdmin: false,
+      userId: "platform-admin-1",
+      isAdmin: true,
       activeOrg: { orgId: "org-1", role: "owner" },
-      canEdit: true,
+      canEdit: false,
       hasMemberWorkspaceAccess: true,
     })
 
@@ -550,12 +612,259 @@ describe("member workspace task actions", () => {
     expect(taskDeleteQuery.delete).toHaveBeenCalledTimes(1)
     expect(projectUpdateQuery.update).toHaveBeenCalledWith({
       task_count: 1,
-      updated_by: "user-1",
+      updated_by: "platform-admin-1",
     })
     expect(revalidatePathMock).toHaveBeenCalledWith("/tasks")
     expect(revalidatePathMock).toHaveBeenCalledWith("/organizations")
     expect(revalidatePathMock).toHaveBeenCalledWith(
       "/organizations/project-standard"
     )
+  })
+
+  it("allows platform admins to change task status for a real project", async () => {
+    const taskQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: "task-1",
+            org_id: "org-2",
+            project_id: "project-2",
+            status: "todo",
+          },
+          error: null,
+        })
+      ),
+    }
+    const projectQuery = createProjectQuery({
+      id: "project-2",
+      org_id: "org-2",
+      task_count: 1,
+      project_kind: "standard",
+      created_source: "user",
+    })
+    resolveMemberWorkspaceActorContextMock.mockResolvedValue({
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === "organization_tasks") return taskQuery
+          if (table === "organization_projects") return projectQuery
+          throw new Error(`Unexpected table query: ${table}`)
+        }),
+      },
+      userId: "platform-admin-1",
+      isAdmin: true,
+      activeOrg: { orgId: "admin-active-org", role: "member" },
+      canEdit: false,
+    })
+
+    const taskUpdateQuery = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+    createSupabaseAdminClientMock.mockReturnValue({
+      from: vi.fn(() => taskUpdateQuery),
+    })
+
+    await expect(
+      updateMemberWorkspaceTaskStatusAction("task-1", "done")
+    ).resolves.toEqual({ ok: true, taskId: "task-1", status: "done" })
+
+    expect(taskUpdateQuery.update).toHaveBeenCalledWith({
+      status: "done",
+      updated_by: "platform-admin-1",
+    })
+  })
+
+  it("allows platform admins to update task details for a real project", async () => {
+    const existingTaskQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: "task-1",
+            org_id: "org-2",
+            project_id: "project-2",
+          },
+          error: null,
+        })
+      ),
+    }
+    const projectQuery = createProjectQuery({
+      id: "project-2",
+      org_id: "org-2",
+      task_count: 1,
+      project_kind: "standard",
+      created_source: "user",
+    })
+    const organizationsQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      returns: vi.fn(() =>
+        Promise.resolve({ data: [{ user_id: "org-2" }], error: null })
+      ),
+    }
+    const membershipsQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      returns: vi.fn(() => Promise.resolve({ data: [], error: null })),
+    }
+    const platformAdminsQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      returns: vi.fn(() =>
+        Promise.resolve({
+          data: [
+            {
+              id: "platform-admin-1",
+              full_name: "Alex Admin",
+              avatar_url: null,
+              email: "alex.admin@example.com",
+              role: "admin",
+            },
+          ],
+          error: null,
+        })
+      ),
+    }
+    const profilesByIdQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      returns: vi.fn(() =>
+        Promise.resolve({
+          data: [
+            {
+              id: "org-2",
+              full_name: "Owner Person",
+              avatar_url: null,
+              email: "owner@example.com",
+              role: "member",
+            },
+            {
+              id: "platform-admin-1",
+              full_name: "Alex Admin",
+              avatar_url: null,
+              email: "alex.admin@example.com",
+              role: "admin",
+            },
+          ],
+          error: null,
+        })
+      ),
+    }
+    let profilesCalls = 0
+    resolveMemberWorkspaceActorContextMock.mockResolvedValue({
+      supabase: {
+        from: vi.fn((table: string) => {
+          if (table === "organization_tasks") return existingTaskQuery
+          if (table === "organization_projects") return projectQuery
+          if (table === "organizations") return organizationsQuery
+          if (table === "organization_memberships") return membershipsQuery
+          if (table === "profiles") {
+            profilesCalls += 1
+            return profilesCalls === 1 ? platformAdminsQuery : profilesByIdQuery
+          }
+          throw new Error(`Unexpected table query: ${table}`)
+        }),
+      },
+      userId: "platform-admin-1",
+      isAdmin: true,
+      activeOrg: { orgId: "admin-active-org", role: "member" },
+      canEdit: false,
+    })
+
+    const taskUpdateQuery = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+    const assigneeMutationQuery = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      insert: vi.fn(() => Promise.resolve({ error: null })),
+    }
+    createSupabaseAdminClientMock.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "organization_tasks") return taskUpdateQuery
+        if (table === "organization_task_assignees") {
+          return assigneeMutationQuery
+        }
+        throw new Error(`Unexpected admin table query: ${table}`)
+      }),
+    })
+
+    await expect(
+      updateMemberWorkspaceTaskAction("task-1", {
+        projectId: "project-2",
+        title: "Updated by Coach House",
+        status: "in-progress",
+        startDate: "2026-04-09",
+        endDate: "2026-04-12",
+      })
+    ).resolves.toEqual({ ok: true, taskId: "task-1" })
+
+    expect(taskUpdateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Updated by Coach House",
+        org_id: "org-2",
+        project_id: "project-2",
+        updated_by: "platform-admin-1",
+      })
+    )
+  })
+
+  it("allows platform admins to reorder every task in a real project", async () => {
+    const projectQuery = createProjectQuery({
+      id: "project-2",
+      org_id: "org-2",
+      task_count: 2,
+      project_kind: "standard",
+      created_source: "user",
+    })
+    resolveMemberWorkspaceActorContextMock.mockResolvedValue({
+      supabase: {
+        from: vi.fn(() => projectQuery),
+      },
+      userId: "platform-admin-1",
+      isAdmin: true,
+      activeOrg: { orgId: "admin-active-org", role: "member" },
+      canEdit: false,
+    })
+
+    const taskRowsQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      returns: vi.fn(() =>
+        Promise.resolve({
+          data: [{ id: "task-1" }, { id: "task-2" }],
+          error: null,
+        })
+      ),
+    }
+    const taskUpdateQuery = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+    let taskTableCalls = 0
+    createSupabaseAdminClientMock.mockReturnValue({
+      from: vi.fn(() => {
+        taskTableCalls += 1
+        return taskTableCalls === 1 ? taskRowsQuery : taskUpdateQuery
+      }),
+    })
+
+    await expect(
+      updateMemberWorkspaceTaskOrderAction("project-2", ["task-2", "task-1"])
+    ).resolves.toEqual({ ok: true, projectId: "project-2" })
+
+    expect(taskUpdateQuery.update).toHaveBeenNthCalledWith(1, {
+      sort_order: 0,
+      updated_by: "platform-admin-1",
+    })
+    expect(taskUpdateQuery.update).toHaveBeenNthCalledWith(2, {
+      sort_order: 1,
+      updated_by: "platform-admin-1",
+    })
   })
 })


### PR DESCRIPTION
## Summary
- replace Backlog, Planned, Active, and Completed with six operational coach categories
- let super admins add, rename, and delete custom categories while protecting defaults
- add production-backed organization cards, placements, real task counts, completeness, program dates, task CRUD, activity history, and fiscal-document access
- preserve coach-owned project metadata during canonical synchronization
- add least-privilege table grants, supporting indexes, and task-count reconciliation as the post-deploy hardening migration

## Default categories
1. New Intake
2. Coach Action
3. Waiting on Organization
4. Review & Approval
5. Ongoing Support
6. Complete

## Verification
- pnpm check:quality: passed
- acceptance: 299 files passed, 1 skipped; 1,449 tests passed, 1 skipped
- linked RLS: passed
- production build and TypeScript: passed
- visuals: 14 passed
- performance budgets: passed
- linked migration dry run: only 20260717143300 pending

## Rollout
Merge and verify both Vercel production deployments first. Apply the pending hardening migration only after the application synchronization fix is live.