### PR TITLE
[STEP S99] Record platform staff rollout

### DIFF
--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -246,3 +246,10 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Extracted the release from the dirty root into the clean `agent/platform-staff-access` worktree based on current `origin/main`; the original dirty worktree remains untouched by packaging.
 - Focused acceptance passed (`13 files`, `84 tests`), lint and focused structural guardrails passed, full acceptance passed (`301 files passed`, `1 skipped`; `1,462 tests passed`, `1 skipped`), snapshots and production build passed, clean-branch visuals passed (`14/14`), performance budgets passed, and the RLS test file passed syntax validation. Linked RLS execution was skipped because the clean worktree has no Supabase credentials.
 - No production database write, account role change, migration application, merge, or deployment occurred.
+
+2026-07-21 15:23 EDT - completed the platform staff access production rollout.
+
+- Merged PR #90 as step S98 at main commit `858226f`. GitHub quality passed, both Vercel production projects completed successfully, and `https://coachhouse.app/` plus `/find` return `200`; protected `/organizations` and `/admin/platform` routes redirect signed-out requests to login.
+- The Supabase integration applied `20260721121500_add_platform_staff_access.sql`; local and linked migration history now match through `20260721121500`, so no duplicate manual database push was run.
+- Verified live access state: `caleb@bandto.com` remains a developer with profile role `admin`; Paula, `fs@coachhousesolutions.org`, and Joel are coaches with profile role `member`.
+- The complete linked RLS suite passed, including proof that a coach is recognized as platform staff without broad administrator privileges. The original dirty worktree remains untouched by release packaging.


### PR DESCRIPTION
## What

Record the completed platform staff access production rollout in the July runlog.

## Verified

- PR #90 merged as S98 at `858226f`
- both Vercel production projects succeeded
- migration history matches through `20260721121500`
- Caleb is developer; Paula, FS, and Joel are coaches
- linked RLS passed
- canonical public and protected-route probes passed

## Checks

- pre-push structural gate passed
- snapshots passed
- acceptance: 301 files passed, 1 skipped; 1,462 tests passed, 1 skipped
