### PR TITLE
[STEP S00] Add organization coach assignments

### DIFF
--- a/docs/plans/2026-07-21-organization-coach-assignments-design.md
+++ b/docs/plans/2026-07-21-organization-coach-assignments-design.md
@@ -1,0 +1,40 @@
+# Organization Coach Assignments
+
+## Goal
+
+Let developers assign one primary coach to each organization from `/organizations` while preserving current coach access until assignment coverage is complete.
+
+## Release Sequence
+
+1. Ship the assignment table, server authorization, loaders, and UI.
+2. Populate assignments through the developer-only controls.
+3. In a separate release, filter coach organization access to assigned organizations.
+
+This sequence avoids hiding all organizations from coaches before mappings exist.
+
+## Data Contract
+
+`organization_coach_assignments` stores one row per organization:
+
+- `organization_id` primary key and foreign key to `organizations.user_id`
+- `coach_user_id` foreign key to `platform_staff_members.user_id`
+- `assigned_by` foreign key to `profiles.id`
+- UTC `created_at` and `updated_at`
+
+The server validates that the selected staff member has `access_level = 'coach'`. RLS lets authenticated platform staff read assignments and permits only developers to insert, update, or delete them. Foreign keys used for lookups and cascades are indexed.
+
+## Server Flow
+
+Independent organization, coach-option, assignment, project, and workstream reads run in parallel where dependencies permit. A server action authenticates and authorizes every mutation, validates UUID inputs, verifies the organization and coach, then atomically upserts or deletes the assignment. Both `/organizations` and the organization detail route are revalidated after success.
+
+Only minimal assignment fields cross the RSC boundary: organization id, coach id, display name, avatar, and email.
+
+## UI
+
+A shared accessible popover picker appears on canonical organization cards and organization detail pages for developers. The trigger shows the assigned coach or `Unassigned`; coaches see the current assignment as read-only. The picker uses native buttons, visible focus, keyboard navigation, 44px mobile targets, pending feedback, long-text truncation, and an empty state. Assignment changes use `useTransition`, optimistic local display, rollback on failure, and a toast result.
+
+## Verification
+
+- acceptance coverage for mapping, validation, authorization, mutation, and UI contracts
+- RLS coverage for staff reads, developer writes, coach write denial, and one-row-per-organization behavior
+- lint, schema types, route/feature/boundary/threshold checks, build, visuals, and production probes

--- a/docs/plans/2026-07-21-organization-coach-assignments-implementation.md
+++ b/docs/plans/2026-07-21-organization-coach-assignments-implementation.md
@@ -1,0 +1,9 @@
+# Organization Coach Assignments Implementation
+
+1. Scaffold `organization-coach-assignments` and add domain types/mappers.
+2. Add the assignment migration, generated schema type, table registry, and RLS tests.
+3. Add coach-option and assignment loaders plus the developer-only server action.
+4. Attach assignment data to canonical organization project cards and detail results.
+5. Add the shared assignment picker and connect list, board, and detail surfaces.
+6. Add focused acceptance coverage and append the July runlog.
+7. Run the full release gate, then publish as a separate PR.

--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -253,3 +253,11 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - The Supabase integration applied `20260721121500_add_platform_staff_access.sql`; local and linked migration history now match through `20260721121500`, so no duplicate manual database push was run.
 - Verified live access state: `caleb@bandto.com` remains a developer with profile role `admin`; Paula, `fs@coachhousesolutions.org`, and Joel are coaches with profile role `member`.
 - The complete linked RLS suite passed, including proof that a coach is recognized as platform staff without broad administrator privileges. The original dirty worktree remains untouched by release packaging.
+
+2026-07-21 19:49 EDT - prepared organization coach assignments for release.
+
+- Added one primary coach assignment per organization with a database-enforced coach-level target, UTC audit fields, platform-staff reads, developer-only writes, and RLS coverage for developer assignment, coach reads, regular-member isolation, and coach write denial.
+- Added server-side assignment loaders and a developer-only authenticated mutation. The server validates UUIDs, organization existence, coach access level, and revalidates the Organizations layout after each upsert or removal.
+- Added shared assignment controls to canonical organization cards in list and board views and to organization detail headers. Developers receive an accessible optimistic picker with rollback, pending and empty states; coaches receive the same assignment state read-only.
+- Kept current coach organization visibility unchanged until assignments are populated, preventing organizations from disappearing during rollout. Assigned-only coach scoping remains the next release segment.
+- The complete release gate passed lint, structural guardrails, snapshots, acceptance (`302 files passed`, `1 skipped`; `1,465 tests passed`, `1 skipped`), production build and TypeScript, isolated clean-branch visuals (`14/14`), and performance budgets. Local RLS execution was skipped because this clean worktree has no Supabase credentials; the migration and expanded linked RLS suite remain required in CI/production rollout verification. The original dirty worktree remains untouched.

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -28,6 +28,10 @@ import {
 } from "@/features/member-workspace"
 import { requirePlatformCapability } from "@/lib/admin/auth"
 import type { ProjectDetails } from "@/features/platform-admin-dashboard"
