### PR TITLE
[STEP S17] Stabilize fiscal sponsorship intake

### DIFF
--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -381,3 +381,9 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Moved account-settings active-organization lookup behind an authenticated Server Action so the browser no longer imports the server-only cookie helper.
 - Removed the stale 19 GB Next cache and restarted localhost on port 3000. Authenticated Chrome verification loaded the organization workbench, opened the fiscal application editor, and completed saved-draft loading without a Runtime Error or Build Error.
 - Focused ESLint, boundaries, routes, `33` fiscal/member-workspace acceptance tests, and the Turbopack production compilation passed. The full build remains blocked during TypeScript checking by the unrelated existing one-argument `revalidateTag` call in `src/actions/public-map-organization-curation.ts`; structure and feature checks remain blocked by existing oversized files and the incomplete `organization-kanban-visibility` scaffold. No deployment, commit, or push occurred.
+
+2026-07-27 17:51 EDT - prepared the fiscal intake stabilization release.
+
+- Extracted only the fiscal budget linkage, uploaded-document containment, application action boundary, account-settings server boundary, and focused acceptance coverage onto current `origin/main`, preserving the assigned-coach review release.
+- Preserved existing legacy application amounts until an activity is selected, while new and explicitly linked applications use the selected program’s structured budget rows and derived total.
+- The complete quality gate passed: supply-chain and large-file checks, lint, all structural guardrails, snapshots, acceptance (`313 files passed`, `1 skipped`; `1,540 tests passed`, `1 skipped`), production build and TypeScript, all `29` visual tests, and performance budgets. RLS exited successfully with its documented no-credentials skip; the current fiscal schema already passed linked RLS during the signing rollout.

--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -356,9 +356,28 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Verified `https://coachhouse.app/` and the fiscal sponsorship handbook return `200`. Production serves the official 140,815-byte W-9 template with SHA-256 `2d420cbb4123dcf1fb82595b2359cfbb5d81f00b9df9d359fcc7af361d093f53`; signed-out W-9 and Form B routes show their authenticated unavailable states, and the fiscal document API returns `401`.
 - Reverified linked Supabase migration parity through `20260727130000`; a production dry run reports the remote database is up to date. No live tax identity or signature was entered during smoke verification, so production contains no test W-9 created by this rollout.
 
+2026-07-27 16:30 EDT - linked fiscal intake to the program budget.
+
+- Replaced the fiscal application’s legacy three-column budget editor with the shared program-builder grid for category, description, cost type, unit, quantity, unit cost, total, reordering, and removal.
+- Preserved structured budget rows from the selected activity through fiscal prefill and draft metadata, synchronized saved fiscal rows and totals back to the source program, and reloaded the draft when the selected activity changes.
+- Filtered zero-only legacy summaries and empty program rows so `$0.00; $0.00` no longer appears as editable content. CSV import, budget-support uploads, derived totals, and agreement-ready expense summaries remain connected.
+- Focused ESLint, `15` focused acceptance tests, boundaries, thresholds, interaction locks, React Grab, workspace surfaces, raw-button checks, and diff checks passed. Live Chrome verification confirmed the selected Idea to Impact Accelerator budget populated the complete grid with a `$7,000` total, no malformed zero summary, and no fiscal-flow console errors. Repository-wide TypeScript, structure, and feature checks remain blocked only by unrelated pre-existing errors, oversized files, and the incomplete `organization-kanban-visibility` feature. No deployment, commit, or push occurred.
+
+2026-07-27 16:41 EDT - contained uploaded fiscal documents in the workflow drawer.
+
+- Constrained the fiscal workflow scroll root, Radix viewport wrapper, tab content, and uploaded-document text so long filenames cannot expand or clip beyond the drawer’s right edge. Shared Sheet and ScrollArea primitives remain unchanged.
+- Focused formatting, ESLint, `10` acceptance tests, boundaries, thresholds, interaction locks, React Grab, and workspace-surface checks passed. Live Chrome verification against the existing uploaded PDFs measured equal bounded viewport/content widths with no horizontal overflow and no fiscal-flow console errors. No deployment, commit, or push occurred.
+
 2026-07-27 17:02 EDT - prepared assigned-coach fiscal review milestones for release.
 
 - Routed fiscal application submission, required-document and W-9 upload, applicant-signature, and signing-completion notifications to developers plus only the coaches assigned to the application organization. Applicant-signature alerts deep-link to the countersign page; review alerts deep-link to the organization project.
 - Restricted application and document decisions, agreement generation and sending, review action visibility, signing-link visibility, and Coach House countersigning to developers or coaches assigned to that organization. Assignment lookup failures deny coach review access and fall back to developer-only notification delivery.
 - Verified linked migration history is aligned through `20260727130000`. Production currently has 55 organizations, 5 coaches, 164 coach assignments, complete organization coverage, and no unassigned coach.
 - Focused fiscal acceptance passed (`4 files`, `14 tests`), full acceptance passed (`313 files`, `1 skipped`; `1,538 tests`, `1 skipped`), snapshots matched, full lint, production build, TypeScript, all structural guardrails, and performance budgets passed. The linked RLS suite passed from the credentialed root; the isolated worktree has no copied credentials.
+
+2026-07-27 17:35 EDT - repaired the fiscal sponsorship client/server boundary.
+
+- Replaced the fiscal action re-export barrel with explicit async Server Action wrappers, keeping application drafts, document uploads, native signing, W-9 completion, workflow review, and agreement actions out of the client module graph.
+- Moved account-settings active-organization lookup behind an authenticated Server Action so the browser no longer imports the server-only cookie helper.
+- Removed the stale 19 GB Next cache and restarted localhost on port 3000. Authenticated Chrome verification loaded the organization workbench, opened the fiscal application editor, and completed saved-draft loading without a Runtime Error or Build Error.
+- Focused ESLint, boundaries, routes, `33` fiscal/member-workspace acceptance tests, and the Turbopack production compilation passed. The full build remains blocked during TypeScript checking by the unrelated existing one-argument `revalidateTag` call in `src/actions/public-map-organization-curation.ts`; structure and feature checks remain blocked by existing oversized files and the incomplete `organization-kanban-visibility` scaffold. No deployment, commit, or push occurred.

--- a/src/actions/account-settings.ts
+++ b/src/actions/account-settings.ts
@@ -1,0 +1,16 @@
+"use server"
+
+import { resolveAuthenticatedAppContext } from "@/lib/auth/request-context"
+
+export async function loadActiveOrganizationNameAction(): Promise<
+  string | null
+> {
+  const { activeOrg, supabase } = await resolveAuthenticatedAppContext()
+  const { data } = await supabase
+    .from("organizations")
+    .select("profile")
+    .eq("user_id", activeOrg.orgId)
+    .maybeSingle<{ profile: Record<string, unknown> | null }>()
+  const name = data?.profile?.name
+  return typeof name === "string" ? name : null
+}

