### PR TITLE
[STEP S02] Add coach assignment operations

### DIFF
--- a/docs/plans/2026-07-21-organization-coach-assignment-operations-design.md
+++ b/docs/plans/2026-07-21-organization-coach-assignment-operations-design.md
@@ -1,0 +1,21 @@
+# Organization Coach Assignment Operations
+
+## Goal
+
+Make the existing per-organization coach picker usable across the full organization portfolio without enabling assigned-only coach access before mappings are complete.
+
+## Approach
+
+Add a compact developer-only assignment operations bar to `/organizations`. It reports canonical organization coverage and provides one URL-backed filter with `All organizations`, `Unassigned`, and each coach. This is preferable to mixing coach ownership into the existing project-member filter because those concepts have different authorization and data sources. It is also smaller and safer than introducing a separate bulk-management page before the workflow requires one.
+
+Coverage counts use canonical organization cards only, so standard organization projects cannot inflate the denominator. Filtering still applies by stable `organizationId`, allowing related standard projects to remain with their organization when a coach filter is active. The filter is stored as `coach=unassigned` or `coach=<user-id>` and is preserved when status, priority, tag, member, view, ordering, or property options change. Invalid or removed coach identifiers fall back to `All organizations`.
+
+## UI and States
+
+The bar shows `assigned / total`, an explicit unassigned count, and a labeled shadcn Select. Counts use tabular numerals. Mobile targets are at least 44px; desktop controls remain compact. Empty filtered results show a recoverable state with a clear-filter action. Long coach names truncate without changing control geometry.
+
+Only developers see assignment operations. Coaches retain read-only assignment labels on cards and details. No RLS, mutation, assignment table, or coach visibility policy changes in this segment.
+
+## Next Gate
+
+After production assignments cover every organization, add a separate database-backed activation switch and enforce assigned-only organization reads server-side. The switch must remain disabled while any organization is unassigned.

--- a/docs/plans/2026-07-21-organization-coach-assignment-operations-implementation.md
+++ b/docs/plans/2026-07-21-organization-coach-assignment-operations-implementation.md
@@ -1,0 +1,8 @@
+# Organization Coach Assignment Operations Implementation
+
+1. Add pure assignment coverage, filter parsing, URL serialization, and project-filter helpers to the existing feature.
+2. Add a shared developer assignment operations bar with coverage and coach counts.
+3. Connect the URL-backed filter to the Organizations page without losing existing filters or view options.
+4. Add a recoverable filtered-empty state across list, board, and timeline views.
+5. Add focused acceptance coverage and append the July runlog.
+6. Run the complete release gate and publish as an isolated PR.

--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -268,3 +268,10 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - The Supabase integration applied `20260721153000_add_organization_coach_assignments.sql`. Linked migration history contains the new remote version, and the complete linked RLS suite passed developer assignment, coach reads, regular-member isolation, coach write denial, and assigned-coach access-level protection.
 - Corrected the RLS proof to verify the persisted assignment remains unchanged when PostgREST filters a forbidden coach update to zero rows. This follow-up changes only the test and release log; the live policy already denied the mutation.
 - Production currently has zero coach assignments. Developers can now populate them through `/organizations`; assigned-only coach visibility remains intentionally deferred until those mappings exist. The original dirty worktree remains untouched.
+
+2026-07-21 21:12 EDT - prepared organization coach assignment operations for release.
+
+- Added a developer-only assignment operations bar to `/organizations` with canonical assigned, total, and unassigned coverage plus All, Unassigned, and per-coach filtering. Coverage counts each organization once and related standard projects follow their organization's assignment.
+- Stored the coach filter in the URL while preserving existing project filters and view options. Invalid or removed coach values safely fall back to All, and zero-result combinations provide a recoverable clear-filters state.
+- Kept current coach visibility, assignment mutation rules, schema, and RLS unchanged. Assigned-only coach scoping remains disabled until every production organization has a coach mapping.
+- Focused acceptance passed (`2 files`, `7 tests`), ESLint and structural guardrails passed, snapshots passed, full acceptance passed (`302 files passed`, `1 skipped`; `1,468 tests passed`, `1 skipped`), production build and TypeScript passed, isolated clean-branch visuals passed (`14/14`), and performance budgets passed. Local RLS execution was skipped because this clean worktree has no Supabase credentials. The original dirty worktree remains untouched.

