### PR TITLE
[STEP S18] Clarify fiscal agreement sending flow

### DIFF
--- a/docs/runlog/2026-07.md
+++ b/docs/runlog/2026-07.md
@@ -387,3 +387,9 @@ entries remain in the [legacy archive](archive/legacy-through-2026-07-14.md).
 - Extracted only the fiscal budget linkage, uploaded-document containment, application action boundary, account-settings server boundary, and focused acceptance coverage onto current `origin/main`, preserving the assigned-coach review release.
 - Preserved existing legacy application amounts until an activity is selected, while new and explicitly linked applications use the selected program’s structured budget rows and derived total.
 - The complete quality gate passed: supply-chain and large-file checks, lint, all structural guardrails, snapshots, acceptance (`313 files passed`, `1 skipped`; `1,540 tests passed`, `1 skipped`), production build and TypeScript, all `29` visual tests, and performance budgets. RLS exited successfully with its documented no-credentials skip; the current fiscal schema already passed linked RLS during the signing rollout.
+
+2026-07-27 18:36 EDT - clarified fiscal agreement preparation and sending.
+
+- Replaced the reviewer-facing `Generate` action with `Prepare agreement` and `Send` with `Send for signature`, matching the real two-step workflow without changing internal document statuses or persistence.
+- Updated related success, error, status, handbook, agreement-document, and empty-state copy to consistently describe preparation, signature delivery, applicant signing, and Coach House countersigning.
+- The complete quality gate passed: supply-chain and large-file checks, lint, all structural guardrails, snapshots, acceptance (`313 files passed`, `1 skipped`; `1,540 tests passed`, `1 skipped`), production build and TypeScript, all `29` visual tests, and performance budgets. One public-home transition test missed its destination during the first visual run, then passed alone and in the clean full rerun. No schema or production-data changes were required.

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-handbook-guide.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-handbook-guide.tsx
@@ -69,7 +69,7 @@ export function FiscalSponsorshipHandbookGuide() {
               </p>
               <p className="text-muted-foreground mt-1 text-sm leading-snug">
                 This guide is pulled from the 2026 Coach House handbook. Use it
-                as the source for generated applications, agreements,
+                as the source for preparing applications, agreements,
                 disclosures, grant requests, and review controls.
               </p>
             </div>

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-project-workbench-admin-actions.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-project-workbench-admin-actions.tsx
@@ -139,9 +139,9 @@ export function FiscalSponsorshipProjectWorkbenchAdminActions({
           !generateFiscalSponsorshipAgreementAction
         }
         onClick={() =>
-          runAction("generate", "Agreement generated", async () => {
+          runAction("generate", "Agreement prepared", async () => {
             if (!generateFiscalSponsorshipAgreementAction) {
-              return { error: "Agreement generation is unavailable." }
+              return { error: "Agreement preparation is unavailable." }
             }
 
             const result = await generateFiscalSponsorshipAgreementAction({
@@ -161,7 +161,7 @@ export function FiscalSponsorshipProjectWorkbenchAdminActions({
         ) : (
           <FileSignatureIcon data-icon="inline-start" aria-hidden />
         )}
-        Generate
+        Prepare agreement
       </Button>
       <Button
         type="button"
@@ -174,9 +174,9 @@ export function FiscalSponsorshipProjectWorkbenchAdminActions({
           !sendFiscalSponsorshipAgreementForSignatureAction
         }
         onClick={() =>
-          runAction("send", "Agreement sent", async () => {
+          runAction("send", "Signature request sent", async () => {
             if (!sendFiscalSponsorshipAgreementForSignatureAction) {
-              return { error: "Agreement sending is unavailable." }
+              return { error: "Sending for signature is unavailable." }
             }
 
             const result =
@@ -198,7 +198,7 @@ export function FiscalSponsorshipProjectWorkbenchAdminActions({
         ) : (
           <SendIcon data-icon="inline-start" aria-hidden />
         )}
-        Send
+        Send for signature
       </Button>
     </div>
   )

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-project-workbench.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-project-workbench.tsx
@@ -374,7 +374,7 @@ export function FiscalSponsorshipProjectWorkbench({
               Fiscal sponsorship workbench
             </p>
             <p className="text-muted-foreground mt-1 text-xs leading-snug">
-              One place for intake, uploads, review, generated documents,
+              One place for intake, uploads, review, prepared documents,
               signatures, and grant-payment readiness.
             </p>
           </div>

--- a/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workflow-drawer-sections.tsx
+++ b/src/features/fiscal-sponsorship/components/fiscal-sponsorship-workflow-drawer-sections.tsx
@@ -393,7 +393,7 @@ export function SigningActions({
         <AlertTitle>No signature packet yet</AlertTitle>
         <AlertDescription>
           Applicant and Coach House signing links appear after the agreement is
-          generated and sent.
+          prepared and sent for signature.
         </AlertDescription>
       </Alert>
     )

--- a/src/features/fiscal-sponsorship/lib/agreement-document.ts
+++ b/src/features/fiscal-sponsorship/lib/agreement-document.ts
@@ -105,7 +105,7 @@ export function buildFiscalSponsorshipAgreementDocument({
   <body>
     <p class="eyebrow">Coach House fiscal sponsorship</p>
     <h1>Model C Fiscal Sponsorship Agreement</h1>
-    <p>Generated ${escapeHtml(generatedDate)} from the approved fiscal sponsorship application.</p>
+    <p>Prepared ${escapeHtml(generatedDate)} from the approved fiscal sponsorship application.</p>
 
     <table>
       <tbody>

--- a/src/features/fiscal-sponsorship/lib/application-data.ts
+++ b/src/features/fiscal-sponsorship/lib/application-data.ts
@@ -97,7 +97,7 @@ Coach House does not currently sponsor projects or organizations based outside t
     id: "fs-agreement-template",
     eyebrow: "Agreement",
     title: "Agreement Template Inputs",
-    markdown: `The Model C agreement is generated from the approved application and incorporated policies.
+    markdown: `The Model C agreement is prepared from the approved application and incorporated policies.
 
 The template needs:
 

--- a/src/features/fiscal-sponsorship/lib/project-workbench-data-helpers.ts
+++ b/src/features/fiscal-sponsorship/lib/project-workbench-data-helpers.ts
@@ -61,13 +61,13 @@ export function formatDocumentStatus(
     draft: "Draft",
     error: "Error",
     executed: "Executed",
-    generated: "Generated",
+    generated: "Prepared",
     partially_signed: "Partially signed",
     sent_for_signature: "Sent for signature",
     voided: "Voided",
   }
 
-  return status ? labels[status] : "Not generated"
+  return status ? labels[status] : "Not prepared"
 }
 
 export function formatPacketStatus(

--- a/src/features/fiscal-sponsorship/lib/project-workbench-data.ts
+++ b/src/features/fiscal-sponsorship/lib/project-workbench-data.ts
@@ -199,7 +199,7 @@ export function buildFiscalSponsorshipProjectWorkbenchData({
         ? `${agreementDocument.title} v${agreementDocument.version} is ${formatDocumentStatus(
             agreementDocumentStatus
           ).toLowerCase()}`
-        : "Generate a Form B agreement after approval",
+        : "Prepare the Form B agreement after approval",
       complete: hasGeneratedAgreement,
     },
     {
@@ -209,7 +209,7 @@ export function buildFiscalSponsorshipProjectWorkbenchData({
         ? `Signature packet is ${formatPacketStatus(
             signaturePacketStatus
           ).toLowerCase()}`
-        : "Send the generated agreement for applicant and Coach House signatures",
+        : "Send the prepared agreement for applicant and Coach House signatures",
       complete: hasCompletedSignaturePacket,
     },
   ]
@@ -367,7 +367,7 @@ export function buildFiscalSponsorshipProjectWorkbenchData({
             ).toLowerCase()}.`
           : "Prepared from confirmed application data.",
         document: agreementDocument,
-        fallbackStatus: "Not generated",
+        fallbackStatus: "Not prepared",
         id: "generated-agreement",
         title: "Prepared agreement",
       }),

--- a/src/features/fiscal-sponsorship/server/workflow-agreement-actions.ts
+++ b/src/features/fiscal-sponsorship/server/workflow-agreement-actions.ts
@@ -53,7 +53,7 @@ export async function generateFiscalSponsorshipAgreement(
   ) {
     return {
       error:
-        "Only the assigned Coach House reviewer can generate this agreement.",
+        "Only the assigned Coach House reviewer can prepare this agreement.",
     }
   }
 
@@ -61,7 +61,7 @@ export async function generateFiscalSponsorshipAgreement(
   if ("error" in loaded) return loaded
 
   if (!["approved", "agreement_ready"].includes(loaded.application.status)) {
-    return { error: "Approve the application before generating an agreement." }
+    return { error: "Approve the application before preparing an agreement." }
   }
   const { data: acceptedW9, error: acceptedW9Error } = await context.supabase
     .from("fiscal_sponsorship_documents")
@@ -82,7 +82,7 @@ export async function generateFiscalSponsorshipAgreement(
   if (!acceptedW9) {
     return {
       error:
-        "Accept the applicant’s completed W-9 before generating an agreement.",
+        "Accept the applicant’s completed W-9 before preparing an agreement.",
     }
   }
 
@@ -126,7 +126,9 @@ export async function generateFiscalSponsorshipAgreement(
     .from("fiscal-signing")
     .upload(storagePath, agreement.bytes, { contentType: mime })
   if (uploadError) {
-    return { error: "Unable to upload generated fiscal sponsorship agreement." }
+    return {
+      error: "Unable to upload the prepared fiscal sponsorship agreement.",
+    }
   }
 
   const { data: previousDocument } = await context.supabase
@@ -174,7 +176,7 @@ export async function generateFiscalSponsorshipAgreement(
     await admin.storage.from("fiscal-signing").remove([storagePath])
     return isMissingFiscalWorkflowTableError(documentError)
       ? buildWorkflowTableError()
-      : { error: "Unable to save the generated agreement document." }
+      : { error: "Unable to save the prepared agreement document." }
   }
 
   const updated = await updateFiscalApplicationStatus({
@@ -193,7 +195,7 @@ export async function generateFiscalSponsorshipAgreement(
     metadata: { documentId: document.id, fileSha256: agreement.sha256 },
     orgId: loaded.application.org_id,
     projectId: loaded.application.project_id,
-    summary: "Fiscal sponsorship agreement generated.",
+    summary: "Fiscal sponsorship agreement prepared.",
     supabase: context.supabase,
     userId: context.user.id,
   })
@@ -265,7 +267,7 @@ export async function sendFiscalSponsorshipAgreementForSignature(
       FISCAL_SPONSORSHIP_FORM_B_TEMPLATE.version ||
     !documentResult.document.file_sha256
   ) {
-    return { error: "Generate the native Form B agreement before sending." }
+    return { error: "Prepare the Form B agreement before sending it." }
   }
   const fields = normalizeFiscalSponsorshipFormBFields(
     (documentResult.document.field_values ?? {}) as Record<string, string>

--- a/src/features/fiscal-sponsorship/server/workflow-support.ts
+++ b/src/features/fiscal-sponsorship/server/workflow-support.ts
@@ -414,12 +414,12 @@ export async function loadLatestAgreementDocument({
   if (error) {
     return isMissingFiscalWorkflowTableError(error)
       ? buildWorkflowTableError()
-      : { error: "Unable to load the generated agreement." }
+      : { error: "Unable to load the prepared agreement." }
   }
 
   if (!data) {
     return {
-      error: "Generate the fiscal sponsorship agreement before sending.",
+      error: "Prepare the fiscal sponsorship agreement before sending it.",
     }
   }
 

--- a/tests/acceptance/fiscal-sponsorship-w9.test.ts
+++ b/tests/acceptance/fiscal-sponsorship-w9.test.ts
@@ -101,7 +101,7 @@ describe("fiscal sponsorship W-9 completion", () => {
     expect(actions).toContain("FISCAL_SPONSORSHIP_SIGNING_BUCKET")
     expect(actions).not.toContain("field_values: fields")
     expect(agreementActions).toContain(
-      "Accept the applicant’s completed W-9 before generating an agreement."
+      "Accept the applicant’s completed W-9 before preparing an agreement."
     )
     expect(migration).toContain("reject_executed_fiscal_tax_form_mutation")
     expect(migration).toContain("Executed fiscal tax forms are immutable")

--- a/tests/acceptance/member-workspace-project-detail-page.test.ts
+++ b/tests/acceptance/member-workspace-project-detail-page.test.ts
@@ -508,7 +508,7 @@ describe("MemberWorkspaceProjectDetailPage", () => {
     expect(markup).toContain("rounded-[1.45rem]")
     expect(markup).toContain("max-w-none")
     expect(markup).not.toContain("Application approved")
-    expect(markup).not.toContain("Agreement generated")
+    expect(markup).not.toContain("Agreement prepared")
   })
 
   it("renders real fiscal sponsorship workflow status when available", () => {
@@ -546,11 +546,11 @@ describe("MemberWorkspaceProjectDetailPage", () => {
     })
 
     expect(markup).toContain("Agreement ready")
-    expect(markup).toContain("Generated")
+    expect(markup).toContain("Prepared")
     expect(markup).toContain("Signatures")
     expect(markup).toContain("Not sent")
     expect(markup).toContain("Next: Send prepared agreement for signatures")
-    expect(markup).toContain("Model C agreement v1 is generated")
+    expect(markup).toContain("Model C agreement v1 is prepared")
   })
 
   it("renders coach fiscal sponsorship workflow actions when provided", () => {
@@ -607,8 +607,9 @@ describe("MemberWorkspaceProjectDetailPage", () => {
       "data-fiscal-sponsorship-project-workbench-admin-actions"
     )
     expect(markup).toContain("Approve")
-    expect(markup).toContain("Generate")
-    expect(markup).toContain("Send")
+    expect(markup).toContain("Prepare agreement")
+    expect(markup).toContain("Send for signature")
+    expect(markup).not.toContain(">Generate<")
   })
 
   it("keeps /organizations fiscal document actions platform-admin only", () => {


### PR DESCRIPTION
## Summary
- replace `Generate` with `Prepare agreement`
- replace `Send` with `Send for signature`
- align agreement status, success, error, handbook, and empty-state copy with the two-step workflow

## Process
1. Approve the application and accept the signed W-9.
2. Prepare the locked Form B agreement.
3. Send it to the applicant for signature.
4. Applicant signs, then Coach House countersigns.
5. Both parties retain the executed copy.

## Verification
- `pnpm check:quality`
- 1,540 acceptance tests passed; 1 skipped
- 29 visual tests passed
- production build and TypeScript passed

No schema, permission, or production-data changes.