--- a/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-static-cards.tsx
+++ b/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-node-static-cards.tsx
@@ -10,6 +10,8 @@ import { WORKSPACE_TEXT_STYLES } from "@/components/workspace/workspace-typograp
 import { Progress } from "@/components/ui/progress"
 import {
   FiscalSponsorshipWorkspaceCardSummary,
+  normalizeFiscalSponsorshipBudgetRows,
+  summarizeBudgetRows,
   type FiscalSponsorshipApplicationPrefill,
   type FiscalSponsorshipProgramOption,
   type FiscalSponsorshipProjectWorkflowSummary,
@@ -80,39 +82,18 @@ function safeSnapshotTextList(snapshot: unknown, key: string) {
     .filter((entry): entry is string => Boolean(entry))
 }
 
-function safeBudgetRowText(row: Record<string, unknown>, key: string) {
-  const value = row[key]
-  return typeof value === "string" && value.trim().length > 0
-    ? value.trim()
-    : null
+function getSnapshotBudgetRows(snapshot: unknown) {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    return []
+  }
+
+  return normalizeFiscalSponsorshipBudgetRows(
+    (snapshot as Record<string, unknown>).budgetRows
+  )
 }
 
 function formatSnapshotBudgetRows(snapshot: unknown) {
-  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
-    return null
-  }
-
-  const rows = (snapshot as Record<string, unknown>).budgetRows
-  if (!Array.isArray(rows)) return null
-
-  const summaryRows = rows
-    .map((row) => {
-      if (!row || typeof row !== "object" || Array.isArray(row)) return null
-
-      const record = row as Record<string, unknown>
-      const category = safeBudgetRowText(record, "category")
-      const description = safeBudgetRowText(record, "description")
-      const totalCost = safeBudgetRowText(record, "totalCost")
-
-      if (!category && !description && !totalCost) return null
-
-      return [category, description, totalCost ? `$${totalCost}` : null]
-        .filter((part): part is string => Boolean(part))
-        .join(" - ")
-    })
-    .filter((row): row is string => Boolean(row))
-
-  return summaryRows.length > 0 ? summaryRows.join("; ") : null
+  return summarizeBudgetRows(getSnapshotBudgetRows(snapshot)) || null
 }
 
 export function mapWorkspaceProgramsToFiscalSponsorshipPrograms(
@@ -124,6 +105,7 @@ export function mapWorkspaceProgramsToFiscalSponsorshipPrograms(
       program.wizard_snapshot,
       "successOutcomes"
     )
+    const budgetRows = getSnapshotBudgetRows(program.wizard_snapshot)
 
     return {
       id: program.id,
@@ -145,6 +127,7 @@ export function mapWorkspaceProgramsToFiscalSponsorshipPrograms(
       estimatedBudgetCents: budgetUsd
         ? Math.round(budgetUsd * 100)
         : program.goal_cents,
+      budgetRows,
       expenseSummary: formatSnapshotBudgetRows(program.wizard_snapshot),
       prospectiveFundingSources: safeSnapshotText(
         program.wizard_snapshot,

--- a/src/app/(dashboard)/my-organization/_lib/workspace-fiscal-sponsorship-prefill.ts
+++ b/src/app/(dashboard)/my-organization/_lib/workspace-fiscal-sponsorship-prefill.ts
@@ -2,9 +2,11 @@ import type {
   OrgProfile,
   OrgProgram,
 } from "@/components/organization/org-profile-card/types"
-import type {
-  FiscalSponsorshipApplicationPrefill,
-  FiscalSponsorshipProjectDurationType,
+import {
+  normalizeFiscalSponsorshipBudgetRows,
+  summarizeBudgetRows,
+  type FiscalSponsorshipApplicationPrefill,
+  type FiscalSponsorshipProjectDurationType,
 } from "@/features/fiscal-sponsorship"
 
 function cleanText(value: string | null | undefined) {
@@ -168,31 +170,15 @@ function resolveBudgetCents(program: OrgProgram | null) {
   return positiveCents(program.goal_cents)
 }
 
+function getProgramBudgetRows(program: OrgProgram | null) {
+  if (!program || !isRecord(program.wizard_snapshot)) return []
+  return normalizeFiscalSponsorshipBudgetRows(
+    program.wizard_snapshot.budgetRows
+  )
+}
+
 function formatBudgetRows(program: OrgProgram | null) {
-  if (!program || !isRecord(program.wizard_snapshot)) return null
-
-  const rows = program.wizard_snapshot.budgetRows
-  if (!Array.isArray(rows)) return null
-
-  const summaryRows = rows
-    .map((row) => {
-      if (!isRecord(row)) return null
-      const category =
-        typeof row.category === "string" ? cleanText(row.category) : null
-      const description =
-        typeof row.description === "string" ? cleanText(row.description) : null
-      const totalCost =
-        typeof row.totalCost === "string" ? cleanText(row.totalCost) : null
-
-      if (!category && !description && !totalCost) return null
-
-      return [category, description, totalCost ? `$${totalCost}` : null]
-        .filter((part): part is string => Boolean(part))
-        .join(" - ")
-    })
-    .filter((row): row is string => Boolean(row))
-
-  return formatListSummary(summaryRows)
+  return summarizeBudgetRows(getProgramBudgetRows(program)) || null
 }
 
 function choosePrimaryProgram(programs: OrgProgram[] | null | undefined) {
@@ -239,6 +225,7 @@ export function buildFiscalSponsorshipApplicationPrefill({
     initialProfile.mission,
     initialProfile.theoryOfChange
   )
+  const budgetRows = getProgramBudgetRows(primaryProgram)
 
   return {
     applicantFullName: contactName,
@@ -279,6 +266,7 @@ export function buildFiscalSponsorshipApplicationPrefill({
       resolveProfileLocation(initialProfile)
     ),
     estimatedBudgetCents: resolveBudgetCents(primaryProgram),
+    budgetRows,
     expenseSummary: formatBudgetRows(primaryProgram),
     prospectiveFundingSources: formatProgramFundingSummary(primaryProgram),
     publicBenefit,

--- a/src/components/account-settings/account-settings-dialog-profile-loader.ts
+++ b/src/components/account-settings/account-settings-dialog-profile-loader.ts
@@ -1,6 +1,6 @@
 import { useEffect, type MutableRefObject } from "react"
 
-import { resolveActiveOrganization } from "@/lib/organization/active-org"
+import { loadActiveOrganizationNameAction } from "@/actions/account-settings"
 import type { useSupabaseClient } from "@/hooks/use-supabase-client"
 
 type ProfileIdentityRow = {
@@ -95,7 +95,8 @@ export function useAccountSettingsProfileLoader({
         setPhone(String(meta.phone))
       }
 
-      initialPhoneRef.current = typeof meta.phone === "string" ? String(meta.phone) : ""
+      initialPhoneRef.current =
+        typeof meta.phone === "string" ? String(meta.phone) : ""
       initialMarketingRef.current =
         typeof meta.marketing_opt_in === "boolean"
           ? (meta.marketing_opt_in as boolean)
@@ -106,8 +107,6 @@ export function useAccountSettingsProfileLoader({
           : defaultNewsletterOptIn
 
       if (data?.user?.id) {
-        const { orgId: activeOrgId } = await resolveActiveOrganization(supabase, data.user.id)
-
         const { data: profileRow } = await supabase
           .from("profiles")
           .select("full_name, avatar_url, headline, company, contact, about")
@@ -115,10 +114,17 @@ export function useAccountSettingsProfileLoader({
           .maybeSingle<ProfileIdentityRow>()
         setAvatarUrl(profileRow?.avatar_url ?? null)
 
-        const profileFullName = typeof profileRow?.full_name === "string" ? profileRow.full_name.trim() : ""
+        const profileFullName =
+          typeof profileRow?.full_name === "string"
+            ? profileRow.full_name.trim()
+            : ""
         const defaultFullName = (defaultName ?? "").trim()
-        const metadataFullName = typeof meta.full_name === "string" ? String(meta.full_name).trim() : ""
-        const resolvedFullName = profileFullName || defaultFullName || metadataFullName
+        const metadataFullName =
+          typeof meta.full_name === "string"
+            ? String(meta.full_name).trim()
+            : ""
+        const resolvedFullName =
+          profileFullName || defaultFullName || metadataFullName
         const { first, last } = splitName(resolvedFullName)
         setFirstName(first)
         setLastName(last)
@@ -137,13 +143,9 @@ export function useAccountSettingsProfileLoader({
         initialContactRef.current = contact
         initialAboutRef.current = about
 
-        const { data: orgRow } = await supabase
-          .from("organizations")
-          .select("profile")
-          .eq("user_id", activeOrgId)
-          .maybeSingle<{ profile: Record<string, unknown> | null }>()
-        const profile = (orgRow?.profile ?? {}) as Record<string, unknown>
-        setOrgName(String(profile.name ?? ""))
+        const activeOrganizationName =
+          await loadActiveOrganizationNameAction().catch(() => null)
+        setOrgName(activeOrganizationName ?? "")
       }
     }
 

--- a/src/features/fiscal-sponsorship/actions.ts
+++ b/src/features/fiscal-sponsorship/actions.ts
@@ -1,28 +1,133 @@
-export {
-  loadFiscalSponsorshipApplicationDraft,
-  saveFiscalSponsorshipApplicationDraft,
+"use server"
+
+import {
+  loadFiscalSponsorshipApplicationDraft as loadFiscalSponsorshipApplicationDraftImpl,
+  saveFiscalSponsorshipApplicationDraft as saveFiscalSponsorshipApplicationDraftImpl,
 } from "./server/actions"
-export {
-  connectFiscalSponsorshipDocumentAsset,
-  reviewFiscalSponsorshipDocument,
-  reviewFiscalSponsorshipApplication,
-  submitFiscalSponsorshipApplication,
-} from "./server/workflow-actions"
-export {
-  generateFiscalSponsorshipAgreement,
-  sendFiscalSponsorshipAgreementForSignature,
-} from "./server/workflow-agreement-actions"
-export { handleFiscalSponsorshipDocuSealWebhook } from "./server/docuseal-webhook"
-export { loadFiscalSponsorshipProjectWorkflowSummary } from "./server/workflow-summary"
-export {
-  completeFiscalSponsorshipSignature,
-  saveFiscalSponsorshipSigningDraft,
+import {
+  completeFiscalSponsorshipSignature as completeFiscalSponsorshipSignatureImpl,
+  saveFiscalSponsorshipSigningDraft as saveFiscalSponsorshipSigningDraftImpl,
 } from "./server/native-signing-actions"
-export {
-  buildFiscalSponsorshipSigningPreview,
-  loadFiscalSponsorshipSigningSession,
+import {
+  buildFiscalSponsorshipSigningPreview as buildFiscalSponsorshipSigningPreviewImpl,
+  loadFiscalSponsorshipSigningSession as loadFiscalSponsorshipSigningSessionImpl,
 } from "./server/native-signing-session-actions"
-export {
-  completeFiscalSponsorshipW9,
-  loadFiscalSponsorshipW9Session,
+import { handleFiscalSponsorshipDocuSealWebhook as handleFiscalSponsorshipDocuSealWebhookImpl } from "./server/docuseal-webhook"
+import {
+  completeFiscalSponsorshipW9 as completeFiscalSponsorshipW9Impl,
+  loadFiscalSponsorshipW9Session as loadFiscalSponsorshipW9SessionImpl,
 } from "./server/w9-actions"
+import {
+  connectFiscalSponsorshipDocumentAsset as connectFiscalSponsorshipDocumentAssetImpl,
+  reviewFiscalSponsorshipApplication as reviewFiscalSponsorshipApplicationImpl,
+  reviewFiscalSponsorshipDocument as reviewFiscalSponsorshipDocumentImpl,
+  submitFiscalSponsorshipApplication as submitFiscalSponsorshipApplicationImpl,
+} from "./server/workflow-actions"
+import {
+  generateFiscalSponsorshipAgreement as generateFiscalSponsorshipAgreementImpl,
+  sendFiscalSponsorshipAgreementForSignature as sendFiscalSponsorshipAgreementForSignatureImpl,
+} from "./server/workflow-agreement-actions"
+import { loadFiscalSponsorshipProjectWorkflowSummary as loadFiscalSponsorshipProjectWorkflowSummaryImpl } from "./server/workflow-summary"
+import { canManageFiscalSponsorshipForOrganization as canManageFiscalSponsorshipForOrganizationImpl } from "./server/workflow-support"
+
+export async function loadFiscalSponsorshipApplicationDraft(
+  ...args: Parameters<typeof loadFiscalSponsorshipApplicationDraftImpl>
+) {
+  return loadFiscalSponsorshipApplicationDraftImpl(...args)
+}
+
+export async function saveFiscalSponsorshipApplicationDraft(
+  ...args: Parameters<typeof saveFiscalSponsorshipApplicationDraftImpl>
+) {
+  return saveFiscalSponsorshipApplicationDraftImpl(...args)
+}
+
+export async function connectFiscalSponsorshipDocumentAsset(
+  ...args: Parameters<typeof connectFiscalSponsorshipDocumentAssetImpl>
+) {
+  return connectFiscalSponsorshipDocumentAssetImpl(...args)
+}
+
+export async function reviewFiscalSponsorshipDocument(
+  ...args: Parameters<typeof reviewFiscalSponsorshipDocumentImpl>
+) {
+  return reviewFiscalSponsorshipDocumentImpl(...args)
+}
+
+export async function reviewFiscalSponsorshipApplication(
+  ...args: Parameters<typeof reviewFiscalSponsorshipApplicationImpl>
+) {
+  return reviewFiscalSponsorshipApplicationImpl(...args)
+}
+
+export async function submitFiscalSponsorshipApplication(
+  ...args: Parameters<typeof submitFiscalSponsorshipApplicationImpl>
+) {
+  return submitFiscalSponsorshipApplicationImpl(...args)
+}
+
+export async function generateFiscalSponsorshipAgreement(
+  ...args: Parameters<typeof generateFiscalSponsorshipAgreementImpl>
+) {
+  return generateFiscalSponsorshipAgreementImpl(...args)
+}
+
+export async function sendFiscalSponsorshipAgreementForSignature(
+  ...args: Parameters<typeof sendFiscalSponsorshipAgreementForSignatureImpl>
+) {
+  return sendFiscalSponsorshipAgreementForSignatureImpl(...args)
+}
+
+export async function handleFiscalSponsorshipDocuSealWebhook(
+  ...args: Parameters<typeof handleFiscalSponsorshipDocuSealWebhookImpl>
+) {
+  return handleFiscalSponsorshipDocuSealWebhookImpl(...args)
+}
+
+export async function loadFiscalSponsorshipProjectWorkflowSummary(
+  ...args: Parameters<typeof loadFiscalSponsorshipProjectWorkflowSummaryImpl>
+) {
+  return loadFiscalSponsorshipProjectWorkflowSummaryImpl(...args)
+}
+
+export async function canManageFiscalSponsorshipForOrganization(
+  ...args: Parameters<typeof canManageFiscalSponsorshipForOrganizationImpl>
+) {
+  return canManageFiscalSponsorshipForOrganizationImpl(...args)
+}
+
+export async function completeFiscalSponsorshipSignature(
+  ...args: Parameters<typeof completeFiscalSponsorshipSignatureImpl>
+) {
+  return completeFiscalSponsorshipSignatureImpl(...args)
+}
+
+export async function saveFiscalSponsorshipSigningDraft(
+  ...args: Parameters<typeof saveFiscalSponsorshipSigningDraftImpl>
+) {
+  return saveFiscalSponsorshipSigningDraftImpl(...args)
+}
+
+export async function buildFiscalSponsorshipSigningPreview(
+  ...args: Parameters<typeof buildFiscalSponsorshipSigningPreviewImpl>
+) {
+  return buildFiscalSponsorshipSigningPreviewImpl(...args)
+}
+
+export async function loadFiscalSponsorshipSigningSession(
+  ...args: Parameters<typeof loadFiscalSponsorshipSigningSessionImpl>
+) {
+  return loadFiscalSponsorshipSigningSessionImpl(...args)
+}
+
+export async function completeFiscalSponsorshipW9(
+  ...args: Parameters<typeof completeFiscalSponsorshipW9Impl>
+) {
+  return completeFiscalSponsorshipW9Impl(...args)
+}
+
+export async function loadFiscalSponsorshipW9Session(
+  ...args: Parameters<typeof loadFiscalSponsorshipW9SessionImpl>
+) {
+  return loadFiscalSponsorshipW9SessionImpl(...args)
+}

--- a/src/features/fiscal-sponsorship/actions.ts
+++ b/src/features/fiscal-sponsorship/actions.ts
@@ -28,7 +28,6 @@ import {
   sendFiscalSponsorshipAgreementForSignature as sendFiscalSponsorshipAgreementForSignatureImpl,
 } from "./server/workflow-agreement-actions"
 import { loadFiscalSponsorshipProjectWorkflowSummary as loadFiscalSponsorshipProjectWorkflowSummaryImpl } from "./server/workflow-summary"
-import { canManageFiscalSponsorshipForOrganization as canManageFiscalSponsorshipForOrganizationImpl } from "./server/workflow-support"
 
 export async function loadFiscalSponsorshipApplicationDraft(
   ...args: Parameters<typeof loadFiscalSponsorshipApplicationDraftImpl>
@@ -88,12 +87,6 @@ export async function loadFiscalSponsorshipProjectWorkflowSummary(
   ...args: Parameters<typeof loadFiscalSponsorshipProjectWorkflowSummaryImpl>
 ) {
   return loadFiscalSponsorshipProjectWorkflowSummaryImpl(...args)
-}
-
-export async function canManageFiscalSponsorshipForOrganization(
-  ...args: Parameters<typeof canManageFiscalSponsorshipForOrganizationImpl>
-) {
-  return canManageFiscalSponsorshipForOrganizationImpl(...args)
 }
 
 export async function completeFiscalSponsorshipSignature(

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-drawer.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-drawer.tsx
@@ -91,7 +91,7 @@ export function FiscalSponsorshipApplicationEditor({
   surface,
 }: FiscalSponsorshipApplicationEditorProps) {
   const formId = React.useId()
-  const loadedProjectIdRef = React.useRef<string | null>(null)
+  const loadedApplicationKeyRef = React.useRef<string | null>(null)
   const [draft, setDraft] = React.useState<FiscalSponsorshipApplicationDraft>(
     () => buildFiscalSponsorshipApplicationDraft({ data })
   )
@@ -115,13 +115,16 @@ export function FiscalSponsorshipApplicationEditor({
     data.applicationPrefill?.sourceActivityKind ??
     data.applicationPrefill?.focusArea ??
     null
+  const applicationKey = `${data.projectId}:${
+    data.applicationPrefill?.sourceActivityId ?? ""
+  }`
   const draftDirty = React.useMemo(
     () => JSON.stringify(draft) !== JSON.stringify(baselineDraft),
     [baselineDraft, draft]
   )
 
   React.useEffect(() => {
-    if (!open || loadedProjectIdRef.current === data.projectId) return
+    if (!open || loadedApplicationKeyRef.current === applicationKey) return
 
     let cancelled = false
     setLoadingDraft(true)
@@ -145,7 +148,7 @@ export function FiscalSponsorshipApplicationEditor({
           application: result.application,
           data,
         })
-        loadedProjectIdRef.current = data.projectId
+        loadedApplicationKeyRef.current = applicationKey
         setDraft(loadedDraft)
         setBaselineDraft(loadedDraft)
         setLoadingDraft(false)
@@ -155,7 +158,7 @@ export function FiscalSponsorshipApplicationEditor({
     return () => {
       cancelled = true
     }
-  }, [data, open])
+  }, [applicationKey, data, open])
 
   React.useEffect(() => {
     if (!draftDirty) return
@@ -318,6 +321,7 @@ export function FiscalSponsorshipApplicationEditor({
         draft={draft}
         formId={formId}
         projectId={data.projectId}
+        sourceActivityTitle={sourceActivityTitle}
         onFieldChange={handleFieldChange}
       />
     </div>

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-editor-fields.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-editor-fields.tsx
@@ -38,6 +38,7 @@ type FiscalSponsorshipApplicationEditorFieldsProps = {
   formId: string
   onFieldChange: DraftFieldChange
   projectId: string
+  sourceActivityTitle?: string | null
 }
 
 function hasText(value: string) {
@@ -94,6 +95,7 @@ export function FiscalSponsorshipApplicationEditorFields({
   formId,
   onFieldChange,
   projectId,
+  sourceActivityTitle,
 }: FiscalSponsorshipApplicationEditorFieldsProps) {
   const sectionCompletion = React.useMemo(
     () => resolveApplicationSectionCompletion(draft),
@@ -141,6 +143,7 @@ export function FiscalSponsorshipApplicationEditorFields({
         draft={draft}
         formId={formId}
         projectId={projectId}
+        sourceActivityTitle={sourceActivityTitle}
         sectionChrome={getSectionChrome("budget")}
         onFieldChange={onFieldChange}
       />

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-editor-review-sections.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-editor-review-sections.tsx
@@ -18,6 +18,7 @@ export function BudgetBenefitSection({
   onFieldChange,
   projectId,
   sectionChrome,
+  sourceActivityTitle,
 }: {
   applicationReady: boolean
   draft: FiscalSponsorshipApplicationDraft
@@ -25,6 +26,7 @@ export function BudgetBenefitSection({
   onFieldChange: DraftFieldChange
   projectId: string
   sectionChrome: EditorSectionChromeProps
+  sourceActivityTitle?: string | null
 }) {
   return (
     <EditorSection
@@ -37,6 +39,7 @@ export function BudgetBenefitSection({
         draft={draft}
         formId={formId}
         projectId={projectId}
+        sourceActivityTitle={sourceActivityTitle}
         onFieldChange={onFieldChange}
       />
       <DraftTextareaField

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-budget-plan-editor.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-budget-plan-editor.tsx
@@ -6,32 +6,23 @@ import FileSpreadsheetIcon from "lucide-react/dist/esm/icons/file-spreadsheet"
 import FileUpIcon from "lucide-react/dist/esm/icons/file-up"
 import Loader2Icon from "lucide-react/dist/esm/icons/loader-2"
 import PlusIcon from "lucide-react/dist/esm/icons/plus"
-import Trash2Icon from "lucide-react/dist/esm/icons/trash-2"
 
+import { BudgetTable } from "@/components/training/module-detail/budget-table"
 import { Button } from "@/components/ui/button"
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { toast } from "@/lib/toast"
 
 import { connectFiscalSponsorshipDocumentAsset } from "../actions"
 import {
   BUDGET_SUPPORT_ACCEPT,
   formatBudgetDollars,
+  getBudgetRowTotal,
   getBudgetTotal,
   isCsvFile,
   makeBudgetRow,
-  parseBudgetRows,
   parseCsvBudgetRows,
-  serializeBudgetRows,
+  summarizeBudgetRows,
   uploadProjectAsset,
   type FiscalSponsorshipBudgetRow,
 } from "../lib/budget-plan"
@@ -44,6 +35,22 @@ type FiscalSponsorshipBudgetPlanEditorProps = {
   formId: string
   onFieldChange: DraftFieldChange
   projectId: string
+  sourceActivityTitle?: string | null
+}
+
+const COST_TYPE_OPTIONS = ["Fixed", "Variable", "Fixed or Variable"]
+const UNIT_OPTIONS = [
+  "Session / Hour",
+  "Participant / Session",
+  "Participant / Event",
+  "Event / Month",
+  "Participant / Trip",
+  "Program / Participant",
+  "Program / Session",
+]
+
+function formatMoney(value: number) {
+  return Number.isFinite(value) ? value.toFixed(2) : "0.00"
 }
 
 export function FiscalSponsorshipBudgetPlanEditor({
@@ -52,70 +59,48 @@ export function FiscalSponsorshipBudgetPlanEditor({
   formId,
   onFieldChange,
   projectId,
+  sourceActivityTitle,
 }: FiscalSponsorshipBudgetPlanEditorProps) {
   const router = useRouter()
   const [selectedSupportFile, setSelectedSupportFile] =
     React.useState<File | null>(null)
-  const [rows, setRows] = React.useState(() =>
-    parseBudgetRows(draft.expenseSummary)
-  )
   const [isUploadPending, startUploadTransition] = React.useTransition()
   const fileInputRef = React.useRef<HTMLInputElement>(null)
-  const lastSerializedRowsRef = React.useRef(draft.expenseSummary)
-  const hasLineItemAmounts = rows.some((row) => row.amount.trim())
+  const rows =
+    draft.budgetRows.length > 0 ? draft.budgetRows : [makeBudgetRow(0)]
+  const totals = rows.map(getBudgetRowTotal)
+  const hasLineItemAmounts = totals.some((total) => total > 0)
   const budgetTotal = getBudgetTotal(rows)
-  const totalInputId = `${formId}-estimatedBudgetDollars`
   const supportFileInputId = `${formId}-budgetSupportFile`
-
-  React.useEffect(() => {
-    if (draft.expenseSummary === lastSerializedRowsRef.current) return
-    setRows(parseBudgetRows(draft.expenseSummary))
-    lastSerializedRowsRef.current = draft.expenseSummary
-  }, [draft.expenseSummary])
+  const unitListId = `${formId}-fiscal-budget-unit-options`
 
   function commitRows(nextRows: FiscalSponsorshipBudgetRow[]) {
-    const serializedRows = serializeBudgetRows(nextRows)
     const nextTotal = getBudgetTotal(nextRows)
-    setRows(nextRows)
-    lastSerializedRowsRef.current = serializedRows
-    onFieldChange("expenseSummary", serializedRows)
-
-    if (nextRows.some((row) => row.amount.trim())) {
-      onFieldChange(
-        "estimatedBudgetDollars",
-        nextTotal > 0 ? formatBudgetDollars(nextTotal) : ""
-      )
-    }
-  }
-
-  function handleRowChange({
-    field,
-    id,
-    value,
-  }: {
-    field: keyof Pick<
-      FiscalSponsorshipBudgetRow,
-      "amount" | "category" | "description"
-    >
-    id: string
-    value: string
-  }) {
-    commitRows(
-      rows.map((row) => (row.id === id ? { ...row, [field]: value } : row))
+    onFieldChange("budgetRows", nextRows)
+    onFieldChange("expenseSummary", summarizeBudgetRows(nextRows))
+    onFieldChange(
+      "estimatedBudgetDollars",
+      nextTotal > 0 ? formatMoney(nextTotal) : ""
     )
   }
 
-  function handleAddRow() {
-    setRows((currentRows) => [
-      ...currentRows,
-      makeBudgetRow(currentRows.length, {
-        id: `budget-row-new-${Date.now()}`,
-      }),
-    ])
+  function handleRowChange(
+    rowIndex: number,
+    patch: Partial<FiscalSponsorshipBudgetRow>
+  ) {
+    const nextRows = [...rows]
+    const nextRow = { ...nextRows[rowIndex], ...patch }
+    nextRow.totalCost = formatMoney(getBudgetRowTotal(nextRow))
+    nextRows[rowIndex] = nextRow
+    commitRows(nextRows)
   }
 
-  function handleRemoveRow(id: string) {
-    const nextRows = rows.filter((row) => row.id !== id)
+  function handleAddRow() {
+    commitRows([...rows, makeBudgetRow(rows.length)])
+  }
+
+  function handleRemoveRow(rowIndex: number) {
+    const nextRows = rows.filter((_, index) => index !== rowIndex)
     commitRows(nextRows.length > 0 ? nextRows : [makeBudgetRow(0)])
   }
 
@@ -198,8 +183,11 @@ export function FiscalSponsorshipBudgetPlanEditor({
           <div className="min-w-0">
             <FieldLabel>Budget plan</FieldLabel>
             <FieldDescription>
-              Add line items or import a CSV with category, description, and
-              amount columns.
+              {sourceActivityTitle
+                ? `Linked to the budget for ${sourceActivityTitle}.`
+                : "Linked to the budget for the selected activity or program."}{" "}
+              Saving this application updates the same line items in the program
+              builder.
             </FieldDescription>
           </div>
           <Button
@@ -213,169 +201,92 @@ export function FiscalSponsorshipBudgetPlanEditor({
             Add row
           </Button>
         </div>
-        <div className="rounded-lg border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="min-w-36">Category</TableHead>
-                <TableHead className="min-w-56">Description</TableHead>
-                <TableHead className="min-w-32">Amount</TableHead>
-                <TableHead className="w-12">
-                  <span className="sr-only">Actions</span>
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((row) => (
-                <TableRow key={row.id}>
-                  <TableCell className="whitespace-normal">
-                    <Input
-                      value={row.category}
-                      aria-label="Budget category"
-                      placeholder="Program supplies"
-                      onChange={(event) =>
-                        handleRowChange({
-                          field: "category",
-                          id: row.id,
-                          value: event.target.value,
-                        })
-                      }
-                    />
-                  </TableCell>
-                  <TableCell className="whitespace-normal">
-                    <Input
-                      value={row.description}
-                      aria-label="Budget description"
-                      placeholder="Materials, venue, contractors..."
-                      onChange={(event) =>
-                        handleRowChange({
-                          field: "description",
-                          id: row.id,
-                          value: event.target.value,
-                        })
-                      }
-                    />
-                  </TableCell>
-                  <TableCell className="whitespace-normal">
-                    <Input
-                      value={row.amount}
-                      aria-label="Budget amount"
-                      placeholder="$0"
-                      inputMode="decimal"
-                      onChange={(event) =>
-                        handleRowChange({
-                          field: "amount",
-                          id: row.id,
-                          value: event.target.value,
-                        })
-                      }
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Remove budget row"
-                      onClick={() => handleRemoveRow(row.id)}
-                    >
-                      <Trash2Icon data-icon="inline-start" aria-hidden />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-            <TableFooter>
-              <TableRow>
-                <TableCell colSpan={2}>Line-item total</TableCell>
-                <TableCell colSpan={2}>
-                  {hasLineItemAmounts
-                    ? formatBudgetDollars(budgetTotal)
-                    : "Add amounts"}
-                </TableCell>
-              </TableRow>
-            </TableFooter>
-          </Table>
+        <div className="min-w-0">
+          <BudgetTable
+            rows={rows}
+            blankRow={makeBudgetRow(0)}
+            totals={totals}
+            subtotal={budgetTotal}
+            costTypeOptions={COST_TYPE_OPTIONS}
+            unitOptions={UNIT_OPTIONS}
+            unitListId={unitListId}
+            formatMoney={formatMoney}
+            onUpdateRow={handleRowChange}
+            onRowsChange={commitRows}
+            layout="grid"
+            maxBodyHeightClassName="max-h-[min(52vh,34rem)]"
+          />
         </div>
+        <FieldDescription className="flex items-center justify-between gap-3">
+          <span>
+            {hasLineItemAmounts
+              ? "The fiscal application total updates from these line items."
+              : "Add quantity and unit cost to calculate the budget."}
+          </span>
+          <span className="text-foreground shrink-0 font-semibold tabular-nums">
+            {hasLineItemAmounts
+              ? formatBudgetDollars(budgetTotal)
+              : "Not calculated"}
+          </span>
+        </FieldDescription>
       </Field>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field>
-          <FieldLabel htmlFor={totalInputId}>Estimated total budget</FieldLabel>
-          <Input
-            id={totalInputId}
-            name="estimatedBudgetDollars"
-            value={draft.estimatedBudgetDollars}
-            placeholder="$0"
-            inputMode="decimal"
-            onChange={(event) =>
-              onFieldChange("estimatedBudgetDollars", event.target.value)
+      <Field>
+        <FieldLabel htmlFor={supportFileInputId}>
+          Budget support files
+        </FieldLabel>
+        <Input
+          ref={fileInputRef}
+          id={supportFileInputId}
+          type="file"
+          accept={BUDGET_SUPPORT_ACCEPT}
+          onChange={(event) =>
+            setSelectedSupportFile(event.target.files?.[0] ?? null)
+          }
+        />
+        <FieldDescription>
+          {selectedSupportFile
+            ? `${selectedSupportFile.name} selected`
+            : "CSV, spreadsheet, PDF, image, and document files are supported."}
+        </FieldDescription>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!isCsvFile(selectedSupportFile)}
+            onClick={() => void handleImportCsvRows()}
+          >
+            <FileSpreadsheetIcon data-icon="inline-start" aria-hidden />
+            Import CSV rows
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={
+              !selectedSupportFile || !applicationReady || isUploadPending
             }
-          />
+            aria-busy={isUploadPending}
+            onClick={handleUploadSupportFile}
+          >
+            {isUploadPending ? (
+              <Loader2Icon
+                data-icon="inline-start"
+                className="animate-spin"
+                aria-hidden
+              />
+            ) : (
+              <FileUpIcon data-icon="inline-start" aria-hidden />
+            )}
+            Upload support file
+          </Button>
+        </div>
+        {!applicationReady ? (
           <FieldDescription>
-            {hasLineItemAmounts
-              ? "Updated from the line-item amounts."
-              : "Use this when line-item amounts are not known yet."}
+            Save the application first to attach budget files for review.
           </FieldDescription>
-        </Field>
-
-        <Field>
-          <FieldLabel htmlFor={supportFileInputId}>
-            Budget support files
-          </FieldLabel>
-          <Input
-            ref={fileInputRef}
-            id={supportFileInputId}
-            type="file"
-            accept={BUDGET_SUPPORT_ACCEPT}
-            onChange={(event) =>
-              setSelectedSupportFile(event.target.files?.[0] ?? null)
-            }
-          />
-          <FieldDescription>
-            {selectedSupportFile
-              ? `${selectedSupportFile.name} selected`
-              : "CSV, spreadsheet, PDF, image, and document files are supported."}
-          </FieldDescription>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={!isCsvFile(selectedSupportFile)}
-              onClick={() => void handleImportCsvRows()}
-            >
-              <FileSpreadsheetIcon data-icon="inline-start" aria-hidden />
-              Import CSV rows
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={
-                !selectedSupportFile || !applicationReady || isUploadPending
-              }
-              aria-busy={isUploadPending}
-              onClick={handleUploadSupportFile}
-            >
-              {isUploadPending ? (
-                <Loader2Icon
-                  data-icon="inline-start"
-                  className="animate-spin"
-                  aria-hidden
-                />
-              ) : (
-                <FileUpIcon data-icon="inline-start" aria-hidden />
-              )}
-              Upload support file
-            </Button>
-          </div>
-          {!applicationReady ? (
-            <FieldDescription>
-              Save the application first to attach budget files for review.
-            </FieldDescription>
-          ) : null}
-        </Field>
-      </div>
+        ) : null}
+      </Field>
     </div>
   )
 }

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-required-documents-upload-panel.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-required-documents-upload-panel.tsx
@@ -351,7 +351,7 @@ export function FiscalSponsorshipRequiredDocumentsUploadPanel({
                       {formatReviewStatus(document?.reviewStatus)}
                     </Badge>
                   </div>
-                  <p className="text-muted-foreground mt-0.5 text-[11px] leading-snug">
+                  <p className="text-muted-foreground mt-0.5 min-w-0 text-[11px] leading-snug [overflow-wrap:anywhere] break-words">
                     {document?.title || requirement.description}
                   </p>
                 </div>
@@ -365,7 +365,7 @@ export function FiscalSponsorshipRequiredDocumentsUploadPanel({
 
               {uploadAllowed ? (
                 <div className="grid min-w-0 gap-2 pl-6">
-                  <Field>
+                  <Field className="min-w-0">
                     <FieldLabel htmlFor={inputId} className="text-xs">
                       {getUploadLabel({ document })}
                     </FieldLabel>
@@ -381,7 +381,7 @@ export function FiscalSponsorshipRequiredDocumentsUploadPanel({
                         })
                       }
                     />
-                    <FieldDescription className="text-[11px]">
+                    <FieldDescription className="min-w-0 text-[11px] [overflow-wrap:anywhere] break-words">
                       {selectedFile
                         ? `${selectedFile.name} selected`
                         : "PDFs, images, spreadsheets, and document files are supported."}

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workflow-drawer.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workflow-drawer.tsx
@@ -86,8 +86,9 @@ export function FiscalSponsorshipWorkflowDrawer({
         </TabsList>
 
         <ScrollArea
-          className="text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 flex-1 rounded-[2rem] border p-3 shadow-sm"
-          viewportClassName="max-h-[calc(100svh-15rem)] rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem]"
+          className="text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 min-w-0 flex-1 overflow-hidden rounded-[2rem] border p-3 shadow-sm"
+          viewportClassName="max-h-[calc(100svh-15rem)] max-w-full overflow-x-hidden rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem] [&>div]:!block [&>div]:!w-full [&>div]:!max-w-full [&>div]:!min-w-0"
+          contentClassName="min-w-0 max-w-full overflow-hidden [&>*]:min-w-0 [&>*]:max-w-full"
         >
           <TabsContent value="work" className="mt-0 flex flex-col gap-4">
             <WorkflowPhases

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workspace-card-summary.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workspace-card-summary.tsx
@@ -120,6 +120,10 @@ export function buildSelectedProgramPrefill({
       basePrefill?.temporaryEndDate
     ),
     estimatedBudgetCents,
+    budgetRows:
+      program.budgetRows && program.budgetRows.length > 0
+        ? program.budgetRows
+        : (basePrefill?.budgetRows ?? null),
     expenseSummary: firstText(
       program.expenseSummary,
       basePrefill?.expenseSummary

--- a/src/features/fiscal-sponsorship/index.ts
+++ b/src/features/fiscal-sponsorship/index.ts
@@ -1,6 +1,7 @@
 export {
   connectFiscalSponsorshipDocumentAsset,
   buildFiscalSponsorshipSigningPreview,
+  canManageFiscalSponsorshipForOrganization,
   generateFiscalSponsorshipAgreement,
   handleFiscalSponsorshipDocuSealWebhook,
   loadFiscalSponsorshipProjectWorkflowSummary,
@@ -44,6 +45,10 @@ export {
   FISCAL_SPONSORSHIP_HANDBOOK_HREF,
   FISCAL_SPONSORSHIP_HANDBOOK_NAV_ITEMS,
 } from "./lib/application-data"
+export {
+  normalizeFiscalSponsorshipBudgetRows,
+  summarizeBudgetRows,
+} from "./lib/budget-plan"
 export { FISCAL_SPONSORSHIP_PROTOTYPE_STEPS } from "./lib/prototype-data"
 export { buildFiscalSponsorshipProjectWorkbenchData } from "./lib/project-workbench-data"
 export {

--- a/src/features/fiscal-sponsorship/index.ts
+++ b/src/features/fiscal-sponsorship/index.ts
@@ -1,7 +1,6 @@
 export {
   connectFiscalSponsorshipDocumentAsset,
   buildFiscalSponsorshipSigningPreview,
-  canManageFiscalSponsorshipForOrganization,
   generateFiscalSponsorshipAgreement,
   handleFiscalSponsorshipDocuSealWebhook,
   loadFiscalSponsorshipProjectWorkflowSummary,

--- a/src/features/fiscal-sponsorship/lib/application-draft.ts
+++ b/src/features/fiscal-sponsorship/lib/application-draft.ts
@@ -178,24 +178,25 @@ export function buildFiscalSponsorshipApplicationDraft({
   )
   const selectedActivityId = prefill?.sourceActivityId?.trim() || null
   const sourceActivityChanged = Boolean(
-    selectedActivityId &&
-    savedBudgetActivityId &&
-    selectedActivityId !== savedBudgetActivityId
+    selectedActivityId && selectedActivityId !== savedBudgetActivityId
   )
   const prefillBudgetRows = normalizeFiscalSponsorshipBudgetRows(
     prefill?.budgetRows
   )
-  const summaryBudgetRows = sourceActivityChanged
-    ? parseBudgetRows("")
-    : parseBudgetRows(
-        firstText(application?.expenseSummary, prefill?.expenseSummary)
-      )
+  const applicationSummaryBudgetRows = parseBudgetRows(
+    text(application?.expenseSummary)
+  )
+  const prefillSummaryBudgetRows = parseBudgetRows(
+    text(prefill?.expenseSummary)
+  )
   const budgetRows =
     savedBudgetRows.length > 0 && !sourceActivityChanged
       ? savedBudgetRows
-      : prefillBudgetRows.length > 0
-        ? prefillBudgetRows
-        : summaryBudgetRows
+      : application && !sourceActivityChanged
+        ? applicationSummaryBudgetRows
+        : prefillBudgetRows.length > 0
+          ? prefillBudgetRows
+          : prefillSummaryBudgetRows
   const budgetTotal = getBudgetTotal(budgetRows)
   const storedEstimatedBudgetDollars = formatBudgetCentsForDraft(
     application?.estimatedBudgetCents ?? prefill?.estimatedBudgetCents

--- a/src/features/fiscal-sponsorship/lib/application-draft.ts
+++ b/src/features/fiscal-sponsorship/lib/application-draft.ts
@@ -6,6 +6,15 @@ import type {
   FiscalSponsorshipProjectDurationType,
   FiscalSponsorshipProjectWorkbenchData,
 } from "../types"
+import type { BudgetTableRow } from "@/lib/modules"
+import {
+  getBudgetTotal,
+  normalizeFiscalSponsorshipBudgetRows,
+  parseBudgetRows,
+  readBudgetRowsFromMetadata,
+  readBudgetSourceActivityIdFromMetadata,
+  summarizeBudgetRows,
+} from "./budget-plan"
 
 export type FiscalSponsorshipBooleanChoice = "unknown" | "yes" | "no"
 
@@ -32,6 +41,7 @@ export type FiscalSponsorshipApplicationDraft = {
   focusArea: string
   projectDescription: string
   projectLocation: string
+  budgetRows: BudgetTableRow[]
   estimatedBudgetDollars: string
   expenseSummary: string
   prospectiveFundingSources: string
@@ -162,6 +172,36 @@ export function buildFiscalSponsorshipApplicationDraft({
   const applicationName = text(application?.applicantFullName)
   const fullName = applicationName || fallbackApplicantName
   const fullNameParts = splitName(fullName)
+  const savedBudgetRows = readBudgetRowsFromMetadata(application?.metadata)
+  const savedBudgetActivityId = readBudgetSourceActivityIdFromMetadata(
+    application?.metadata
+  )
+  const selectedActivityId = prefill?.sourceActivityId?.trim() || null
+  const sourceActivityChanged = Boolean(
+    selectedActivityId &&
+    savedBudgetActivityId &&
+    selectedActivityId !== savedBudgetActivityId
+  )
+  const prefillBudgetRows = normalizeFiscalSponsorshipBudgetRows(
+    prefill?.budgetRows
+  )
+  const summaryBudgetRows = sourceActivityChanged
+    ? parseBudgetRows("")
+    : parseBudgetRows(
+        firstText(application?.expenseSummary, prefill?.expenseSummary)
+      )
+  const budgetRows =
+    savedBudgetRows.length > 0 && !sourceActivityChanged
+      ? savedBudgetRows
+      : prefillBudgetRows.length > 0
+        ? prefillBudgetRows
+        : summaryBudgetRows
+  const budgetTotal = getBudgetTotal(budgetRows)
+  const storedEstimatedBudgetDollars = formatBudgetCentsForDraft(
+    application?.estimatedBudgetCents ?? prefill?.estimatedBudgetCents
+  )
+  const estimatedBudgetDollars =
+    budgetTotal > 0 ? String(budgetTotal) : storedEstimatedBudgetDollars
 
   return {
     projectId: data.projectId,
@@ -227,9 +267,8 @@ export function buildFiscalSponsorshipApplicationDraft({
       application?.projectLocation,
       prefill?.projectLocation
     ),
-    estimatedBudgetDollars: formatBudgetCentsForDraft(
-      application?.estimatedBudgetCents ?? prefill?.estimatedBudgetCents
-    ),
+    budgetRows,
+    estimatedBudgetDollars,
     expenseSummary: firstText(
       application?.expenseSummary,
       prefill?.expenseSummary
@@ -313,7 +352,7 @@ export function buildFiscalSponsorshipApplicationInput({
     estimatedBudgetCents: parseBudgetDollarsToCents(
       draft.estimatedBudgetDollars
     ),
-    expenseSummary: nullableText(draft.expenseSummary),
+    expenseSummary: nullableText(summarizeBudgetRows(draft.budgetRows)),
     prospectiveFundingSources: nullableText(draft.prospectiveFundingSources),
     publicBenefit: nullableText(draft.publicBenefit),
     leadershipBackground: nullableText(draft.leadershipBackground),
@@ -369,6 +408,7 @@ export function buildFiscalSponsorshipApplicationInput({
       },
     },
     metadata: {
+      budgetRows: draft.budgetRows,
       lastEditedSurface: "project-fiscal-sponsorship-drawer",
       selectedActivityId: data.applicationPrefill?.sourceActivityId ?? null,
     },

--- a/src/features/fiscal-sponsorship/lib/budget-plan.ts
+++ b/src/features/fiscal-sponsorship/lib/budget-plan.ts
@@ -1,9 +1,6 @@
-export type FiscalSponsorshipBudgetRow = {
-  amount: string
-  category: string
-  description: string
-  id: string
-}
+import type { BudgetTableRow } from "@/lib/modules"
+
+export type FiscalSponsorshipBudgetRow = BudgetTableRow
 
 export type ProjectAssetUploadResponse = {
   assets?: Array<{
@@ -17,14 +14,21 @@ export const BUDGET_SUPPORT_ACCEPT =
   ".csv,text/csv,application/pdf,image/*,.xls,.xlsx,.doc,.docx"
 
 export function makeBudgetRow(
-  index: number,
+  _index: number,
   value?: Partial<FiscalSponsorshipBudgetRow>
 ): FiscalSponsorshipBudgetRow {
+  const explicitTotal = value?.totalCost?.trim() ?? ""
+  const hasExplicitTotal = parseMoneyValue(explicitTotal) > 0
+
   return {
-    amount: value?.amount ?? "",
     category: value?.category ?? "",
+    costPerUnit:
+      value?.costPerUnit?.trim() || (hasExplicitTotal ? explicitTotal : ""),
+    costType: value?.costType?.trim() || (hasExplicitTotal ? "Fixed" : ""),
     description: value?.description ?? "",
-    id: value?.id ?? `budget-row-${index}`,
+    totalCost: explicitTotal,
+    unit: value?.unit?.trim() || (hasExplicitTotal ? "Program" : ""),
+    units: value?.units?.trim() || (hasExplicitTotal ? "1" : ""),
   }
 }
 
@@ -32,9 +36,54 @@ function normalizeBudgetCell(value: string) {
   return value.replaceAll("|", "/").trim()
 }
 
+function hasMeaningfulBudgetRow(row: FiscalSponsorshipBudgetRow) {
+  const hasText = [row.category, row.costType, row.description, row.unit].some(
+    (value) => value.trim().length > 0
+  )
+  const hasAmount = [row.units, row.costPerUnit, row.totalCost].some(
+    (value) => parseMoneyValue(value) > 0
+  )
+
+  return hasText || hasAmount
+}
+
+function isZeroOnlyBudgetSummary(value: string) {
+  return /^\s*\$?\s*0(?:\.0{1,2})?(?:\s*;\s*\$?\s*0(?:\.0{1,2})?)*\s*$/.test(
+    value
+  )
+}
+
+function legacyAmountRow({
+  amount,
+  category,
+  description,
+  index,
+}: {
+  amount: string
+  category: string
+  description: string
+  index: number
+}) {
+  const normalizedAmount = amount.replace(/^\$/, "").trim()
+
+  return makeBudgetRow(index, {
+    category,
+    costPerUnit: normalizedAmount,
+    costType: normalizedAmount ? "Fixed" : "",
+    description,
+    totalCost: normalizedAmount,
+    unit: normalizedAmount ? "Program" : "",
+    units: normalizedAmount ? "1" : "",
+  })
+}
+
 export function parseBudgetRows(value: string): FiscalSponsorshipBudgetRow[] {
+  if (!value.trim() || isZeroOnlyBudgetSummary(value)) {
+    return [makeBudgetRow(0)]
+  }
+
   const rows = value
-    .split(/\r?\n/)
+    .split(/\r?\n|;\s*/)
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line, index) => {
@@ -44,27 +93,42 @@ export function parseBudgetRows(value: string): FiscalSponsorshipBudgetRow[] {
           ? line.split("\t")
           : line.split(" - ")
 
-      return makeBudgetRow(index, {
+      if (cells.length >= 7) {
+        return makeBudgetRow(index, {
+          category: cells[0]?.trim() ?? "",
+          description: cells[1]?.trim() ?? "",
+          costType: cells[2]?.trim() ?? "",
+          unit: cells[3]?.trim() ?? "",
+          units: cells[4]?.trim() ?? "",
+          costPerUnit: cells[5]?.trim() ?? "",
+          totalCost: cells[6]?.trim() ?? "",
+        })
+      }
+
+      return legacyAmountRow({
         amount: cells[2]?.trim() ?? "",
         category: cells[0]?.trim() ?? "",
         description: cells[1]?.trim() ?? "",
+        index,
       })
     })
+    .filter(hasMeaningfulBudgetRow)
 
   return rows.length > 0 ? rows : [makeBudgetRow(0)]
 }
 
 export function serializeBudgetRows(rows: FiscalSponsorshipBudgetRow[]) {
   return rows
-    .filter(
-      (row) =>
-        row.category.trim() || row.description.trim() || row.amount.trim()
-    )
+    .filter(hasMeaningfulBudgetRow)
     .map((row) =>
       [
         normalizeBudgetCell(row.category),
         normalizeBudgetCell(row.description),
-        normalizeBudgetCell(row.amount),
+        normalizeBudgetCell(row.costType),
+        normalizeBudgetCell(row.unit),
+        normalizeBudgetCell(row.units),
+        normalizeBudgetCell(row.costPerUnit),
+        normalizeBudgetCell(row.totalCost),
       ].join(" | ")
     )
     .join("\n")
@@ -83,8 +147,79 @@ export function formatBudgetDollars(value: number) {
   }).format(value)
 }
 
+export function getBudgetRowTotal(row: FiscalSponsorshipBudgetRow) {
+  if (row.units.trim() && row.costPerUnit.trim()) {
+    return parseMoneyValue(row.units) * parseMoneyValue(row.costPerUnit)
+  }
+
+  const explicitTotal = parseMoneyValue(row.totalCost)
+  if (explicitTotal > 0) return explicitTotal
+  return 0
+}
+
 export function getBudgetTotal(rows: FiscalSponsorshipBudgetRow[]) {
-  return rows.reduce((total, row) => total + parseMoneyValue(row.amount), 0)
+  return rows.reduce((total, row) => total + getBudgetRowTotal(row), 0)
+}
+
+export function summarizeBudgetRows(rows: FiscalSponsorshipBudgetRow[]) {
+  return rows
+    .filter(hasMeaningfulBudgetRow)
+    .map((row) => {
+      const total = getBudgetRowTotal(row)
+      const amount = total > 0 ? `$${total.toFixed(2)}` : null
+
+      return [row.category.trim(), row.description.trim(), amount]
+        .filter(Boolean)
+        .join(" - ")
+    })
+    .filter(Boolean)
+    .join("; ")
+}
+
+export function normalizeFiscalSponsorshipBudgetRows(
+  value: unknown
+): FiscalSponsorshipBudgetRow[] {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((entry, index) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return null
+      }
+
+      const record = entry as Record<string, unknown>
+      const text = (key: keyof FiscalSponsorshipBudgetRow) =>
+        typeof record[key] === "string" ? record[key].trim() : ""
+      const row = makeBudgetRow(index, {
+        category: text("category"),
+        costPerUnit: text("costPerUnit"),
+        costType: text("costType"),
+        description: text("description"),
+        totalCost: text("totalCost"),
+        unit: text("unit"),
+        units: text("units"),
+      })
+
+      return hasMeaningfulBudgetRow(row) ? row : null
+    })
+    .filter((row): row is FiscalSponsorshipBudgetRow => row !== null)
+}
+
+export function readBudgetRowsFromMetadata(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return []
+  return normalizeFiscalSponsorshipBudgetRows(
+    (value as Record<string, unknown>).budgetRows
+  )
+}
+
+export function readBudgetSourceActivityIdFromMetadata(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const selectedActivityId = (value as Record<string, unknown>)
+    .selectedActivityId
+  return typeof selectedActivityId === "string" &&
+    selectedActivityId.trim().length > 0
+    ? selectedActivityId.trim()
+    : null
 }
 
 function parseCsvLine(line: string) {
@@ -128,15 +263,36 @@ function getBudgetCsvColumnIndexes(header: string[]) {
   const description = normalized.findIndex((cell) =>
     /\b(description|detail|notes?)\b/.test(cell)
   )
-  const amount = normalized.findIndex((cell) =>
-    /\b(amount|cost|budget|total)\b/.test(cell)
+  const costType = normalized.findIndex((cell) =>
+    /\b(cost type|fixed|variable)\b/.test(cell)
+  )
+  const unit = normalized.findIndex((cell) => /\bunit(?: type)?\b/.test(cell))
+  const units = normalized.findIndex((cell) =>
+    /\b(quantity|qty|number of units|# of units)\b/.test(cell)
+  )
+  const costPerUnit = normalized.findIndex((cell) =>
+    /\b(cost per unit|unit cost|rate)\b/.test(cell)
+  )
+  const totalCost = normalized.findIndex((cell) =>
+    /\b(amount|total|total cost|estimated cost|budget)\b/.test(cell)
   )
 
   return {
-    amount: amount >= 0 ? amount : 2,
     category: category >= 0 ? category : 0,
+    costPerUnit,
+    costType,
     description: description >= 0 ? description : 1,
-    hasHeader: category >= 0 || description >= 0 || amount >= 0,
+    hasHeader:
+      category >= 0 ||
+      description >= 0 ||
+      costType >= 0 ||
+      unit >= 0 ||
+      units >= 0 ||
+      costPerUnit >= 0 ||
+      totalCost >= 0,
+    totalCost: totalCost >= 0 ? totalCost : 2,
+    unit,
+    units,
   }
 }
 
@@ -154,18 +310,37 @@ export function parseCsvBudgetRows(value: string) {
   const dataRows = indexes.hasHeader ? csvRows.slice(1) : csvRows
 
   return dataRows
-    .map((cells, index) =>
-      makeBudgetRow(index, {
-        amount: cells[indexes.amount] ?? "",
+    .map((cells, index) => {
+      const totalCost = cells[indexes.totalCost] ?? ""
+      return makeBudgetRow(index, {
         category: cells[indexes.category] ?? "",
+        costPerUnit:
+          indexes.costPerUnit >= 0
+            ? (cells[indexes.costPerUnit] ?? "")
+            : totalCost,
+        costType:
+          indexes.costType >= 0
+            ? (cells[indexes.costType] ?? "")
+            : totalCost
+              ? "Fixed"
+              : "",
         description: cells[indexes.description] ?? "",
-        id: `budget-csv-row-${index}`,
+        totalCost,
+        unit:
+          indexes.unit >= 0
+            ? (cells[indexes.unit] ?? "")
+            : totalCost
+              ? "Program"
+              : "",
+        units:
+          indexes.units >= 0
+            ? (cells[indexes.units] ?? "")
+            : totalCost
+              ? "1"
+              : "",
       })
-    )
-    .filter(
-      (row) =>
-        row.category.trim() || row.description.trim() || row.amount.trim()
-    )
+    })
+    .filter(hasMeaningfulBudgetRow)
 }
 
 export function isCsvFile(file: File | null): file is File {

--- a/src/features/fiscal-sponsorship/server/actions.ts
+++ b/src/features/fiscal-sponsorship/server/actions.ts
@@ -8,6 +8,11 @@ import { createSupabaseAdminClient } from "@/lib/supabase/admin"
 import { canEditOrganization } from "@/lib/organization/active-org"
 import type { Database } from "@/lib/supabase"
 import { normalizeFiscalSponsorshipInput } from "../lib"
+import {
+  getBudgetTotal,
+  readBudgetRowsFromMetadata,
+  readBudgetSourceActivityIdFromMetadata,
+} from "../lib/budget-plan"
 import type {
   FiscalSponsorshipApplicationRecord,
   FiscalSponsorshipApplicationStatus,
@@ -34,6 +39,69 @@ type FiscalProjectRow = {
 type ResolveFiscalProjectResult =
   | { ok: true; project: FiscalProjectRow }
   | { ok: false; error: string }
+
+async function syncFiscalBudgetToSourceProgram({
+  metadata,
+  orgId,
+  supabase,
+}: {
+  metadata: unknown
+  orgId: string
+  supabase: FiscalApplicationMutationClient
+}) {
+  const sourceActivityId = readBudgetSourceActivityIdFromMetadata(metadata)
+  const hasBudgetRows =
+    metadata &&
+    typeof metadata === "object" &&
+    !Array.isArray(metadata) &&
+    Array.isArray((metadata as Record<string, unknown>).budgetRows)
+  const budgetRows = readBudgetRowsFromMetadata(metadata)
+  if (!sourceActivityId || !hasBudgetRows) return null
+
+  const { data: program, error: programError } = await supabase
+    .from("programs")
+    .select("wizard_snapshot, raised_cents")
+    .eq("id", sourceActivityId)
+    .eq("user_id", orgId)
+    .maybeSingle<{
+      raised_cents: number | null
+      wizard_snapshot: Record<string, unknown> | null
+    }>()
+
+  if (programError || !program) {
+    return "Unable to find the selected activity budget."
+  }
+
+  const totalBudget = getBudgetTotal(budgetRows)
+  const raisedUsd =
+    typeof program.raised_cents === "number" &&
+    Number.isFinite(program.raised_cents)
+      ? program.raised_cents / 100
+      : 0
+  const fundraisingTarget = Math.max(0, totalBudget - raisedUsd)
+  const wizardSnapshot =
+    program.wizard_snapshot &&
+    typeof program.wizard_snapshot === "object" &&
+    !Array.isArray(program.wizard_snapshot)
+      ? program.wizard_snapshot
+      : {}
+  const { error: updateError } = await supabase
+    .from("programs")
+    .update({
+      goal_cents: Math.round(fundraisingTarget * 100),
+      wizard_snapshot: {
+        ...wizardSnapshot,
+        budgetRows,
+        budgetUsd: totalBudget,
+        goalUsd: fundraisingTarget,
+        updatedAt: new Date().toISOString(),
+      },
+    })
+    .eq("id", sourceActivityId)
+    .eq("user_id", orgId)
+
+  return updateError ? "Unable to update the selected activity budget." : null
+}
 
 function isMissingFiscalApplicationTableError(error: unknown) {
   if (!error || typeof error !== "object") return false
@@ -327,6 +395,13 @@ export async function saveFiscalSponsorshipApplicationDraft(
         "This application is locked while Coach House reviews or processes it.",
     }
   }
+
+  const budgetSyncError = await syncFiscalBudgetToSourceProgram({
+    metadata: normalized.value.metadata,
+    orgId: projectResult.project.org_id,
+    supabase,
+  })
+  if (budgetSyncError) return { error: budgetSyncError }
 
   const { created_by: _createdBy, status: _status, ...draftUpdate } = payload
   const mutation = existingApplication

--- a/src/features/fiscal-sponsorship/types.ts
+++ b/src/features/fiscal-sponsorship/types.ts
@@ -1,5 +1,7 @@
 import type * as React from "react"
 
+import type { BudgetTableRow } from "@/lib/modules"
+
 import type { FiscalSponsorshipFormBFields } from "./lib/form-b-field-manifest"
 import type {
   FiscalSponsorshipW9Fields,
@@ -148,6 +150,7 @@ export type FiscalSponsorshipApplicationPrefill = {
   projectDescription?: string | null
   projectLocation?: string | null
   estimatedBudgetCents?: number | null
+  budgetRows?: BudgetTableRow[] | null
   expenseSummary?: string | null
   prospectiveFundingSources?: string | null
   publicBenefit?: string | null
@@ -395,6 +398,7 @@ export type FiscalSponsorshipProgramOption = {
   goalCents?: number | null
   raisedCents?: number | null
   estimatedBudgetCents?: number | null
+  budgetRows?: BudgetTableRow[] | null
   expenseSummary?: string | null
   prospectiveFundingSources?: string | null
   publicBenefit?: string | null

--- a/tests/acceptance/fiscal-sponsorship-application-draft.test.ts
+++ b/tests/acceptance/fiscal-sponsorship-application-draft.test.ts
@@ -235,7 +235,14 @@ describe("fiscal sponsorship application drafts", () => {
         temporaryEndDate: "2026-12-31",
         focusArea: "Food security",
         projectLocation: "Chicago, IL",
-        estimatedBudgetDollars: "25000",
+        budgetRows: [
+          expect.objectContaining({
+            category: "Food",
+            description: "ingredients",
+            totalCost: "12000.00",
+          }),
+        ],
+        estimatedBudgetDollars: "12000",
         prospectiveFundingSources:
           "Community donors; Public fundraising goal: $25,000",
         publicBenefit: "Neighbors receive free meals.",

--- a/tests/acceptance/fiscal-sponsorship-application-ui.test.ts
+++ b/tests/acceptance/fiscal-sponsorship-application-ui.test.ts
@@ -3,6 +3,14 @@ import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
+import {
+  getBudgetTotal,
+  normalizeFiscalSponsorshipBudgetRows,
+  parseBudgetRows,
+  readBudgetSourceActivityIdFromMetadata,
+  serializeBudgetRows,
+} from "@/features/fiscal-sponsorship/lib/budget-plan"
+
 const ROOT = process.cwd()
 
 function readSource(relativePath: string) {
@@ -10,6 +18,29 @@ function readSource(relativePath: string) {
 }
 
 describe("fiscal sponsorship application UI", () => {
+  it("keeps client-callable fiscal actions behind a real Server Action boundary", () => {
+    const actionFacade = readSource(
+      "src/features/fiscal-sponsorship/actions.ts"
+    )
+    const applicationDrawer = readSource(
+      "src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-drawer.tsx"
+    )
+
+    expect(actionFacade.startsWith('"use server"')).toBe(true)
+    expect(actionFacade).not.toContain("export {")
+    expect(actionFacade).toContain(
+      "export async function loadFiscalSponsorshipApplicationDraft"
+    )
+    expect(actionFacade).toContain(
+      "export async function saveFiscalSponsorshipApplicationDraft"
+    )
+    expect(actionFacade).toContain(
+      "export async function submitFiscalSponsorshipApplication"
+    )
+    expect(applicationDrawer).toContain('from "../actions"')
+    expect(applicationDrawer).not.toContain("../server/")
+  })
+
   it("keeps one application editor for inline and drawer surfaces", () => {
     const applicationDrawer = readSource(
       "src/features/fiscal-sponsorship/components/fiscal-sponsorship-application-drawer.tsx"
@@ -39,6 +70,10 @@ describe("fiscal sponsorship application UI", () => {
     expect(applicationDrawer).toContain("onInteractOutside")
     expect(applicationDrawer).toContain("Discard application changes?")
     expect(applicationDrawer).toContain("beforeunload")
+    expect(applicationDrawer).toContain("loadedApplicationKeyRef")
+    expect(applicationDrawer).toContain(
+      "data.applicationPrefill?.sourceActivityId"
+    )
     expect(applicationDrawer).toContain("<ScrollFadeEffect")
     expect(applicationDrawer).toContain(
       "min-h-0 flex-1 overflow-y-auto overscroll-contain px-6 py-5 [--mask-height:2rem] [--scroll-buffer:1.5rem]"
@@ -142,9 +177,19 @@ describe("fiscal sponsorship application UI", () => {
     const applicationDraft = readSource(
       "src/features/fiscal-sponsorship/lib/application-draft.ts"
     )
+    const applicationActions = readSource(
+      "src/features/fiscal-sponsorship/server/actions.ts"
+    )
 
     expect(budgetPlanEditor).toContain("Budget plan")
-    expect(budgetPlanEditor).toContain("TableHeader")
+    expect(budgetPlanEditor).toContain("BudgetTable")
+    expect(budgetPlanEditor).toContain('layout="grid"')
+    expect(budgetPlanEditor).toContain("Linked to the budget for")
+    expect(budgetPlanEditor).toContain(
+      "Saving this application updates the same line items"
+    )
+    expect(budgetPlanEditor).not.toContain("TableHead")
+    expect(budgetPlanEditor).not.toContain('placeholder="$0"')
     expect(budgetPlanEditor).toContain("Import CSV rows")
     expect(budgetPlanEditor).toContain("parseCsvBudgetRows")
     expect(budgetPlanEditor).toContain("connectFiscalSponsorshipDocumentAsset")
@@ -164,5 +209,52 @@ describe("fiscal sponsorship application UI", () => {
     expect(applicationDraft).toContain("documentTemplatePayload")
     expect(applicationDraft).toContain("individualApplicant")
     expect(applicationDraft).toContain('draft.legalEntityType === "individual"')
+    expect(applicationDraft).toContain("budgetRows: draft.budgetRows")
+
+    expect(applicationActions).toContain("syncFiscalBudgetToSourceProgram")
+    expect(applicationActions).toContain("budgetRows")
+    expect(applicationActions).toContain("budgetUsd: totalBudget")
+    expect(applicationActions).toContain("goalUsd: fundraisingTarget")
+  })
+
+  it("preserves complete program budget rows and ignores zero-only legacy summaries", () => {
+    expect(parseBudgetRows("$0.00; $0.00")).toEqual([
+      {
+        category: "",
+        costPerUnit: "",
+        costType: "",
+        description: "",
+        totalCost: "",
+        unit: "",
+        units: "",
+      },
+    ])
+    expect(
+      normalizeFiscalSponsorshipBudgetRows([
+        { category: "", description: "", totalCost: "0.00" },
+        { category: "", description: "", totalCost: "$0.00" },
+      ])
+    ).toEqual([])
+    expect(
+      readBudgetSourceActivityIdFromMetadata({
+        selectedActivityId: " program-2 ",
+      })
+    ).toBe("program-2")
+
+    const rows = parseBudgetRows(
+      "Materials | Welding kits | Variable | Participant / Program | 20 | 75.00 | 1500.00"
+    )
+
+    expect(rows[0]).toEqual({
+      category: "Materials",
+      costPerUnit: "75.00",
+      costType: "Variable",
+      description: "Welding kits",
+      totalCost: "1500.00",
+      unit: "Participant / Program",
+      units: "20",
+    })
+    expect(getBudgetTotal(rows)).toBe(1500)
+    expect(parseBudgetRows(serializeBudgetRows(rows))).toEqual(rows)
   })
 })

--- a/tests/acceptance/fiscal-sponsorship-workflow-drawer-contract.test.ts
+++ b/tests/acceptance/fiscal-sponsorship-workflow-drawer-contract.test.ts
@@ -82,10 +82,13 @@ describe("fiscal sponsorship workspace drawer contract", () => {
       "pointer-events-none grid-rows-[0fr] opacity-0"
     )
     expect(workflowDrawer).toContain(
-      "text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 flex-1 rounded-[2rem] border p-3 shadow-sm"
+      "text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 min-w-0 flex-1 overflow-hidden rounded-[2rem] border p-3 shadow-sm"
     )
     expect(workflowDrawer).toContain(
-      'viewportClassName="max-h-[calc(100svh-15rem)] rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem]"'
+      'viewportClassName="max-h-[calc(100svh-15rem)] max-w-full overflow-x-hidden rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem] [&>div]:!block [&>div]:!w-full [&>div]:!max-w-full [&>div]:!min-w-0"'
+    )
+    expect(workflowDrawer).toContain(
+      'contentClassName="min-w-0 max-w-full overflow-hidden [&>*]:min-w-0 [&>*]:max-w-full"'
     )
     expect(workflowDrawer).not.toContain("space-y-4")
   })
@@ -101,6 +104,7 @@ describe("fiscal sponsorship workspace drawer contract", () => {
     expect(uploadPanel).toContain("uploadFiscalSponsorshipProjectAsset")
     expect(projectAssetUpload).toContain('fetch("/api/account/project-assets"')
     expect(uploadPanel).toContain("connectFiscalSponsorshipDocumentAsset")
+    expect(uploadPanel).toContain("[overflow-wrap:anywhere]")
     expect(uploadPanel).toContain(
       "Grant requests and reports come after signing"
     )

--- a/tests/acceptance/workspace-fiscal-sponsorship-card.test.ts
+++ b/tests/acceptance/workspace-fiscal-sponsorship-card.test.ts
@@ -344,10 +344,13 @@ describe("workspace fiscal sponsorship card", () => {
       "pointer-events-none grid-rows-[0fr] opacity-0"
     )
     expect(workflowDrawer).toContain(
-      "text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 flex-1 rounded-[2rem] border p-3 shadow-sm"
+      "text-card-foreground border-border/60 bg-muted relative mx-3 mt-3 min-h-0 min-w-0 flex-1 overflow-hidden rounded-[2rem] border p-3 shadow-sm"
     )
     expect(workflowDrawer).toContain(
-      'viewportClassName="max-h-[calc(100svh-15rem)] rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem]"'
+      'viewportClassName="max-h-[calc(100svh-15rem)] max-w-full overflow-x-hidden rounded-none scroll-fade-effect-y [--mask-height:2rem] [--scroll-buffer:1.5rem] [&>div]:!block [&>div]:!w-full [&>div]:!max-w-full [&>div]:!min-w-0"'
+    )
+    expect(workflowDrawer).toContain(
+      'contentClassName="min-w-0 max-w-full overflow-hidden [&>*]:min-w-0 [&>*]:max-w-full"'
     )
     expect(workflowDrawerSections).toContain("px-1 pt-1")
     expect(workflowDrawer).not.toContain("space-y-4")
@@ -474,6 +477,17 @@ describe("workspace fiscal sponsorship card", () => {
         projectDescription: "Free meals and food access.",
         projectLocation: "Chicago, IL, US",
         estimatedBudgetCents: 2500000,
+        budgetRows: [
+          {
+            category: "Food",
+            costPerUnit: "12000.00",
+            costType: "Fixed",
+            description: "Ingredients",
+            totalCost: "12000.00",
+            unit: "Program",
+            units: "1",
+          },
+        ],
         expenseSummary: "Food - Ingredients - $12000.00",
         prospectiveFundingSources:
           "Community donors; Public fundraising goal: $5,000; Raised to date: $1,250",
@@ -550,6 +564,17 @@ describe("workspace fiscal sponsorship card", () => {
       expect.objectContaining({
         description: "Selected snapshot description.",
         estimatedBudgetCents: 3200000,
+        budgetRows: [
+          {
+            category: "Materials",
+            costPerUnit: "15000.00",
+            costType: "Fixed",
+            description: "Welding kits",
+            totalCost: "15000.00",
+            unit: "Program",
+            units: "1",
+          },
+        ],
         expenseSummary: "Materials - Welding kits - $15000.00",
         focusArea: "Training & Capacity Building",
         prospectiveFundingSources: "State grant",
@@ -566,6 +591,7 @@ describe("workspace fiscal sponsorship card", () => {
         projectDurationType: "ongoing_multi_year",
         temporaryStartDate: "2026-08-01",
         estimatedBudgetCents: 3200000,
+        budgetRows: selectedProgram?.budgetRows,
         expenseSummary: "Materials - Welding kits - $15000.00",
         prospectiveFundingSources:
           "State grant; Public fundraising goal: $9,000; Raised to date: $2,000",


### PR DESCRIPTION
## Summary
- fix the fiscal application client/server boundary that caused the Turbopack module-factory runtime error
- replace the legacy budget fields with the linked program budget grid and synchronize saved rows back to the selected activity
- contain uploaded-document content inside the fiscal workflow drawer
- keep account-settings server state out of the browser module graph

## Verification
- `pnpm check:quality`
- 1,540 acceptance tests passed; 1 skipped
- 29 visual tests passed
- production build and TypeScript passed
- authenticated localhost verification opened the fiscal application editor without runtime or build errors

## Scope
Fiscal sponsorship only. No schema or production-data changes.