--- a/src/features/member-workspace/components/projects/member-workspace-projects-filtered-empty.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-projects-filtered-empty.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { FunnelX } from "@phosphor-icons/react/dist/ssr"
+
+import { Button } from "@/components/ui/button"
+import { Empty } from "@/components/ui/empty"
+
+export function MemberWorkspaceProjectsFilteredEmpty({
+  onClear,
+}: {
+  onClear: () => void
+}) {
+  return (
+    <div className="p-4">
+      <Empty
+        icon={<FunnelX className="size-6" aria-hidden />}
+        title="No matching organizations"
+        description="No organizations match the active coach and project filters."
+        variant="subtle"
+        actions={
+          <Button type="button" variant="outline" onClick={onClear}>
+            Clear filters
+          </Button>
+        }
+      />
+    </div>
+  )
+}

--- a/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
+++ b/src/features/member-workspace/components/projects/member-workspace-projects-page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-
 import {
   ChipOverflow,
   type PlatformAdminDashboardLabProject,
@@ -24,11 +23,19 @@ import { MemberWorkspaceProjectFilterPopover } from "./member-workspace-project-
 import { MemberWorkspaceProjectTimelineView } from "./member-workspace-project-timeline-view"
 import { MemberWorkspaceProjectViewOptionsPopover } from "./member-workspace-project-view-options-popover"
 import { MemberWorkspaceProjectWizard } from "./member-workspace-project-wizard"
+import { MemberWorkspaceProjectsFilteredEmpty } from "./member-workspace-projects-filtered-empty"
 import { MemberWorkspaceClearStarterDataButton } from "../shared/member-workspace-clear-starter-data-button"
 import styles from "./member-workspace-projects-surface-theme.module.css"
-import type {
-  OrganizationCoachAssignmentAction,
-  OrganizationCoachOption,
+import {
+  applyOrganizationCoachFilterToParams,
+  computeOrganizationCoachAssignmentCoverage,
+  filterProjectsByOrganizationCoach,
+  normalizeOrganizationCoachFilter,
+  ORGANIZATION_COACH_FILTER_ALL,
+  OrganizationCoachAssignmentOperationsBar,
+  type OrganizationCoachFilterValue,
+  type OrganizationCoachAssignmentAction,
+  type OrganizationCoachOption,
 } from "@/features/organization-coach-assignments"
 import {
   applyViewOptionsToParams,
@@ -116,6 +123,9 @@ export function MemberWorkspaceProjectsPage(props: {
   const searchParams = useSearchParams()
 
   const [filters, setFilters] = useState<FilterChip[]>([])
+  const [coachFilter, setCoachFilter] = useState<OrganizationCoachFilterValue>(
+    ORGANIZATION_COACH_FILTER_ALL
+  )
   const [viewOptions, setViewOptions] = useState(DEFAULT_VIEW_OPTIONS)
   const [isProjectWizardOpen, setIsProjectWizardOpen] = useState(false)
   const [editingProject, setEditingProject] =
@@ -125,22 +135,34 @@ export function MemberWorkspaceProjectsPage(props: {
 
   useEffect(() => {
     const currentParams = searchParams.toString()
-    if (prevParamsRef.current === currentParams) return
+    const currentStateKey = `${currentParams}|${coachOptions
+      .map((coach) => coach.id)
+      .join(",")}`
+    if (prevParamsRef.current === currentStateKey) return
 
-    prevParamsRef.current = currentParams
+    prevParamsRef.current = currentStateKey
     const params = new URLSearchParams(currentParams)
     setFilters(paramsToChips(params))
+    setCoachFilter(
+      normalizeOrganizationCoachFilter({
+        coachOptions,
+        value: params.get("coach"),
+      })
+    )
     setViewOptions(paramsToViewOptions(params))
-  }, [searchParams])
+  }, [coachOptions, searchParams])
 
   const replaceSearchState = ({
     nextFilters = filters,
+    nextCoachFilter = coachFilter,
     nextViewOptions = viewOptions,
   }: {
     nextFilters?: FilterChip[]
+    nextCoachFilter?: OrganizationCoachFilterValue
     nextViewOptions?: typeof viewOptions
   }) => {
     const params = chipsToParams(nextFilters)
+    applyOrganizationCoachFilterToParams(params, nextCoachFilter)
     applyViewOptionsToParams(params, nextViewOptions)
     const nextQuery = params.toString()
     router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
@@ -158,27 +180,59 @@ export function MemberWorkspaceProjectsPage(props: {
     replaceSearchState({ nextViewOptions })
   }
 
+  const handleCoachFilterChange = (
+    nextCoachFilter: OrganizationCoachFilterValue
+  ) => {
+    setCoachFilter(nextCoachFilter)
+    replaceSearchState({ nextCoachFilter })
+  }
+
+  const handleClearAllFilters = () => {
+    setFilters([])
+    setCoachFilter(ORGANIZATION_COACH_FILTER_ALL)
+    replaceSearchState({
+      nextFilters: [],
+      nextCoachFilter: ORGANIZATION_COACH_FILTER_ALL,
+    })
+  }
+
+  const coachAssignmentCoverage = useMemo(
+    () => computeOrganizationCoachAssignmentCoverage(projects),
+    [projects]
+  )
+  const coachFilteredProjects = useMemo(
+    () =>
+      filterProjectsByOrganizationCoach({
+        projects,
+        value: coachFilter,
+      }),
+    [coachFilter, projects]
+  )
+
   const filteredProjects = useMemo(
     () =>
       filterMemberWorkspaceProjects({
         filters,
-        projects,
+        projects: coachFilteredProjects,
         viewOptions,
         workstreamCategories,
       }),
-    [filters, projects, viewOptions, workstreamCategories]
+    [coachFilteredProjects, filters, viewOptions, workstreamCategories]
   )
 
   const counts = useMemo(
     () =>
       computeMemberWorkspaceProjectFilterCounts({
         filters,
-        projects,
+        projects: coachFilteredProjects,
         viewOptions,
         workstreamCategories,
       }),
-    [filters, projects, viewOptions, workstreamCategories]
+    [coachFilteredProjects, filters, viewOptions, workstreamCategories]
   )
+  const hasActiveFilters =
+    filters.length > 0 || coachFilter !== ORGANIZATION_COACH_FILTER_ALL
+  const showFilteredEmpty = hasActiveFilters && filteredProjects.length === 0
 
   return (
     <>
@@ -201,10 +255,21 @@ export function MemberWorkspaceProjectsPage(props: {
             </div>
           </div>
 
+          {canManageCoachAssignments ? (
+            <div className="border-border border-b px-4 py-3">
+              <OrganizationCoachAssignmentOperationsBar
+                coachOptions={coachOptions}
+                coverage={coachAssignmentCoverage}
+                value={coachFilter}
+                onValueChange={handleCoachFilterChange}
+              />
+            </div>
+          ) : null}
+
           <div className="flex items-center justify-between px-4 pt-3 pb-3">
             <div className="flex items-center gap-2">
               <MemberWorkspaceProjectFilterPopover
-                projects={projects}
+                projects={coachFilteredProjects}
                 initialChips={filters}
                 onApply={handleFiltersChange}
                 onClear={() => handleFiltersChange([])}
@@ -232,13 +297,18 @@ export function MemberWorkspaceProjectsPage(props: {
         </header>
 
         <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
-          {viewOptions.viewType === "timeline" ? (
+          {showFilteredEmpty ? (
+            <MemberWorkspaceProjectsFilteredEmpty
+              onClear={handleClearAllFilters}
+            />
+          ) : null}
+          {!showFilteredEmpty && viewOptions.viewType === "timeline" ? (
             <MemberWorkspaceProjectTimelineView
               projects={filteredProjects}
               updateProjectScheduleAction={updateProjectScheduleAction}
             />
           ) : null}
-          {viewOptions.viewType === "list" ? (
+          {!showFilteredEmpty && viewOptions.viewType === "list" ? (
             <MemberWorkspaceProjectCardsView
               projects={filteredProjects}
               visibleProperties={viewOptions.properties}
@@ -264,7 +334,7 @@ export function MemberWorkspaceProjectsPage(props: {
               updateCoachAssignmentAction={updateCoachAssignmentAction}
             />
           ) : null}
-          {viewOptions.viewType === "board" ? (
+          {!showFilteredEmpty && viewOptions.viewType === "board" ? (
             <MemberWorkspaceProjectBoardView
               projects={filteredProjects}
               showClosedProjects={viewOptions.showClosedProjects}

--- a/src/features/organization-coach-assignments/README.md
+++ b/src/features/organization-coach-assignments/README.md
@@ -4,6 +4,11 @@ Internal tooling for assigning one coach-level platform staff member to an
 organization. Developers manage assignments; coaches can read them. This
 feature does not yet restrict organization visibility to assigned coaches.
 
+The Organizations assignment operations bar reports canonical coverage and
+filters all related organization projects by coach or unassigned state. Its
+`coach` query parameter remains compatible with the existing project filters
+and view options.
+
 ## Ownership
 
 - Domain logic: `src/features/organization-coach-assignments/lib/**`

--- a/src/features/organization-coach-assignments/components/index.ts
+++ b/src/features/organization-coach-assignments/components/index.ts
@@ -1,1 +1,2 @@
 export { OrganizationCoachAssignmentControl } from "./organization-coach-assignment-control"
+export { OrganizationCoachAssignmentOperationsBar } from "./organization-coach-assignment-operations-bar"

--- a/src/features/organization-coach-assignments/components/organization-coach-assignment-operations-bar.tsx
+++ b/src/features/organization-coach-assignments/components/organization-coach-assignment-operations-bar.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { UsersThree } from "@phosphor-icons/react/dist/ssr"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  ORGANIZATION_COACH_FILTER_ALL,
+  ORGANIZATION_COACH_FILTER_UNASSIGNED,
+} from "../lib"
+import type {
+  OrganizationCoachAssignmentCoverage,
+  OrganizationCoachFilterValue,
+  OrganizationCoachOption,
+} from "../types"
+
+function Count({ value }: { value: number }) {
+  return (
+    <span className="text-muted-foreground ml-auto tabular-nums">{value}</span>
+  )
+}
+
+export function OrganizationCoachAssignmentOperationsBar({
+  coachOptions,
+  coverage,
+  value,
+  onValueChange,
+}: {
+  coachOptions: OrganizationCoachOption[]
+  coverage: OrganizationCoachAssignmentCoverage
+  value: OrganizationCoachFilterValue
+  onValueChange: (value: OrganizationCoachFilterValue) => void
+}) {
+  return (
+    <div
+      className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+      aria-label="Coach assignment coverage"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-lg">
+          <UsersThree className="text-muted-foreground size-4" aria-hidden />
+        </div>
+        <div className="min-w-0">
+          <p className="text-foreground text-sm font-medium">
+            <span className="tabular-nums">{coverage.assigned}</span> of{" "}
+            <span className="tabular-nums">{coverage.total}</span> assigned
+          </p>
+          <p className="text-muted-foreground text-xs">
+            <span className="tabular-nums">{coverage.unassigned}</span>{" "}
+            unassigned
+          </p>
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+        <span className="text-muted-foreground text-xs font-medium">Coach</span>
+        <Select value={value} onValueChange={onValueChange}>
+          <SelectTrigger
+            className="h-11 w-full min-w-0 sm:h-9 sm:w-64"
+            aria-label="Filter organizations by coach"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="end" className="w-72">
+            <SelectItem
+              value={ORGANIZATION_COACH_FILTER_ALL}
+              className="min-h-11 *:[span]:last:flex-1"
+            >
+              <span>All organizations</span>
+              <Count value={coverage.total} />
+            </SelectItem>
+            <SelectItem
+              value={ORGANIZATION_COACH_FILTER_UNASSIGNED}
+              className="min-h-11 *:[span]:last:flex-1"
+            >
+              <span>Unassigned</span>
+              <Count value={coverage.unassigned} />
+            </SelectItem>
+            <SelectSeparator />
+            {coachOptions.map((coach) => (
+              <SelectItem
+                key={coach.id}
+                value={coach.id}
+                className="min-h-11 *:[span]:last:flex-1"
+              >
+                <span className="min-w-0 flex-1 truncate">{coach.name}</span>
+                <Count value={coverage.countByCoachId[coach.id] ?? 0} />
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/src/features/organization-coach-assignments/index.ts
+++ b/src/features/organization-coach-assignments/index.ts
@@ -1,11 +1,24 @@
-export { OrganizationCoachAssignmentControl } from "./components"
-export { getOrganizationCoachInitials } from "./lib"
+export {
+  OrganizationCoachAssignmentControl,
+  OrganizationCoachAssignmentOperationsBar,
+} from "./components"
+export {
+  applyOrganizationCoachFilterToParams,
+  computeOrganizationCoachAssignmentCoverage,
+  filterProjectsByOrganizationCoach,
+  getOrganizationCoachInitials,
+  normalizeOrganizationCoachFilter,
+  ORGANIZATION_COACH_FILTER_ALL,
+  ORGANIZATION_COACH_FILTER_UNASSIGNED,
+} from "./lib"
 export { updateOrganizationCoachAssignmentAction } from "./actions"
 export { loadOrganizationCoachAssignmentData } from "./loaders"
 export type {
   OrganizationCoachAssignmentAction,
   OrganizationCoachAssignment,
   OrganizationCoachAssignmentData,
+  OrganizationCoachAssignmentCoverage,
+  OrganizationCoachFilterValue,
   OrganizationCoachOption,
   UpdateOrganizationCoachAssignmentInput,
   UpdateOrganizationCoachAssignmentResult,

--- a/src/features/organization-coach-assignments/lib/index.ts
+++ b/src/features/organization-coach-assignments/lib/index.ts
@@ -1,4 +1,12 @@
 import type { OrganizationCoachOption } from "../types"
+import type { PlatformAdminDashboardLabProject } from "@/features/platform-admin-dashboard"
+import type {
+  OrganizationCoachAssignmentCoverage,
+  OrganizationCoachFilterValue,
+} from "../types"
+
+export const ORGANIZATION_COACH_FILTER_ALL = "all"
+export const ORGANIZATION_COACH_FILTER_UNASSIGNED = "unassigned"
 
 export function getOrganizationCoachInitials(coach: OrganizationCoachOption) {
   return coach.name
@@ -8,4 +16,83 @@ export function getOrganizationCoachInitials(coach: OrganizationCoachOption) {
     .join("")
     .slice(0, 2)
     .toUpperCase()
+}
+
+export function normalizeOrganizationCoachFilter({
+  coachOptions,
+  value,
+}: {
+  coachOptions: OrganizationCoachOption[]
+  value: string | null | undefined
+}): OrganizationCoachFilterValue {
+  if (value === ORGANIZATION_COACH_FILTER_UNASSIGNED) {
+    return ORGANIZATION_COACH_FILTER_UNASSIGNED
+  }
+  if (coachOptions.some((coach) => coach.id === value)) {
+    return value as string
+  }
+  return ORGANIZATION_COACH_FILTER_ALL
+}
+
+export function applyOrganizationCoachFilterToParams(
+  params: URLSearchParams,
+  value: OrganizationCoachFilterValue
+) {
+  if (value === ORGANIZATION_COACH_FILTER_ALL) {
+    params.delete("coach")
+  } else {
+    params.set("coach", value)
+  }
+  return params
+}
+
+export function filterProjectsByOrganizationCoach({
+  projects,
+  value,
+}: {
+  projects: PlatformAdminDashboardLabProject[]
+  value: OrganizationCoachFilterValue
+}) {
+  if (value === ORGANIZATION_COACH_FILTER_ALL) return projects
+
+  return projects.filter((project) => {
+    if (!project.organizationId) return false
+    const coachId = project.organizationCoachAssignment?.coach.id ?? null
+    return value === ORGANIZATION_COACH_FILTER_UNASSIGNED
+      ? coachId === null
+      : coachId === value
+  })
+}
+
+export function computeOrganizationCoachAssignmentCoverage(
+  projects: PlatformAdminDashboardLabProject[]
+): OrganizationCoachAssignmentCoverage {
+  const organizations = new Map<string, string | null>()
+  for (const project of projects) {
+    if (
+      project.projectKind !== "organization_admin" ||
+      !project.organizationId
+    ) {
+      continue
+    }
+    organizations.set(
+      project.organizationId,
+      project.organizationCoachAssignment?.coach.id ?? null
+    )
+  }
+
+  const countByCoachId: Record<string, number> = {}
+  let assigned = 0
+  for (const coachId of organizations.values()) {
+    if (!coachId) continue
+    assigned += 1
+    countByCoachId[coachId] = (countByCoachId[coachId] ?? 0) + 1
+  }
+
+  return {
+    total: organizations.size,
+    assigned,
+    unassigned: organizations.size - assigned,
+    countByCoachId,
+  }
 }

--- a/src/features/organization-coach-assignments/types.ts
+++ b/src/features/organization-coach-assignments/types.ts
@@ -30,3 +30,12 @@ export type UpdateOrganizationCoachAssignmentResult =
 export type OrganizationCoachAssignmentAction = (
   input: UpdateOrganizationCoachAssignmentInput
 ) => Promise<UpdateOrganizationCoachAssignmentResult>
+
+export type OrganizationCoachFilterValue = "all" | "unassigned" | string
+
+export type OrganizationCoachAssignmentCoverage = {
+  total: number
+  assigned: number
+  unassigned: number
+  countByCoachId: Record<string, number>
+}

--- a/tests/acceptance/organization-coach-assignments.test.ts
+++ b/tests/acceptance/organization-coach-assignments.test.ts
@@ -2,7 +2,39 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 
-import { getOrganizationCoachInitials } from "@/features/organization-coach-assignments"
+import {
+  applyOrganizationCoachFilterToParams,
+  computeOrganizationCoachAssignmentCoverage,
+  filterProjectsByOrganizationCoach,
+  getOrganizationCoachInitials,
+  normalizeOrganizationCoachFilter,
+} from "@/features/organization-coach-assignments"
+import type { PlatformAdminDashboardLabProject } from "@/features/platform-admin-dashboard"
+
+const paula = {
+  id: "00000000-0000-4000-8000-000000000001",
+  name: "Paula Coach",
+  email: "paula@example.com",
+  avatarUrl: null,
+}
+
+function project(
+  overrides: Partial<PlatformAdminDashboardLabProject> &
+    Pick<PlatformAdminDashboardLabProject, "id" | "name">
+): PlatformAdminDashboardLabProject {
+  return {
+    taskCount: 0,
+    progress: 0,
+    startDate: new Date("2026-07-21T00:00:00.000Z"),
+    endDate: new Date("2026-07-21T00:00:00.000Z"),
+    status: "active",
+    priority: "medium",
+    tags: [],
+    members: [],
+    tasks: [],
+    ...overrides,
+  }
+}
 
 describe("organization-coach-assignments feature contract", () => {
   it("builds compact coach initials", () => {
@@ -43,5 +75,109 @@ describe("organization-coach-assignments feature contract", () => {
 
     expect(action).toContain('platformAccessLevel !== "developer"')
     expect(action).toContain('.eq("access_level", "coach")')
+  })
+
+  it("counts canonical organization assignment coverage once", () => {
+    const assignment = {
+      organizationId: "org-1",
+      coach: paula,
+      assignedBy: null,
+      updatedAt: "2026-07-21T00:00:00.000Z",
+    }
+    const coverage = computeOrganizationCoachAssignmentCoverage([
+      project({
+        id: "canonical-1",
+        name: "Organization One",
+        organizationId: "org-1",
+        projectKind: "organization_admin",
+        organizationCoachAssignment: assignment,
+      }),
+      project({
+        id: "standard-1",
+        name: "Organization One project",
+        organizationId: "org-1",
+        projectKind: "standard",
+        organizationCoachAssignment: assignment,
+      }),
+      project({
+        id: "canonical-2",
+        name: "Organization Two",
+        organizationId: "org-2",
+        projectKind: "organization_admin",
+        organizationCoachAssignment: null,
+      }),
+    ])
+
+    expect(coverage).toEqual({
+      total: 2,
+      assigned: 1,
+      unassigned: 1,
+      countByCoachId: { [paula.id]: 1 },
+    })
+  })
+
+  it("filters related organization projects by coach or unassigned state", () => {
+    const assignment = {
+      organizationId: "org-1",
+      coach: paula,
+      assignedBy: null,
+      updatedAt: "2026-07-21T00:00:00.000Z",
+    }
+    const projects = [
+      project({
+        id: "canonical-1",
+        name: "Organization One",
+        organizationId: "org-1",
+        projectKind: "organization_admin",
+        organizationCoachAssignment: assignment,
+      }),
+      project({
+        id: "standard-1",
+        name: "Organization One project",
+        organizationId: "org-1",
+        projectKind: "standard",
+        organizationCoachAssignment: assignment,
+      }),
+      project({
+        id: "canonical-2",
+        name: "Organization Two",
+        organizationId: "org-2",
+        projectKind: "organization_admin",
+        organizationCoachAssignment: null,
+      }),
+    ]
+
+    expect(
+      filterProjectsByOrganizationCoach({ projects, value: paula.id }).map(
+        ({ id }) => id
+      )
+    ).toEqual(["canonical-1", "standard-1"])
+    expect(
+      filterProjectsByOrganizationCoach({
+        projects,
+        value: "unassigned",
+      }).map(({ id }) => id)
+    ).toEqual(["canonical-2"])
+  })
+
+  it("normalizes and serializes stable coach filters", () => {
+    expect(
+      normalizeOrganizationCoachFilter({
+        coachOptions: [paula],
+        value: "removed-coach",
+      })
+    ).toBe("all")
+    expect(
+      normalizeOrganizationCoachFilter({
+        coachOptions: [paula],
+        value: paula.id,
+      })
+    ).toBe(paula.id)
+
+    const params = new URLSearchParams("status=active")
+    applyOrganizationCoachFilterToParams(params, "unassigned")
+    expect(params.toString()).toBe("status=active&coach=unassigned")
+    applyOrganizationCoachFilterToParams(params, "all")
+    expect(params.toString()).toBe("status=active")
   })
 })


### PR DESCRIPTION
## Summary

- add developer-only assignment coverage and coach/unassigned filtering to Organizations
- keep the coach filter URL-backed while preserving existing project filters and views
- keep assigned-only coach visibility disabled until production mappings are complete

## Impact

Developers can see assignment coverage and isolate organizations by coach or unassigned status. Coaches retain their current read-only access and visibility.

## Validation

- focused acceptance: 7 passed
- full acceptance: 1,468 passed, 1 skipped
- lint and all structural guardrails
- snapshots
- production build and TypeScript
- isolated visual suite: 14 passed
- performance budgets

Local RLS execution skipped because this clean worktree has no Supabase credentials. This release has no schema or RLS changes.