+import {
+  loadOrganizationCoachAssignmentData,
+  updateOrganizationCoachAssignmentAction,
+} from "@/features/organization-coach-assignments"
 
 type PageProps = {
   params: Promise<{ id: string }>
@@ -85,8 +89,13 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
     result.scope === "organization" || result.scope === "platform-admin"
   const canDeleteProject =
     canEditProjectDetails && projectKind !== "organization_admin"
-  const fiscalSponsorshipWorkflowSummary =
-    await loadFiscalSponsorshipProjectWorkflowSummary(result.project.id)
+  const [fiscalSponsorshipWorkflowSummary, coachAssignmentData] =
+    await Promise.all([
+      loadFiscalSponsorshipProjectWorkflowSummary(result.project.id),
+      loadOrganizationCoachAssignmentData({
+        organizationIds: [result.organizationSummary.orgId],
+      }),
+    ])
   const fiscalSponsorshipWorkflowData =
     "error" in fiscalSponsorshipWorkflowSummary
       ? null
@@ -98,6 +107,20 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
       assigneeOptions={result.assigneeOptions}
       currentUser={result.currentUser}
       organizationSummary={result.organizationSummary}
+      coachAssignment={
+        coachAssignmentData.assignmentsByOrganizationId.get(
+          result.organizationSummary.orgId
+        ) ?? null
+      }
+      coachOptions={coachAssignmentData.coachOptions}
+      canManageCoachAssignment={
+        coachAssignmentData.available && staff.accessLevel === "developer"
+      }
+      updateCoachAssignmentAction={
+        coachAssignmentData.available && staff.accessLevel === "developer"
+          ? updateOrganizationCoachAssignmentAction
+          : undefined
+      }
       fiscalSponsorshipWorkflowSummary={fiscalSponsorshipWorkflowData}
       canManageProject={canManageProject}
       canManageProjectAssets={canManageProjectAssets}

--- a/src/app/(dashboard)/organizations/page.tsx
+++ b/src/app/(dashboard)/organizations/page.tsx
@@ -13,14 +13,29 @@ import {
   updateMemberWorkspaceProjectStatusAction,
 } from "@/features/member-workspace"
 import { requirePlatformCapability } from "@/lib/admin/auth"
+import {
+  loadOrganizationCoachAssignmentData,
+  updateOrganizationCoachAssignmentAction,
+} from "@/features/organization-coach-assignments"
 
 export default async function OrganizationsPage() {
-  await requirePlatformCapability("organizations", {
+  const staff = await requirePlatformCapability("organizations", {
     loginRedirect: "/organizations",
   })
 
+  const pageData = await loadMemberWorkspaceProjectsPage()
+  const coachAssignmentData = await loadOrganizationCoachAssignmentData({
+    organizationIds: pageData.organizationOptions.map(({ orgId }) => orgId),
+  })
+  const projects = pageData.projects.map((project) => ({
+    ...project,
+    organizationCoachAssignment: project.organizationId
+      ? (coachAssignmentData.assignmentsByOrganizationId.get(
+          project.organizationId
+        ) ?? null)
+      : null,
+  }))
   const {
-    projects,
     storageMode,
     canResetStarterData,
     starterProjectCount,
@@ -29,7 +44,7 @@ export default async function OrganizationsPage() {
     organizationOptions,
     assigneeOptions,
     workstreamCategories,
-  } = await loadMemberWorkspaceProjectsPage()
+  } = pageData
 
   return (
     <MemberWorkspaceProjectsPage
@@ -56,6 +71,15 @@ export default async function OrganizationsPage() {
       scope={scope}
       organizationOptions={organizationOptions}
       assigneeOptions={assigneeOptions}
+      coachOptions={coachAssignmentData.coachOptions}
+      canManageCoachAssignments={
+        coachAssignmentData.available && staff.accessLevel === "developer"
+      }
+      updateCoachAssignmentAction={
+        coachAssignmentData.available && staff.accessLevel === "developer"
+          ? updateOrganizationCoachAssignmentAction
+          : undefined
+      }
       workstreamCategories={workstreamCategories}
       createWorkstreamCategoryAction={
         createPlatformAdminWorkstreamCategoryAction

--- a/src/features/member-workspace/components/projects/member-workspace-project-board-view.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-board-view.tsx
@@ -28,6 +28,11 @@ import {
 import { MemberWorkspaceProjectCard } from "./member-workspace-project-card"
 import type { MemberWorkspaceWorkstreamCategory } from "../../types"
 import {
+  OrganizationCoachAssignmentControl,
+  type OrganizationCoachAssignmentAction,
+  type OrganizationCoachOption,
+} from "@/features/organization-coach-assignments"
+import {
   MemberWorkspaceProjectBoardCategoryMenu,
   MemberWorkspaceProjectBoardCategoryToolbar,
 } from "./member-workspace-project-board-category-controls"
@@ -100,6 +105,9 @@ export function MemberWorkspaceProjectBoardView({
   deleteWorkstreamCategoryAction,
   restoreWorkstreamDefaultsAction,
   updateProjectWorkstreamAction,
+  coachOptions = [],
+  canManageCoachAssignments = false,
+  updateCoachAssignmentAction,
 }: {
   projects: PlatformAdminDashboardLabProject[]
   onAddProject?: () => void
@@ -128,6 +136,9 @@ export function MemberWorkspaceProjectBoardView({
     projectId: string,
     categoryId: string
   ) => Promise<{ ok: true; id: string } | { error: string }>
+  coachOptions?: OrganizationCoachOption[]
+  canManageCoachAssignments?: boolean
+  updateCoachAssignmentAction?: OrganizationCoachAssignmentAction
 }) {
   const router = useRouter()
   const [items, setItems] =
@@ -376,39 +387,56 @@ export function MemberWorkspaceProjectBoardView({
                       }
                       visibleProperties={visibleProperties}
                       actions={
-                        canManageProjectCard ? (
-                          <Popover>
-                            <PopoverTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7 rounded-lg"
-                                disabled={pendingProjectIds.includes(
-                                  project.id
-                                )}
-                                type="button"
-                              >
-                                <DotsThreeVertical className="h-4 w-4" />
-                              </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-40 p-2" align="end">
-                              <div className="space-y-1">
-                                {columns.map((nextColumn) => (
-                                  <button
-                                    key={nextColumn.id}
-                                    type="button"
-                                    className="hover:bg-accent w-full rounded-md px-2 py-1 text-left text-sm"
-                                    onClick={() =>
-                                      moveProject(project.id, nextColumn.id)
-                                    }
-                                  >
-                                    Move to {nextColumn.label}
-                                  </button>
-                                ))}
-                              </div>
-                            </PopoverContent>
-                          </Popover>
-                        ) : undefined
+                        <>
+                          {project.projectKind === "organization_admin" &&
+                          project.organizationId ? (
+                            <OrganizationCoachAssignmentControl
+                              assignment={
+                                project.organizationCoachAssignment ?? null
+                              }
+                              canManage={canManageCoachAssignments}
+                              coachOptions={coachOptions}
+                              organizationId={project.organizationId}
+                              organizationName={project.name}
+                              updateAssignmentAction={
+                                updateCoachAssignmentAction
+                              }
+                            />
+                          ) : null}
+                          {canManageProjectCard ? (
+                            <Popover>
+                              <PopoverTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7 rounded-lg"
+                                  disabled={pendingProjectIds.includes(
+                                    project.id
+                                  )}
+                                  type="button"
+                                >
+                                  <DotsThreeVertical className="h-4 w-4" />
+                                </Button>
+                              </PopoverTrigger>
+                              <PopoverContent className="w-40 p-2" align="end">
+                                <div className="space-y-1">
+                                  {columns.map((nextColumn) => (
+                                    <button
+                                      key={nextColumn.id}
+                                      type="button"
+                                      className="hover:bg-accent w-full rounded-md px-2 py-1 text-left text-sm"
+                                      onClick={() =>
+                                        moveProject(project.id, nextColumn.id)
+                                      }
+                                    >
+                                      Move to {nextColumn.label}
+                                    </button>
+                                  ))}
+                                </div>
+                              </PopoverContent>
+                            </Popover>
+                          ) : null}
+                        </>
                       }
                     />
                   </div>

--- a/src/features/member-workspace/components/projects/member-workspace-project-cards-view.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-cards-view.tsx
@@ -6,6 +6,11 @@ import { Button } from "@/components/ui/button"
 import type { PlatformAdminDashboardLabProject } from "@/features/platform-admin-dashboard"
 import { Empty } from "@/components/ui/empty"
 import { MemberWorkspaceProjectCard } from "./member-workspace-project-card"
+import {
+  OrganizationCoachAssignmentControl,
+  type OrganizationCoachAssignmentAction,
+  type OrganizationCoachOption,
+} from "@/features/organization-coach-assignments"
 
 export function MemberWorkspaceProjectCardsView({
   onEditProject,
@@ -13,12 +18,18 @@ export function MemberWorkspaceProjectCardsView({
   onCreateProject,
   scope,
   visibleProperties,
+  coachOptions = [],
+  canManageCoachAssignments = false,
+  updateCoachAssignmentAction,
 }: {
   onEditProject?: (project: PlatformAdminDashboardLabProject) => void
   projects: PlatformAdminDashboardLabProject[]
   onCreateProject?: () => void
   scope: "organization" | "platform-admin"
   visibleProperties?: Array<"title" | "status" | "assignee" | "dueDate">
+  coachOptions?: OrganizationCoachOption[]
+  canManageCoachAssignments?: boolean
+  updateCoachAssignmentAction?: OrganizationCoachAssignmentAction
 }) {
   if (projects.length === 0) {
     return (
@@ -58,6 +69,19 @@ export function MemberWorkspaceProjectCardsView({
                 : onEditProject
             }
             visibleProperties={visibleProperties}
+            actions={
+              project.projectKind === "organization_admin" &&
+              project.organizationId ? (
+                <OrganizationCoachAssignmentControl
+                  assignment={project.organizationCoachAssignment ?? null}
+                  canManage={canManageCoachAssignments}
+                  coachOptions={coachOptions}
+                  organizationId={project.organizationId}
+                  organizationName={project.name}
+                  updateAssignmentAction={updateCoachAssignmentAction}
+                />
+              ) : undefined
+            }
           />
         ))}
         {onCreateProject ? (

--- a/src/features/member-workspace/components/projects/member-workspace-project-detail-header.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-detail-header.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import type { ReactNode } from "react"
+
 import {
   ArrowsClockwise,
   Briefcase,
@@ -87,6 +89,7 @@ type MemberWorkspaceProjectDetailHeaderProps = {
     value: string
   ) => void
   onEditProject?: () => void
+  actions?: ReactNode
 }
 
 function InlineEditableText({
@@ -146,6 +149,7 @@ export function MemberWorkspaceProjectDetailHeader({
   draft,
   onChangeDraftField,
   onEditProject,
+  actions,
 }: MemberWorkspaceProjectDetailHeaderProps) {
   const statusLabel =
     isEditing && draft
@@ -331,18 +335,21 @@ export function MemberWorkspaceProjectDetailHeader({
           ) : null}
         </div>
 
-        {canEditProject && !isEditing ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Edit project"
-            className="text-muted-foreground hover:text-foreground size-9 rounded-lg"
-            onClick={onEditProject}
-          >
-            <PencilSimpleLine className="h-4 w-4" />
-          </Button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {actions}
+          {canEditProject && !isEditing ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Edit project"
+              className="text-muted-foreground hover:text-foreground size-9 rounded-lg"
+              onClick={onEditProject}
+            >
+              <PencilSimpleLine className="h-4 w-4" />
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {!isEditing ? (

--- a/src/features/member-workspace/components/projects/member-workspace-project-detail-page.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-project-detail-page.tsx
@@ -41,6 +41,12 @@ import { MemberWorkspaceProjectDetailTabs } from "./member-workspace-project-det
 import { ProjectDetailTopBarActions } from "./member-workspace-project-detail-top-bar-actions"
 import { useProjectAssetActions } from "./member-workspace-project-asset-actions"
 import { useMemberWorkspaceProjectTaskCreate } from "./member-workspace-project-task-create"
+import {
+  OrganizationCoachAssignmentControl,
+  type OrganizationCoachAssignment,
+  type OrganizationCoachAssignmentAction,
+  type OrganizationCoachOption,
+} from "@/features/organization-coach-assignments"
 
 type MemberWorkspaceProjectDetailPageProps = {
   project: ProjectDetails
@@ -48,6 +54,10 @@ type MemberWorkspaceProjectDetailPageProps = {
   currentUser: User
   fiscalSponsorshipWorkflowSummary?: FiscalSponsorshipProjectWorkflowSummary | null
   organizationSummary: MemberWorkspaceAdminOrganizationSummary
+  coachAssignment?: OrganizationCoachAssignment | null
+  coachOptions?: OrganizationCoachOption[]
+  canManageCoachAssignment?: boolean
+  updateCoachAssignmentAction?: OrganizationCoachAssignmentAction
   canManageProject?: boolean
   canManageProjectAssets?: boolean
   canEditProjectDetails?: boolean
@@ -163,6 +173,10 @@ export function MemberWorkspaceProjectDetailPage({
   currentUser,
   fiscalSponsorshipWorkflowSummary,
   organizationSummary,
+  coachAssignment = null,
+  coachOptions = [],
+  canManageCoachAssignment = false,
+  updateCoachAssignmentAction,
   canManageProject: canManageProjectProp,
   canManageProjectAssets: canManageProjectAssetsProp,
   canEditProjectDetails: canEditProjectDetailsProp,
@@ -405,6 +419,16 @@ export function MemberWorkspaceProjectDetailPage({
                     draft={projectDraft}
                     onChangeDraftField={handleChangeProjectDraftField}
                     onEditProject={handleStartProjectEditing}
+                    actions={
+                      <OrganizationCoachAssignmentControl
+                        assignment={coachAssignment}
+                        canManage={canManageCoachAssignment}
+                        coachOptions={coachOptions}
+                        organizationId={organizationSummary.orgId}
+                        organizationName={organizationSummary.name}
+                        updateAssignmentAction={updateCoachAssignmentAction}
+                      />
+                    }
                   />
 
                   <MemberWorkspaceProjectDetailTabs

--- a/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
@@ -26,6 +26,10 @@ import { MemberWorkspaceProjectViewOptionsPopover } from "./member-workspace-pro
 import { MemberWorkspaceProjectWizard } from "./member-workspace-project-wizard"
 import { MemberWorkspaceClearStarterDataButton } from "../shared/member-workspace-clear-starter-data-button"
 import styles from "./member-workspace-projects-surface-theme.module.css"
+import type {
+  OrganizationCoachAssignmentAction,
+  OrganizationCoachOption,
+} from "@/features/organization-coach-assignments"
 import {
   applyViewOptionsToParams,
   DEFAULT_MEMBER_WORKSPACE_PROJECT_VIEW_OPTIONS as DEFAULT_VIEW_OPTIONS,
@@ -60,6 +64,9 @@ export function MemberWorkspaceProjectsPage(props: {
   canCreateProjects: boolean
   organizationOptions: MemberWorkspaceProjectOrganizationOption[]
   assigneeOptions: MemberWorkspacePersonOption[]
+  coachOptions?: OrganizationCoachOption[]
+  canManageCoachAssignments?: boolean
+  updateCoachAssignmentAction?: OrganizationCoachAssignmentAction
   scope: "organization" | "platform-admin"
   workstreamCategories?: MemberWorkspaceWorkstreamCategory[]
   createWorkstreamCategoryAction?: (
@@ -93,6 +100,9 @@ export function MemberWorkspaceProjectsPage(props: {
     canCreateProjects,
     organizationOptions,
     scope,
+    coachOptions = [],
+    canManageCoachAssignments = false,
+    updateCoachAssignmentAction,
     workstreamCategories = [],
     createWorkstreamCategoryAction,
     updateWorkstreamCategoryAction,
@@ -249,6 +259,9 @@ export function MemberWorkspaceProjectsPage(props: {
                   : undefined
               }
               scope={scope}
+              coachOptions={coachOptions}
+              canManageCoachAssignments={canManageCoachAssignments}
+              updateCoachAssignmentAction={updateCoachAssignmentAction}
             />
           ) : null}
           {viewOptions.viewType === "board" ? (
@@ -263,6 +276,9 @@ export function MemberWorkspaceProjectsPage(props: {
               deleteWorkstreamCategoryAction={deleteWorkstreamCategoryAction}
               restoreWorkstreamDefaultsAction={restoreWorkstreamDefaultsAction}
               updateProjectWorkstreamAction={updateProjectWorkstreamAction}
+              coachOptions={coachOptions}
+              canManageCoachAssignments={canManageCoachAssignments}
+              updateCoachAssignmentAction={updateCoachAssignmentAction}
               onAddProject={
                 canCreateProjects
                   ? () => {

--- a/src/features/organization-coach-assignments/README.md
+++ b/src/features/organization-coach-assignments/README.md
@@ -1,0 +1,22 @@
+# Organization coach assignments
+
+Internal tooling for assigning one coach-level platform staff member to an
+organization. Developers manage assignments; coaches can read them. This
+feature does not yet restrict organization visibility to assigned coaches.
+
+## Ownership
+
+- Domain logic: `src/features/organization-coach-assignments/lib/**`
+- Server actions/queries: `src/features/organization-coach-assignments/server/**`
+- UI components: `src/features/organization-coach-assignments/components/**`
+- Hooks/controllers: `src/features/organization-coach-assignments/hooks/**`
+
+## Rules
+
+- Keep route files in `src/app/**` as composition-only wrappers over this feature.
+- Import other features only through their public entrypoint (`@/features/<name>`).
+- Keep `lib/**` pure: no React, no UI imports, no route imports.
+- Keep `server/**` free of UI/component imports.
+- Keep shared UI in `src/components/ui/**`; avoid one-off primitives here.
+- Keep acceptance coverage in `tests/acceptance/organization-coach-assignments.test.ts`.
+- Add acceptance tests for user-visible behavior before merging.

--- a/src/features/organization-coach-assignments/actions.ts
+++ b/src/features/organization-coach-assignments/actions.ts
@@ -1,0 +1,1 @@
+export { updateOrganizationCoachAssignmentAction } from "./server/actions"

--- a/src/features/organization-coach-assignments/components/index.ts
+++ b/src/features/organization-coach-assignments/components/index.ts
@@ -1,0 +1,1 @@
+export { OrganizationCoachAssignmentControl } from "./organization-coach-assignment-control"

--- a/src/features/organization-coach-assignments/components/organization-coach-assignment-control.tsx
+++ b/src/features/organization-coach-assignments/components/organization-coach-assignment-control.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import {
+  Check,
+  CircleNotch,
+  User,
+  UserSwitch,
+} from "@phosphor-icons/react/dist/ssr"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import { getOrganizationCoachInitials } from "../lib"
+import type {
+  OrganizationCoachAssignment,
+  OrganizationCoachOption,
+  UpdateOrganizationCoachAssignmentInput,
+  UpdateOrganizationCoachAssignmentResult,
+} from "../types"
+import { useOrganizationCoachAssignmentController } from "../hooks/use-organization-coach-assignments-controller"
+
+type AssignmentAction = (
+  input: UpdateOrganizationCoachAssignmentInput
+) => Promise<UpdateOrganizationCoachAssignmentResult>
+
+function CoachAvatar({ coach }: { coach: OrganizationCoachOption | null }) {
+  return (
+    <Avatar className="border-border size-6 border">
+      {coach?.avatarUrl ? (
+        <AvatarImage src={coach.avatarUrl} alt={coach.name} />
+      ) : null}
+      <AvatarFallback className="text-[10px]">
+        {coach ? getOrganizationCoachInitials(coach) : <User />}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+export function OrganizationCoachAssignmentControl({
+  assignment,
+  canManage,
+  coachOptions,
+  organizationId,
+  organizationName,
+  updateAssignmentAction,
+}: {
+  assignment: OrganizationCoachAssignment | null
+  canManage: boolean
+  coachOptions: OrganizationCoachOption[]
+  organizationId: string
+  organizationName: string
+  updateAssignmentAction?: AssignmentAction
+}) {
+  const controller = useOrganizationCoachAssignmentController({
+    assignment,
+    organizationId,
+    updateAssignmentAction,
+  })
+  const coach = controller.assignment?.coach ?? null
+
+  if (!canManage || !updateAssignmentAction) {
+    return (
+      <div
+        className="text-muted-foreground flex min-h-9 items-center gap-2 text-xs"
+        aria-label={`${organizationName} coach: ${coach?.name ?? "Unassigned"}`}
+      >
+        <CoachAvatar coach={coach} />
+        <span>{coach?.name ?? "Unassigned"}</span>
+      </div>
+    )
+  }
+
+  return (
+    <Popover open={controller.open} onOpenChange={controller.setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-11 max-w-48 justify-start gap-2 rounded-lg px-2 md:h-9"
+          disabled={controller.pending}
+          aria-busy={controller.pending}
+          aria-label={`Assign a coach to ${organizationName}`}
+        >
+          <CoachAvatar coach={coach} />
+          <span className="truncate">{coach?.name ?? "Assign coach"}</span>
+          {controller.pending ? (
+            <CircleNotch className="text-muted-foreground ml-auto animate-spin" />
+          ) : (
+            <UserSwitch className="text-muted-foreground ml-auto" />
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-2">
+        <p className="text-muted-foreground px-2 py-1 text-xs font-medium">
+          Organization coach
+        </p>
+        <button
+          type="button"
+          className={cn(
+            "hover:bg-accent flex min-h-11 w-full items-center gap-2 rounded-md px-2 text-left text-sm",
+            !coach && "bg-accent"
+          )}
+          onClick={() => controller.assign(null)}
+        >
+          <CoachAvatar coach={null} />
+          <span>Unassigned</span>
+          {!coach ? <Check className="ml-auto" /> : null}
+        </button>
+        {coachOptions.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={cn(
+              "hover:bg-accent flex min-h-11 w-full items-center gap-2 rounded-md px-2 text-left text-sm",
+              option.id === coach?.id && "bg-accent"
+            )}
+            onClick={() => controller.assign(option)}
+          >
+            <CoachAvatar coach={option} />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate">{option.name}</span>
+              {option.email ? (
+                <span className="text-muted-foreground block truncate text-xs">
+                  {option.email}
+                </span>
+              ) : null}
+            </span>
+            {option.id === coach?.id ? <Check /> : null}
+          </button>
+        ))}
+        {coachOptions.length === 0 ? (
+          <p className="text-muted-foreground px-2 py-3 text-sm">
+            No coach-level staff are available.
+          </p>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/features/organization-coach-assignments/hooks/use-organization-coach-assignments-controller.ts
+++ b/src/features/organization-coach-assignments/hooks/use-organization-coach-assignments-controller.ts
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import type {
+  OrganizationCoachAssignment,
+  OrganizationCoachOption,
+  UpdateOrganizationCoachAssignmentInput,
+  UpdateOrganizationCoachAssignmentResult,
+} from "../types"
+
+type AssignmentAction = (
+  input: UpdateOrganizationCoachAssignmentInput
+) => Promise<UpdateOrganizationCoachAssignmentResult>
+
+export function useOrganizationCoachAssignmentController({
+  assignment: initialAssignment,
+  organizationId,
+  updateAssignmentAction,
+}: {
+  assignment: OrganizationCoachAssignment | null
+  organizationId: string
+  updateAssignmentAction?: AssignmentAction
+}) {
+  const router = useRouter()
+  const [assignment, setAssignment] = useState(initialAssignment)
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  useEffect(() => setAssignment(initialAssignment), [initialAssignment])
+
+  const assign = (coach: OrganizationCoachOption | null) => {
+    if (!updateAssignmentAction || pending) return
+    const previous = assignment
+    setAssignment(
+      coach
+        ? {
+            organizationId,
+            coach,
+            assignedBy: null,
+            updatedAt: new Date().toISOString(),
+          }
+        : null
+    )
+    setOpen(false)
+
+    startTransition(async () => {
+      const result = await updateAssignmentAction({
+        organizationId,
+        coachUserId: coach?.id ?? null,
+      })
+      if ("error" in result) {
+        setAssignment(previous)
+        toast.error(result.error)
+        return
+      }
+      toast.success(coach ? `Assigned ${coach.name}` : "Coach unassigned")
+      router.refresh()
+    })
+  }
+
+  return { assignment, assign, open, pending, setOpen }
+}

--- a/src/features/organization-coach-assignments/index.ts
+++ b/src/features/organization-coach-assignments/index.ts
@@ -1,0 +1,12 @@
+export { OrganizationCoachAssignmentControl } from "./components"
+export { getOrganizationCoachInitials } from "./lib"
+export { updateOrganizationCoachAssignmentAction } from "./actions"
+export { loadOrganizationCoachAssignmentData } from "./loaders"
+export type {
+  OrganizationCoachAssignmentAction,
+  OrganizationCoachAssignment,
+  OrganizationCoachAssignmentData,
+  OrganizationCoachOption,
+  UpdateOrganizationCoachAssignmentInput,
+  UpdateOrganizationCoachAssignmentResult,
+} from "./types"

--- a/src/features/organization-coach-assignments/lib/index.ts
+++ b/src/features/organization-coach-assignments/lib/index.ts
@@ -1,0 +1,11 @@
+import type { OrganizationCoachOption } from "../types"
+
+export function getOrganizationCoachInitials(coach: OrganizationCoachOption) {
+  return coach.name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase()
+}

--- a/src/features/organization-coach-assignments/loaders.ts
+++ b/src/features/organization-coach-assignments/loaders.ts
@@ -1,0 +1,1 @@
+export { loadOrganizationCoachAssignmentData } from "./server/loaders"

--- a/src/features/organization-coach-assignments/server/actions.ts
+++ b/src/features/organization-coach-assignments/server/actions.ts
@@ -1,0 +1,83 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { z } from "zod"
+
+import { resolveAuthenticatedAppContext } from "@/lib/auth/request-context"
+import { createSupabaseAdminClient } from "@/lib/supabase/admin"
+import type {
+  UpdateOrganizationCoachAssignmentInput,
+  UpdateOrganizationCoachAssignmentResult,
+} from "../types"
+
+const inputSchema = z.object({
+  organizationId: z.string().uuid(),
+  coachUserId: z.string().uuid().nullable(),
+})
+
+function isMissingAssignmentsTable(error: { code?: string | null }) {
+  return error.code === "42P01" || error.code === "PGRST205"
+}
+
+export async function updateOrganizationCoachAssignmentAction(
+  input: UpdateOrganizationCoachAssignmentInput
+): Promise<UpdateOrganizationCoachAssignmentResult> {
+  const parsed = inputSchema.safeParse(input)
+  if (!parsed.success)
+    return { error: "Select a valid organization and coach." }
+
+  const { user, profileAudience } = await resolveAuthenticatedAppContext()
+  if (profileAudience.platformAccessLevel !== "developer") {
+    return { error: "Only developers can change coach assignments." }
+  }
+
+  const admin = createSupabaseAdminClient()
+  const { data: organization } = await admin
+    .from("organizations")
+    .select("user_id")
+    .eq("user_id", parsed.data.organizationId)
+    .maybeSingle()
+  if (!organization) return { error: "Organization not found." }
+
+  let error = null
+  if (parsed.data.coachUserId) {
+    const { data: coach } = await admin
+      .from("platform_staff_members")
+      .select("user_id")
+      .eq("user_id", parsed.data.coachUserId)
+      .eq("access_level", "coach")
+      .maybeSingle()
+    if (!coach) return { error: "Select a coach-level staff member." }
+
+    const result = await admin.from("organization_coach_assignments").upsert(
+      {
+        organization_id: parsed.data.organizationId,
+        coach_user_id: parsed.data.coachUserId,
+        assigned_by: user.id,
+      },
+      { onConflict: "organization_id" }
+    )
+    error = result.error
+  } else {
+    const result = await admin
+      .from("organization_coach_assignments")
+      .delete()
+      .eq("organization_id", parsed.data.organizationId)
+    error = result.error
+  }
+
+  if (error) {
+    if (isMissingAssignmentsTable(error)) {
+      return { error: "Assignments need the latest database migration." }
+    }
+    console.error("Unable to update organization coach assignment.", error)
+    return { error: "Unable to update the coach assignment." }
+  }
+
+  revalidatePath("/organizations", "layout")
+  return {
+    ok: true,
+    organizationId: parsed.data.organizationId,
+    coachUserId: parsed.data.coachUserId,
+  }
+}

--- a/src/features/organization-coach-assignments/server/loaders.ts
+++ b/src/features/organization-coach-assignments/server/loaders.ts
@@ -1,0 +1,119 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+import { createSupabaseAdminClient } from "@/lib/supabase/admin"
+import type {
+  OrganizationCoachAssignment,
+  OrganizationCoachAssignmentData,
+  OrganizationCoachOption,
+} from "../types"
+
+type AdminClient = SupabaseClient<Database>
+type AssignmentRow =
+  Database["public"]["Tables"]["organization_coach_assignments"]["Row"]
+type ProfileRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "full_name" | "email" | "avatar_url"
+>
+
+function isMissingAssignmentsTable(error: {
+  code?: string | null
+  message?: string | null
+}) {
+  return error.code === "42P01" || error.code === "PGRST205"
+}
+
+function toCoachOption(profile: ProfileRow): OrganizationCoachOption {
+  return {
+    id: profile.id,
+    name: profile.full_name?.trim() || profile.email?.trim() || "Coach",
+    email: profile.email?.trim() || null,
+    avatarUrl: profile.avatar_url?.trim() || null,
+  }
+}
+
+async function loadCoachProfiles(supabase: AdminClient) {
+  const { data: staff, error: staffError } = await supabase
+    .from("platform_staff_members")
+    .select("user_id")
+    .eq("access_level", "coach")
+
+  if (staffError) throw new Error("Unable to load coaches.")
+  const coachIds = (staff ?? []).map((row) => row.user_id)
+  if (coachIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, full_name, email, avatar_url")
+    .in("id", coachIds)
+    .returns<ProfileRow[]>()
+
+  if (error) throw new Error("Unable to load coach profiles.")
+  return (data ?? [])
+    .map(toCoachOption)
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+async function loadAssignmentRows(
+  supabase: AdminClient,
+  organizationIds: string[]
+) {
+  if (organizationIds.length === 0) {
+    return { available: true, rows: [] as AssignmentRow[] }
+  }
+
+  const { data, error } = await supabase
+    .from("organization_coach_assignments")
+    .select(
+      "organization_id, coach_user_id, assigned_by, created_at, updated_at"
+    )
+    .in("organization_id", organizationIds)
+    .returns<AssignmentRow[]>()
+
+  if (error && isMissingAssignmentsTable(error)) {
+    return { available: false, rows: [] as AssignmentRow[] }
+  }
+  if (error) throw new Error("Unable to load organization coach assignments.")
+  return { available: true, rows: data ?? [] }
+}
+
+function mapAssignments(
+  rows: AssignmentRow[],
+  coachById: Map<string, OrganizationCoachOption>
+) {
+  const assignments = new Map<string, OrganizationCoachAssignment>()
+  for (const row of rows) {
+    const coach = coachById.get(row.coach_user_id)
+    if (!coach) continue
+    assignments.set(row.organization_id, {
+      organizationId: row.organization_id,
+      coach,
+      assignedBy: row.assigned_by,
+      updatedAt: row.updated_at,
+    })
+  }
+  return assignments
+}
+
+export async function loadOrganizationCoachAssignmentData({
+  organizationIds,
+  supabase = createSupabaseAdminClient(),
+}: {
+  organizationIds: string[]
+  supabase?: AdminClient
+}): Promise<OrganizationCoachAssignmentData> {
+  const [coachOptions, assignmentResult] = await Promise.all([
+    loadCoachProfiles(supabase),
+    loadAssignmentRows(supabase, organizationIds),
+  ])
+  const coachById = new Map(coachOptions.map((coach) => [coach.id, coach]))
+
+  return {
+    available: assignmentResult.available,
+    assignmentsByOrganizationId: mapAssignments(
+      assignmentResult.rows,
+      coachById
+    ),
+    coachOptions,
+  }
+}

--- a/src/features/organization-coach-assignments/types.ts
+++ b/src/features/organization-coach-assignments/types.ts
@@ -1,0 +1,32 @@
+export type OrganizationCoachOption = {
+  id: string
+  name: string
+  email: string | null
+  avatarUrl: string | null
+}
+
+export type OrganizationCoachAssignment = {
+  organizationId: string
+  coach: OrganizationCoachOption
+  assignedBy: string | null
+  updatedAt: string
+}
+
+export type OrganizationCoachAssignmentData = {
+  available: boolean
+  assignmentsByOrganizationId: Map<string, OrganizationCoachAssignment>
+  coachOptions: OrganizationCoachOption[]
+}
+
+export type UpdateOrganizationCoachAssignmentInput = {
+  organizationId: string
+  coachUserId: string | null
+}
+
+export type UpdateOrganizationCoachAssignmentResult =
+  | { ok: true; organizationId: string; coachUserId: string | null }
+  | { error: string }
+
+export type OrganizationCoachAssignmentAction = (
+  input: UpdateOrganizationCoachAssignmentInput
+) => Promise<UpdateOrganizationCoachAssignmentResult>

--- a/src/features/platform-admin-dashboard/types.ts
+++ b/src/features/platform-admin-dashboard/types.ts
@@ -52,6 +52,17 @@ export type PlatformAdminDashboardLabProject = {
   members: string[]
   primaryPersonName?: string
   primaryPersonAvatarUrl?: string | null
+  organizationCoachAssignment?: {
+    organizationId: string
+    coach: {
+      id: string
+      name: string
+      email: string | null
+      avatarUrl: string | null
+    }
+    assignedBy: string | null
+    updatedAt: string
+  } | null
   client?: string
   typeLabel?: string
   durationLabel?: string

--- a/src/lib/supabase/schema/tables/index.ts
+++ b/src/lib/supabase/schema/tables/index.ts
@@ -53,6 +53,7 @@ import type { OrganizationTasksTable } from "./organization_tasks"
 import type { PlatformAdminProjectWorkstreamStatesTable } from "./platform_admin_project_workstream_states"
 import type { PlatformAdminWorkstreamCategoriesTable } from "./platform_admin_workstream_categories"
 import type { PlatformStaffMembersTable } from "./platform_staff_members"
+import type { OrganizationCoachAssignmentsTable } from "./organization_coach_assignments"
 import type { OrganizationWorkspaceBoardsTable } from "./organization_workspace_boards"
 import type { OrganizationWorkspaceCommunicationChannelsTable } from "./organization_workspace_communication_channels"
 import type { OrganizationWorkspaceCommunicationDeliveriesTable } from "./organization_workspace_communication_deliveries"
@@ -144,6 +145,7 @@ export type { OrganizationTasksTable } from "./organization_tasks"
 export type { PlatformAdminProjectWorkstreamStatesTable } from "./platform_admin_project_workstream_states"
 export type { PlatformAdminWorkstreamCategoriesTable } from "./platform_admin_workstream_categories"
 export type { PlatformStaffMembersTable } from "./platform_staff_members"
+export type { OrganizationCoachAssignmentsTable } from "./organization_coach_assignments"
 export type { OrganizationWorkspaceBoardsTable } from "./organization_workspace_boards"
 export type { OrganizationWorkspaceCommunicationChannelsTable } from "./organization_workspace_communication_channels"
 export type { OrganizationWorkspaceCommunicationDeliveriesTable } from "./organization_workspace_communication_deliveries"
@@ -236,6 +238,7 @@ export type PublicTables = {
   platform_admin_project_workstream_states: PlatformAdminProjectWorkstreamStatesTable
   platform_admin_workstream_categories: PlatformAdminWorkstreamCategoriesTable
   platform_staff_members: PlatformStaffMembersTable
+  organization_coach_assignments: OrganizationCoachAssignmentsTable
   organization_workspace_boards: OrganizationWorkspaceBoardsTable
   organization_workspace_communication_channels: OrganizationWorkspaceCommunicationChannelsTable
   organization_workspace_communication_deliveries: OrganizationWorkspaceCommunicationDeliveriesTable

--- a/src/lib/supabase/schema/tables/organization_coach_assignments.ts
+++ b/src/lib/supabase/schema/tables/organization_coach_assignments.ts
@@ -1,0 +1,46 @@
+export type OrganizationCoachAssignmentsTable = {
+  Row: {
+    organization_id: string
+    coach_user_id: string
+    assigned_by: string | null
+    created_at: string
+    updated_at: string
+  }
+  Insert: {
+    organization_id: string
+    coach_user_id: string
+    assigned_by?: string | null
+    created_at?: string
+    updated_at?: string
+  }
+  Update: {
+    organization_id?: string
+    coach_user_id?: string
+    assigned_by?: string | null
+    created_at?: string
+    updated_at?: string
+  }
+  Relationships: [
+    {
+      foreignKeyName: "organization_coach_assignments_organization_id_fkey"
+      columns: ["organization_id"]
+      isOneToOne: true
+      referencedRelation: "organizations"
+      referencedColumns: ["user_id"]
+    },
+    {
+      foreignKeyName: "organization_coach_assignments_coach_user_id_fkey"
+      columns: ["coach_user_id"]
+      isOneToOne: false
+      referencedRelation: "platform_staff_members"
+      referencedColumns: ["user_id"]
+    },
+    {
+      foreignKeyName: "organization_coach_assignments_assigned_by_fkey"
+      columns: ["assigned_by"]
+      isOneToOne: false
+      referencedRelation: "profiles"
+      referencedColumns: ["id"]
+    },
+  ]
+}

--- a/supabase/migrations/20260721153000_add_organization_coach_assignments.sql
+++ b/supabase/migrations/20260721153000_add_organization_coach_assignments.sql
@@ -1,0 +1,119 @@
+create table if not exists public.organization_coach_assignments (
+  organization_id uuid primary key references public.organizations(user_id) on delete cascade,
+  coach_user_id uuid not null references public.platform_staff_members(user_id) on delete restrict,
+  assigned_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists organization_coach_assignments_coach_user_id_idx
+  on public.organization_coach_assignments(coach_user_id);
+
+create index if not exists organization_coach_assignments_assigned_by_idx
+  on public.organization_coach_assignments(assigned_by);
+
+create or replace function public.require_coach_assignment_access_level()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1
+    from public.platform_staff_members
+    where user_id = new.coach_user_id
+      and access_level = 'coach'
+  ) then
+    raise exception 'Organization assignments require coach-level staff.';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists require_coach_assignment_access_level
+  on public.organization_coach_assignments;
+create trigger require_coach_assignment_access_level
+before insert or update of coach_user_id
+on public.organization_coach_assignments
+for each row execute procedure public.require_coach_assignment_access_level();
+
+revoke execute on function public.require_coach_assignment_access_level()
+  from public, anon, authenticated;
+
+create or replace function public.prevent_assigned_coach_access_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.access_level = 'coach'
+    and new.access_level <> 'coach'
+    and exists (
+      select 1
+      from public.organization_coach_assignments
+      where coach_user_id = old.user_id
+    ) then
+    raise exception 'Unassign this coach from organizations before changing access level.';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists prevent_assigned_coach_access_change
+  on public.platform_staff_members;
+create trigger prevent_assigned_coach_access_change
+before update of access_level
+on public.platform_staff_members
+for each row execute procedure public.prevent_assigned_coach_access_change();
+
+revoke execute on function public.prevent_assigned_coach_access_change()
+  from public, anon, authenticated;
+
+drop trigger if exists set_updated_at_organization_coach_assignments
+  on public.organization_coach_assignments;
+create trigger set_updated_at_organization_coach_assignments
+before update on public.organization_coach_assignments
+for each row execute procedure public.handle_updated_at();
+
+alter table public.organization_coach_assignments enable row level security;
+alter table public.organization_coach_assignments force row level security;
+
+revoke all on public.organization_coach_assignments from anon;
+grant select, insert, update, delete on public.organization_coach_assignments to authenticated;
+
+drop policy if exists organization_coach_assignments_platform_staff_select
+  on public.organization_coach_assignments;
+create policy organization_coach_assignments_platform_staff_select
+on public.organization_coach_assignments
+for select
+to authenticated
+using ((select public.is_platform_staff()));
+
+drop policy if exists organization_coach_assignments_developer_insert
+  on public.organization_coach_assignments;
+create policy organization_coach_assignments_developer_insert
+on public.organization_coach_assignments
+for insert
+to authenticated
+with check ((select public.is_admin()));
+
+drop policy if exists organization_coach_assignments_developer_update
+  on public.organization_coach_assignments;
+create policy organization_coach_assignments_developer_update
+on public.organization_coach_assignments
+for update
+to authenticated
+using ((select public.is_admin()))
+with check ((select public.is_admin()));
+
+drop policy if exists organization_coach_assignments_developer_delete
+  on public.organization_coach_assignments;
+create policy organization_coach_assignments_developer_delete
+on public.organization_coach_assignments
+for delete
+to authenticated
+using ((select public.is_admin()));

--- a/supabase/tests/rls.test.mjs
+++ b/supabase/tests/rls.test.mjs
@@ -509,6 +509,66 @@ async function run() {
     })
   }
 
+  if (await tableExists("organization_coach_assignments")) {
+    const { data: developerAssignment, error: developerAssignmentError } =
+      await adminSessionClient
+        .from("organization_coach_assignments")
+        .insert({
+          organization_id: member.id,
+          coach_user_id: coach.id,
+          assigned_by: admin.id,
+        })
+        .select("organization_id, coach_user_id")
+        .maybeSingle()
+    results.push({
+      name: "developer can assign a coach to an organization",
+      passed:
+        !developerAssignmentError &&
+        developerAssignment?.coach_user_id === coach.id,
+    })
+
+    const { data: coachAssignment, error: coachAssignmentError } =
+      await coachClient
+        .from("organization_coach_assignments")
+        .select("organization_id, coach_user_id")
+        .eq("organization_id", member.id)
+        .maybeSingle()
+    results.push({
+      name: "coach can read organization coach assignments",
+      passed:
+        !coachAssignmentError && coachAssignment?.coach_user_id === coach.id,
+    })
+
+    const { data: memberAssignment, error: memberAssignmentError } =
+      await memberClient
+        .from("organization_coach_assignments")
+        .select("organization_id")
+        .eq("organization_id", member.id)
+        .maybeSingle()
+    results.push({
+      name: "regular member cannot read organization coach assignments",
+      passed: !memberAssignment && !memberAssignmentError,
+    })
+
+    const { error: coachWriteError } = await coachClient
+      .from("organization_coach_assignments")
+      .update({ assigned_by: coach.id })
+      .eq("organization_id", member.id)
+    results.push({
+      name: "coach cannot change organization coach assignments",
+      passed: !!coachWriteError,
+    })
+
+    const { error: assignedCoachLevelChangeError } = await adminSessionClient
+      .from("platform_staff_members")
+      .update({ access_level: "developer" })
+      .eq("user_id", coach.id)
+    results.push({
+      name: "assigned coach cannot be changed to developer before unassignment",
+      passed: !!assignedCoachLevelChangeError,
+    })
+  }
+
   let orgAccessReady = false
   let workspaceTablesAvailable = false
   let workspaceCommunicationsTableAvailable = false
@@ -835,13 +895,11 @@ async function run() {
       passed: !!adminCategory && !adminCategoryError,
     })
 
-    const {
-      data: deniedAnonCategory,
-      error: deniedAnonCategoryError,
-    } = await anonClient
-      .from("platform_admin_workstream_categories")
-      .select("id")
-      .eq("id", categoryId)
+    const { data: deniedAnonCategory, error: deniedAnonCategoryError } =
+      await anonClient
+        .from("platform_admin_workstream_categories")
+        .select("id")
+        .eq("id", categoryId)
     results.push({
       name: "anonymous users have no workstream category table privileges",
       passed:
@@ -1186,7 +1244,9 @@ async function run() {
         name: "anonymous users have no organization activity table privileges",
         passed:
           deniedAnonActivityReadError?.code === "42501" ||
-          /permission denied/i.test(deniedAnonActivityReadError?.message ?? "") ||
+          /permission denied/i.test(
+            deniedAnonActivityReadError?.message ?? ""
+          ) ||
           (Array.isArray(deniedAnonActivity) &&
             deniedAnonActivity.length === 0),
       })

--- a/tests/acceptance/organization-coach-assignments.test.ts
+++ b/tests/acceptance/organization-coach-assignments.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { getOrganizationCoachInitials } from "@/features/organization-coach-assignments"
+
+describe("organization-coach-assignments feature contract", () => {
+  it("builds compact coach initials", () => {
+    expect(
+      getOrganizationCoachInitials({
+        id: "coach-id",
+        name: "Paula Coach",
+        email: null,
+        avatarUrl: null,
+      })
+    ).toBe("PC")
+  })
+
+  it("keeps writes developer-only and reads internal", () => {
+    const migration = readFileSync(
+      resolve(
+        process.cwd(),
+        "supabase/migrations/20260721153000_add_organization_coach_assignments.sql"
+      ),
+      "utf8"
+    )
+
+    expect(migration).toContain("using ((select public.is_platform_staff()))")
+    expect(migration).toContain("with check ((select public.is_admin()))")
+    expect(migration).toContain("require_coach_assignment_access_level")
+    expect(migration).toContain("prevent_assigned_coach_access_change")
+    expect(migration).toContain("force row level security")
+  })
+
+  it("validates developer access again inside the server action", () => {
+    const action = readFileSync(
+      resolve(
+        process.cwd(),
+        "src/features/organization-coach-assignments/server/actions.ts"
+      ),
+      "utf8"
+    )
+
+    expect(action).toContain('platformAccessLevel !== "developer"')
+    expect(action).toContain('.eq("access_level", "coach")')
+  })
+})


### PR DESCRIPTION
## Summary
- add one primary coach assignment per organization with developer-only writes and internal RLS reads
- add assignment controls to Organizations list, board, and detail views
- preserve current coach visibility until assignments are populated

## Validation
- full acceptance: 1,465 passed, 1 skipped
- production build and TypeScript passed
- isolated visuals: 14/14
- performance and all relevant guardrails passed
- linked RLS pending CI migration application