### PR TITLE
[STEP S20] Unify organization Mission, Vision, and Values

### DIFF
--- a/docs/RUNLOG.md
+++ b/docs/RUNLOG.md
@@ -4,7 +4,7 @@ Canonical index for implementation history and session continuation.
 
 ## Current log
 
-- [2026-07](runlog/2026-07.md)
+- [2026-08](runlog/2026-08.md)
 
 ## Archive
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -1,0 +1,11 @@
+# RUNLOG — 2026-08
+
+2026-08-01 15:18 EDT - unified organization Mission, Vision, and Values with roadmap sections.
+
+- Kept `mission_vision_values` as the canonical Mission id and route, added first-class Vision and Values sections, and routed roadmap, organization-profile, curriculum, public-map, search, readiness, and admin readers through one sanitized narrative contract.
+- Replaced organization Mission, Vision, and Values textareas with compact rich-text editors, added section and organization-row optimistic concurrency checks, retained failed local drafts, and surfaced save and assignment-sync failures.
+- Fixed assignment profile synchronization to use the invited member's active organization and existing staff/admin authorization instead of the member user id.
+- Added copy-only, hash-recorded, idempotent migration planning; one-organization-only apply protection; and explicit-heading manual-review proposals that never modify combined Mission content.
+- Production dry-run only: 56 organizations, 10 profile-only, 8 combined-only, 8 both, 30 neither; 41 safe field copies; 16 manual reviews; 5 Vision and 2 Values heading extracts. Defy Ventures remains manual-only because its unchanged 5,646-character content has no explicit section headings. No production write occurred.
+- Full lint, snapshots, acceptance tests, build, visual regression, performance budgets, structure, routes, features, scaffold, thresholds, boundaries, storage, interaction, React Grab, workspace-surface, raw-button, supply-chain, large-file, SQL helper, and browser checks passed. RLS test execution skipped without a local test Supabase environment; existing membership policies were inspected. No deployment or data migration occurred.
+- Continue by reconciling the isolated branch with the dirty root's overlapping organization `brandVoice*`, roadmap `budgetRows`, and existing August runlog work. Deploy compatible code before any migration; then review and approve Defy manually before running copy-only migrations.

--- a/src/actions/organization.ts
+++ b/src/actions/organization.ts
@@ -6,13 +6,34 @@ import { revalidatePath } from "next/cache"
 import { requireServerSession } from "@/lib/auth"
 import { geocodeOrganizationLocation } from "@/lib/geocoding/geocode"
 import { buildOrganizationAddress } from "@/lib/geocoding/organization-address"
-import { normalizeOrganizationLocationFields, normalizeWhitespace } from "@/lib/location/organization-location"
+import {
+  normalizeOrganizationLocationFields,
+  normalizeWhitespace,
+} from "@/lib/location/organization-location"
 import type { BrandTypographyConfig } from "@/lib/organization/org-profile-brand-types"
 import type { Database } from "@/lib/supabase"
-import { sanitizeOrgProfileText, shouldStripOrgProfileHtml } from "@/lib/organization/profile-cleanup"
+import {
+  sanitizeOrgProfileText,
+  shouldStripOrgProfileHtml,
+} from "@/lib/organization/profile-cleanup"
 import { normalizeExternalUrl } from "@/lib/organization/urls"
-import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
-import { ORG_MEDIA_BUCKET, resolveOrgMediaCleanupPath } from "@/lib/storage/org-media"
+import {
+  findOrganizationNarrativeRevisionConflict,
+  normalizeOrganizationNarrativeHtml,
+  type OrganizationNarratives,
+  type OrganizationNarrativeRevisions,
+  resolveOrganizationNarrativeRevisions,
+  resolveOrganizationNarratives,
+  updateOrganizationNarratives,
+} from "@/lib/roadmap"
+import {
+  canEditOrganization,
+  resolveActiveOrganization,
+} from "@/lib/organization/active-org"
+import {
+  ORG_MEDIA_BUCKET,
+  resolveOrgMediaCleanupPath,
+} from "@/lib/storage/org-media"
 
 type OrgProfilePayload = {
   name?: string | null
@@ -60,9 +81,12 @@ type OrgProfilePayload = {
   brandTypography?: BrandTypographyConfig | null
   publicSlug?: string | null
   isPublic?: boolean | null
+  narrativeRevisions?: OrganizationNarrativeRevisions
 }
 
-export async function updateOrganizationProfileAction(payload: OrgProfilePayload) {
+export async function updateOrganizationProfileAction(
+  payload: OrgProfilePayload
+) {
   const { supabase, session } = await requireServerSession("/organization")
 
   const userId = session.user.id
@@ -73,7 +97,9 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
   // Load existing profile to merge
   const { data: orgRow, error: orgErr } = await supabase
     .from("organizations")
-    .select("ein, profile, location_lat, location_lng, public_slug, is_public")
+    .select(
+      "ein, profile, location_lat, location_lng, public_slug, is_public, updated_at"
+    )
     .eq("user_id", orgId)
     .maybeSingle<{
       ein: string | null
@@ -82,6 +108,7 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
       location_lng: number | null
       public_slug: string | null
       is_public: boolean | null
+      updated_at: string
     }>()
 
   if (orgErr) {
@@ -89,16 +116,51 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
   }
 
   const current = (orgRow?.profile ?? {}) as Record<string, unknown>
-  const previousLogoUrl = typeof current["logoUrl"] === "string" ? (current["logoUrl"] as string) : null
+  const previousLogoUrl =
+    typeof current["logoUrl"] === "string"
+      ? (current["logoUrl"] as string)
+      : null
   const previousBrandMarkUrl =
     typeof current["brandMarkUrl"] === "string"
       ? (current["brandMarkUrl"] as string)
       : null
-  const previousHeaderUrl = typeof current["headerUrl"] === "string" ? (current["headerUrl"] as string) : null
+  const previousHeaderUrl =
+    typeof current["headerUrl"] === "string"
+      ? (current["headerUrl"] as string)
+      : null
   const logoTouched = Object.prototype.hasOwnProperty.call(payload, "logoUrl")
-  const brandMarkTouched = Object.prototype.hasOwnProperty.call(payload, "brandMarkUrl")
-  const headerTouched = Object.prototype.hasOwnProperty.call(payload, "headerUrl")
-  const next: Record<string, unknown> = { ...current }
+  const brandMarkTouched = Object.prototype.hasOwnProperty.call(
+    payload,
+    "brandMarkUrl"
+  )
+  const headerTouched = Object.prototype.hasOwnProperty.call(
+    payload,
+    "headerUrl"
+  )
+  let next: Record<string, unknown> = { ...current }
+  const currentNarratives = resolveOrganizationNarratives(current)
+  const narrativeUpdates: Partial<OrganizationNarratives> = {}
+  for (const key of ["mission", "vision", "values"] as const) {
+    if (!Object.prototype.hasOwnProperty.call(payload, key)) continue
+    const value = payload[key]
+    const normalized = normalizeOrganizationNarrativeHtml(
+      typeof value === "string" ? value : ""
+    )
+    if (normalized !== currentNarratives[key]) {
+      narrativeUpdates[key] = normalized
+    }
+  }
+  const narrativeConflict = findOrganizationNarrativeRevisionConflict({
+    profile: current,
+    updates: narrativeUpdates,
+    expectedRevisions: payload.narrativeRevisions,
+  })
+  if (narrativeConflict) {
+    return {
+      error: `${narrativeConflict[0].toUpperCase()}${narrativeConflict.slice(1)} was updated elsewhere. Reload before saving.`,
+      conflict: narrativeConflict,
+    }
+  }
   const urlFields = new Set([
     "publicUrl",
     "newsletter",
@@ -115,18 +177,27 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
   ])
 
   for (const [k, v] of Object.entries(payload)) {
+    if (k === "narrativeRevisions") {
+      continue
+    }
+    if (k === "mission" || k === "vision" || k === "values") {
+      continue
+    }
     // Store EIN in both the column and profile for now (column is canonical)
     if (k === "ein") {
       next[k] = v ?? null
     } else if (k === "formationStatus") {
       const trimmed = typeof v === "string" ? v.trim() : ""
       next[k] =
-        trimmed === "pre_501c3" || trimmed === "in_progress" || trimmed === "approved"
+        trimmed === "pre_501c3" ||
+        trimmed === "in_progress" ||
+        trimmed === "approved"
           ? trimmed
           : null
     } else if (k === "locationType") {
       const trimmed = typeof v === "string" ? v.trim() : ""
-      next.location_type = trimmed === "online" || trimmed === "in_person" ? trimmed : null
+      next.location_type =
+        trimmed === "online" || trimmed === "in_person" ? trimmed : null
     } else if (k === "locationUrl") {
       next.location_url = typeof v === "string" ? normalizeExternalUrl(v) : null
     } else {
@@ -147,6 +218,8 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
       }
     }
   }
+
+  next = updateOrganizationNarratives(next, narrativeUpdates).nextProfile
 
   const addressMapping: Array<[keyof OrgProfilePayload, string]> = [
     ["addressStreet", "address_street"],
@@ -187,11 +260,13 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
   next["address_country"] = normalizedLocation.country || null
 
   const fallbackAddress =
-    typeof payload.address === "string" && normalizeWhitespace(payload.address).length > 0
+    typeof payload.address === "string" &&
+    normalizeWhitespace(payload.address).length > 0
       ? normalizeWhitespace(payload.address)
-      : (typeof current["address"] === "string" && normalizeWhitespace(current["address"]).length > 0
-          ? normalizeWhitespace(current["address"])
-          : null)
+      : typeof current["address"] === "string" &&
+          normalizeWhitespace(current["address"]).length > 0
+        ? normalizeWhitespace(current["address"])
+        : null
 
   next.address = buildOrganizationAddress({
     street: normalizedLocation.street,
@@ -212,20 +287,29 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
         ? String(payload.name ?? current["name"] ?? "")
         : ""
   const normalizedSlugRaw = desiredSlug ? slugify(desiredSlug) : undefined
-  const normalizedSlug = normalizedSlugRaw && normalizedSlugRaw.length > 0 ? normalizedSlugRaw : undefined
+  const normalizedSlug =
+    normalizedSlugRaw && normalizedSlugRaw.length > 0
+      ? normalizedSlugRaw
+      : undefined
 
   let locationLat = orgRow?.location_lat ?? null
   let locationLng = orgRow?.location_lng ?? null
 
-  const nextLogoUrl = typeof next["logoUrl"] === "string" ? (next["logoUrl"] as string) : null
+  const nextLogoUrl =
+    typeof next["logoUrl"] === "string" ? (next["logoUrl"] as string) : null
   const nextBrandMarkUrl =
     typeof next["brandMarkUrl"] === "string"
       ? (next["brandMarkUrl"] as string)
       : null
-  const nextHeaderUrl = typeof next["headerUrl"] === "string" ? (next["headerUrl"] as string) : null
+  const nextHeaderUrl =
+    typeof next["headerUrl"] === "string" ? (next["headerUrl"] as string) : null
   const cleanupPaths = new Set<string>()
   if (logoTouched) {
-    const cleanupPath = resolveOrgMediaCleanupPath({ previousUrl: previousLogoUrl, nextUrl: nextLogoUrl, userId: orgId })
+    const cleanupPath = resolveOrgMediaCleanupPath({
+      previousUrl: previousLogoUrl,
+      nextUrl: nextLogoUrl,
+      userId: orgId,
+    })
     if (cleanupPath) cleanupPaths.add(cleanupPath)
   }
   if (brandMarkTouched) {
@@ -237,7 +321,11 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
     if (cleanupPath) cleanupPaths.add(cleanupPath)
   }
   if (headerTouched) {
-    const cleanupPath = resolveOrgMediaCleanupPath({ previousUrl: previousHeaderUrl, nextUrl: nextHeaderUrl, userId: orgId })
+    const cleanupPath = resolveOrgMediaCleanupPath({
+      previousUrl: previousHeaderUrl,
+      nextUrl: nextHeaderUrl,
+      userId: orgId,
+    })
     if (cleanupPath) cleanupPaths.add(cleanupPath)
   }
 
@@ -262,30 +350,51 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
 
   const insertPayload: any = {
     user_id: orgId,
-    ein: typeof payload.ein === "string" ? payload.ein : orgRow?.ein ?? null,
+    ein: typeof payload.ein === "string" ? payload.ein : (orgRow?.ein ?? null),
     public_slug: normalizedSlug ?? undefined,
     is_public: payload.isPublic ?? undefined,
-    profile: next as unknown as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
+    profile:
+      next as unknown as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
     location_lat: locationLat,
     location_lng: locationLng,
   }
 
-  const { error: upsertErr } = await supabase
-    .from("organizations")
-    .upsert(insertPayload, { onConflict: "user_id" })
+  if (orgRow) {
+    const { data: updatedRow, error: updateError } = await supabase
+      .from("organizations")
+      .update(insertPayload)
+      .eq("user_id", orgId)
+      .eq("updated_at", orgRow.updated_at)
+      .select("user_id")
+      .maybeSingle<{ user_id: string }>()
 
-  if (upsertErr) {
-    return { error: upsertErr.message }
+    if (updateError) return { error: updateError.message }
+    if (!updatedRow) {
+      return {
+        error: "This organization was updated elsewhere. Reload before saving.",
+      }
+    }
+  } else {
+    const { error: insertError } = await supabase
+      .from("organizations")
+      .insert(insertPayload)
+    if (insertError) return { error: insertError.message }
   }
 
   if (cleanupPaths.size > 0) {
-    await supabase.storage.from(ORG_MEDIA_BUCKET).remove(Array.from(cleanupPaths))
+    await supabase.storage
+      .from(ORG_MEDIA_BUCKET)
+      .remove(Array.from(cleanupPaths))
   }
 
-  const previousSlug = typeof orgRow?.public_slug === "string" && orgRow.public_slug.length > 0 ? orgRow.public_slug : null
+  const previousSlug =
+    typeof orgRow?.public_slug === "string" && orgRow.public_slug.length > 0
+      ? orgRow.public_slug
+      : null
   const nextSlug = normalizedSlug ?? previousSlug
   const wasPublic = Boolean(orgRow?.is_public)
-  const isPublic = typeof payload.isPublic === "boolean" ? payload.isPublic : wasPublic
+  const isPublic =
+    typeof payload.isPublic === "boolean" ? payload.isPublic : wasPublic
 
   revalidateOrganizationViews({
     previousSlug,
@@ -293,7 +402,10 @@ export async function updateOrganizationProfileAction(payload: OrgProfilePayload
     wasPublic,
     isPublic,
   })
-  return { ok: true }
+  return {
+    ok: true,
+    narrativeRevisions: resolveOrganizationNarrativeRevisions(next),
+  }
 }
 
 function slugify(input: string): string {
@@ -335,4 +447,3 @@ function revalidateOrganizationViews({
     revalidatePath(`/find/${nextSlug}`)
   }
 }
- 

--- a/src/actions/roadmap.ts
+++ b/src/actions/roadmap.ts
@@ -2,23 +2,34 @@
 
 import { revalidatePath } from "next/cache"
 
+import { sanitizeHtml } from "@/lib/markdown/sanitize"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 import type { Json } from "@/lib/supabase"
 import {
+  getOrganizationNarrativeKeyForSectionId,
+  normalizeOrganizationNarrativeHtml,
   ROADMAP_SECTION_LIMIT,
   getRoadmapWorkspaceRevalidationPaths,
   removeRoadmapSection,
   resolveRoadmapSections,
+  updateOrganizationNarrativeSection,
   updateRoadmapSection,
   type RoadmapSection,
 } from "@/lib/roadmap"
 import { publicSharingEnabled } from "@/lib/feature-flags"
-import { ORG_MEDIA_BUCKET, resolveOrgMediaCleanupPath } from "@/lib/storage/org-media"
-import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import {
+  ORG_MEDIA_BUCKET,
+  resolveOrgMediaCleanupPath,
+} from "@/lib/storage/org-media"
+import {
+  canEditOrganization,
+  resolveActiveOrganization,
+} from "@/lib/organization/active-org"
 import { createNotification } from "@/lib/notifications"
 
 type SaveInput = {
   sectionId?: string
+  expectedLastUpdated?: string | null
   title?: string
   subtitle?: string
   content?: string
@@ -53,6 +64,7 @@ function revalidateRoadmapWorkspacePaths({
 
 export async function saveRoadmapSectionAction({
   sectionId,
+  expectedLastUpdated,
   title,
   subtitle,
   content,
@@ -83,9 +95,13 @@ export async function saveRoadmapSectionAction({
 
   const { data: orgRow, error: orgError } = await supabase
     .from("organizations")
-    .select("profile, public_slug")
+    .select("profile, public_slug, updated_at")
     .eq("user_id", orgId)
-    .maybeSingle<{ profile: Json | null; public_slug: string | null }>()
+    .maybeSingle<{
+      profile: Json | null
+      public_slug: string | null
+      updated_at: string
+    }>()
 
   if (orgError) {
     return { error: orgError.message }
@@ -93,26 +109,56 @@ export async function saveRoadmapSectionAction({
 
   const currentProfile = (orgRow?.profile ?? {}) as Record<string, unknown>
   const existingSections = resolveRoadmapSections(currentProfile)
-  const normalizedSectionId = typeof sectionId === "string" ? sectionId.trim() : ""
+  const normalizedSectionId =
+    typeof sectionId === "string" ? sectionId.trim() : ""
   const previousSection = normalizedSectionId
-    ? existingSections.find((section) => section.id === normalizedSectionId) ?? null
+    ? (existingSections.find((section) => section.id === normalizedSectionId) ??
+      null)
     : null
 
+  if (
+    previousSection &&
+    expectedLastUpdated !== undefined &&
+    previousSection.lastUpdated !== expectedLastUpdated
+  ) {
+    return {
+      error:
+        "This roadmap section was updated elsewhere. Reload before saving.",
+    }
+  }
+
   if (!previousSection && existingSections.length >= ROADMAP_SECTION_LIMIT) {
-    return { error: `Roadmaps support up to ${ROADMAP_SECTION_LIMIT} sections.` }
+    return {
+      error: `Roadmaps support up to ${ROADMAP_SECTION_LIMIT} sections.`,
+    }
   }
   const isNewSection = !previousSection
-  const { nextProfile, section } = updateRoadmapSection(currentProfile, sectionId ?? null, {
+  const narrativeKey =
+    getOrganizationNarrativeKeyForSectionId(normalizedSectionId)
+  const sanitizedContent =
+    typeof content === "string"
+      ? narrativeKey
+        ? normalizeOrganizationNarrativeHtml(content)
+        : sanitizeHtml(content)
+      : content
+  const sectionUpdates = {
     title,
     subtitle,
-    content,
+    content: sanitizedContent,
     imageUrl,
     isPublic: allowPublicSharing ? isPublic : false,
     layout,
     status,
     ctaLabel,
     ctaUrl,
-  })
+  }
+  const { nextProfile, section } = narrativeKey
+    ? updateOrganizationNarrativeSection(
+        currentProfile,
+        narrativeKey,
+        sectionUpdates
+      )
+    : updateRoadmapSection(currentProfile, sectionId ?? null, sectionUpdates)
 
   const cleanupPath = resolveOrgMediaCleanupPath({
     previousUrl: previousSection?.imageUrl ?? null,
@@ -120,15 +166,27 @@ export async function saveRoadmapSectionAction({
     userId: orgId,
   })
 
-  const { error: upsertError } = await supabase
-    .from("organizations")
-    .upsert({
+  if (orgRow) {
+    const { data: updatedRow, error: updateError } = await supabase
+      .from("organizations")
+      .update({ profile: nextProfile as Json })
+      .eq("user_id", orgId)
+      .eq("updated_at", orgRow.updated_at)
+      .select("user_id")
+      .maybeSingle<{ user_id: string }>()
+
+    if (updateError) return { error: updateError.message }
+    if (!updatedRow) {
+      return {
+        error: "This organization was updated elsewhere. Reload before saving.",
+      }
+    }
+  } else {
+    const { error: insertError } = await supabase.from("organizations").insert({
       user_id: orgId,
       profile: nextProfile as Json,
     })
-
-  if (upsertError) {
-    return { error: upsertError.message }
+    if (insertError) return { error: insertError.message }
   }
 
   if (cleanupPath) {
@@ -144,7 +202,9 @@ export async function saveRoadmapSectionAction({
     const notifyResult = await createNotification(supabase, {
       userId: user.id,
       title: "Roadmap section added",
-      description: section.title ? `New section: ${section.title}.` : "A new roadmap section was added.",
+      description: section.title
+        ? `New section: ${section.title}.`
+        : "A new roadmap section was added.",
       href: "/organization",
       tone: "success",
       type: "roadmap_section_added",
@@ -159,7 +219,9 @@ export async function saveRoadmapSectionAction({
   return { section }
 }
 
-export async function deleteRoadmapSectionAction(sectionId: string | null | undefined): Promise<DeleteResult> {
+export async function deleteRoadmapSectionAction(
+  sectionId: string | null | undefined
+): Promise<DeleteResult> {
   const supabase = await createSupabaseServerClient()
   const {
     data: { user },
@@ -179,9 +241,13 @@ export async function deleteRoadmapSectionAction(sectionId: string | null | unde
 
   const { data: orgRow, error: orgError } = await supabase
     .from("organizations")
-    .select("profile, public_slug")
+    .select("profile, public_slug, updated_at")
     .eq("user_id", orgId)
-    .maybeSingle<{ profile: Json | null; public_slug: string | null }>()
+    .maybeSingle<{
+      profile: Json | null
+      public_slug: string | null
+      updated_at: string
+    }>()
 
   if (orgError) {
     return { error: orgError.message }
@@ -189,8 +255,15 @@ export async function deleteRoadmapSectionAction(sectionId: string | null | unde
 
   const currentProfile = (orgRow?.profile ?? {}) as Record<string, unknown>
   const targetId = typeof sectionId === "string" ? sectionId.trim() : ""
-  const previousSection = targetId ? resolveRoadmapSections(currentProfile).find((section) => section.id === targetId) ?? null : null
-  const { nextProfile, removed, error } = removeRoadmapSection(currentProfile, sectionId)
+  const previousSection = targetId
+    ? (resolveRoadmapSections(currentProfile).find(
+        (section) => section.id === targetId
+      ) ?? null)
+    : null
+  const { nextProfile, removed, error } = removeRoadmapSection(
+    currentProfile,
+    sectionId
+  )
 
   if (error) {
     return { error }
@@ -200,15 +273,21 @@ export async function deleteRoadmapSectionAction(sectionId: string | null | unde
     return { error: "Unable to delete section." }
   }
 
-  const { error: upsertError } = await supabase
-    .from("organizations")
-    .upsert({
-      user_id: orgId,
-      profile: nextProfile as Json,
-    })
+  if (!orgRow) return { error: "Organization not found." }
 
-  if (upsertError) {
-    return { error: upsertError.message }
+  const { data: updatedRow, error: updateError } = await supabase
+    .from("organizations")
+    .update({ profile: nextProfile as Json })
+    .eq("user_id", orgId)
+    .eq("updated_at", orgRow.updated_at)
+    .select("user_id")
+    .maybeSingle<{ user_id: string }>()
+
+  if (updateError) return { error: updateError.message }
+  if (!updatedRow) {
+    return {
+      error: "This organization was updated elsewhere. Reload before deleting.",
+    }
   }
 
   const cleanupPath = resolveOrgMediaCleanupPath({
@@ -231,7 +310,9 @@ export async function deleteRoadmapSectionAction(sectionId: string | null | unde
 
 type ToggleResult = { ok: true } | { error: string }
 
-export async function setRoadmapPublicAction(nextPublic: boolean): Promise<ToggleResult> {
+export async function setRoadmapPublicAction(
+  nextPublic: boolean
+): Promise<ToggleResult> {
   if (!publicSharingEnabled) {
     return { error: "Public sharing is disabled until launch." }
   }
@@ -297,7 +378,9 @@ type HeroResult = { ok: true } | { error: string }
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value)
 
-export async function setRoadmapHeroImageAction(heroUrl: string | null): Promise<HeroResult> {
+export async function setRoadmapHeroImageAction(
+  heroUrl: string | null
+): Promise<HeroResult> {
   const supabase = await createSupabaseServerClient()
   const {
     data: { user },
@@ -315,23 +398,38 @@ export async function setRoadmapHeroImageAction(heroUrl: string | null): Promise
   const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
   if (!canEditOrganization(role)) return { error: "Forbidden" }
 
-  const nextHero = typeof heroUrl === "string" && heroUrl.trim().length > 0 ? heroUrl.trim() : null
+  const nextHero =
+    typeof heroUrl === "string" && heroUrl.trim().length > 0
+      ? heroUrl.trim()
+      : null
 
   const { data: orgRow, error: orgError } = await supabase
     .from("organizations")
-    .select("profile, public_slug, is_public_roadmap")
+    .select("profile, public_slug, is_public_roadmap, updated_at")
     .eq("user_id", orgId)
-    .maybeSingle<{ profile: Json | null; public_slug: string | null; is_public_roadmap: boolean | null }>()
+    .maybeSingle<{
+      profile: Json | null
+      public_slug: string | null
+      is_public_roadmap: boolean | null
+      updated_at: string
+    }>()
 
   if (orgError) {
     return { error: orgError.message }
   }
 
   const currentProfile = (orgRow?.profile ?? {}) as Record<string, unknown>
-  const currentRoadmap = isRecord(currentProfile.roadmap) ? (currentProfile.roadmap as Record<string, unknown>) : {}
-  const previousHeroUrl = typeof currentRoadmap.heroUrl === "string" ? (currentRoadmap.heroUrl as string) : null
+  const currentRoadmap = isRecord(currentProfile.roadmap)
+    ? (currentProfile.roadmap as Record<string, unknown>)
+    : {}
+  const previousHeroUrl =
+    typeof currentRoadmap.heroUrl === "string"
+      ? (currentRoadmap.heroUrl as string)
+      : null
   const nextProfile = isRecord(currentProfile) ? { ...currentProfile } : {}
-  const roadmapRecord = isRecord(nextProfile.roadmap) ? { ...(nextProfile.roadmap as Record<string, unknown>) } : {}
+  const roadmapRecord = isRecord(nextProfile.roadmap)
+    ? { ...(nextProfile.roadmap as Record<string, unknown>) }
+    : {}
   roadmapRecord.heroUrl = nextHero
   nextProfile.roadmap = roadmapRecord
 
@@ -341,12 +439,27 @@ export async function setRoadmapHeroImageAction(heroUrl: string | null): Promise
     userId: orgId,
   })
 
-  const { error: upsertError } = await supabase
-    .from("organizations")
-    .upsert({ user_id: orgId, profile: nextProfile as Json }, { onConflict: "user_id" })
+  if (orgRow) {
+    const { data: updatedRow, error: updateError } = await supabase
+      .from("organizations")
+      .update({ profile: nextProfile as Json })
+      .eq("user_id", orgId)
+      .eq("updated_at", orgRow.updated_at)
+      .select("user_id")
+      .maybeSingle<{ user_id: string }>()
 
-  if (upsertError) {
-    return { error: upsertError.message }
+    if (updateError) return { error: updateError.message }
+    if (!updatedRow) {
+      return {
+        error: "This organization was updated elsewhere. Reload before saving.",
+      }
+    }
+  } else {
+    const { error: insertError } = await supabase.from("organizations").insert({
+      user_id: orgId,
+      profile: nextProfile as Json,
+    })
+    if (insertError) return { error: insertError.message }
   }
 
   if (cleanupPath) {

--- a/src/app/(dashboard)/my-organization/_lib/helpers.ts
+++ b/src/app/(dashboard)/my-organization/_lib/helpers.ts
@@ -1,5 +1,9 @@
 import type { ModuleCardStatus } from "@/lib/accelerator/progress"
 import { normalizeOrganizationLocationFields } from "@/lib/location/organization-location"
+import {
+  resolveOrganizationNarrativeRevisions,
+  resolveOrganizationNarratives,
+} from "@/lib/roadmap"
 import type {
   BrandTypographyConfig,
   BrandTypographyTracking,
@@ -155,6 +159,7 @@ export function buildInitialOrganizationProfile({
     postal: profile["address_postal"],
     country: profile["address_country"],
   })
+  const narratives = resolveOrganizationNarratives(profile)
 
   return {
     name: String(profile["name"] ?? ""),
@@ -188,10 +193,10 @@ export function buildInitialOrganizationProfile({
     tiktok: String(profile["tiktok"] ?? ""),
     newsletter: String(profile["newsletter"] ?? ""),
     github: String(profile["github"] ?? ""),
-    vision: String(profile["vision"] ?? ""),
-    mission: String(profile["mission"] ?? ""),
+    vision: narratives.vision,
+    mission: narratives.mission,
     need: String(profile["need"] ?? ""),
-    values: String(profile["values"] ?? ""),
+    values: narratives.values,
     originStory: String(profile["originStory"] ?? profile["origin_story"] ?? ""),
     theoryOfChange: String(profile["theoryOfChange"] ?? profile["theory_of_change"] ?? ""),
     programs: String(profile["programs"] ?? ""),
@@ -207,5 +212,6 @@ export function buildInitialOrganizationProfile({
     brandTypography: readTypographyConfig(profile["brandTypography"]),
     publicSlug: String(organization?.public_slug ?? ""),
     isPublic: Boolean(organization?.is_public ?? false),
+    narrativeRevisions: resolveOrganizationNarrativeRevisions(profile),
   }
 }

--- a/src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts
+++ b/src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts
@@ -1,71 +1,118 @@
 import type { Database } from "@/lib/supabase"
-import { sanitizeOrgProfileText, shouldStripOrgProfileHtml } from "@/lib/organization/profile-cleanup"
+import {
+  sanitizeOrgProfileText,
+  shouldStripOrgProfileHtml,
+} from "@/lib/organization/profile-cleanup"
+import {
+  isOrganizationNarrativeKey,
+  type OrganizationNarratives,
+  updateOrganizationNarratives,
+} from "@/lib/roadmap"
 
 import type { SupabaseServerClient } from "./types"
 
 type SyncMappedAnswersToOrganizationProfileParams = {
   supabase: SupabaseServerClient
-  userId: string
+  organizationId: string
   sanitizedAnswers: Record<string, unknown>
   orgKeyMapping: Record<string, string>
 }
 
 export async function syncMappedAnswersToOrganizationProfile({
   supabase,
-  userId,
+  organizationId,
   sanitizedAnswers,
   orgKeyMapping,
-}: SyncMappedAnswersToOrganizationProfileParams): Promise<void> {
+}: SyncMappedAnswersToOrganizationProfileParams): Promise<
+  { ok: true } | { error: string }
+> {
   if (Object.keys(orgKeyMapping).length === 0) {
-    return
+    return { ok: true }
   }
 
   const { data: organizationRow, error: organizationError } = await supabase
     .from("organizations" satisfies keyof Database["public"]["Tables"])
-    .select("profile")
-    .eq("user_id", userId)
-    .maybeSingle<{ profile: Record<string, unknown> | null }>()
+    .select("profile, updated_at")
+    .eq("user_id", organizationId)
+    .maybeSingle<{
+      profile: Record<string, unknown> | null
+      updated_at: string
+    }>()
 
   if (organizationError) {
-    return
+    return { error: organizationError.message }
   }
 
-  const currentProfile = (organizationRow?.profile ?? {}) as Record<string, unknown>
-  const nextProfile: Record<string, unknown> = { ...currentProfile }
+  const currentProfile = (organizationRow?.profile ?? {}) as Record<
+    string,
+    unknown
+  >
+  let nextProfile: Record<string, unknown> = { ...currentProfile }
+  const narrativeUpdates: Partial<OrganizationNarratives> = {}
 
   for (const [fieldName, organizationKey] of Object.entries(orgKeyMapping)) {
     const value = sanitizedAnswers[fieldName]
+    let normalizedValue: string | string[] | number | null = null
     if (typeof value === "string") {
       const trimmed = value.trim()
       if (trimmed.length > 0) {
-        const cleaned = shouldStripOrgProfileHtml(organizationKey) ? sanitizeOrgProfileText(trimmed) : trimmed
-        if (cleaned) {
-          nextProfile[organizationKey] = cleaned
-        }
+        normalizedValue = trimmed
       }
     } else if (Array.isArray(value)) {
       const normalized = value
         .map((item) => (typeof item === "string" ? item.trim() : ""))
         .filter((item) => item.length > 0)
       if (normalized.length > 0) {
-        if (shouldStripOrgProfileHtml(organizationKey)) {
-          nextProfile[organizationKey] = normalized.join("\n")
-        } else {
-          nextProfile[organizationKey] = normalized
-        }
+        normalizedValue = normalized
       }
     } else if (typeof value === "number") {
-      nextProfile[organizationKey] = value
+      normalizedValue = value
+    }
+
+    if (normalizedValue === null) continue
+    if (isOrganizationNarrativeKey(organizationKey)) {
+      narrativeUpdates[organizationKey] = Array.isArray(normalizedValue)
+        ? normalizedValue.join("\n")
+        : String(normalizedValue)
+      continue
+    }
+
+    if (typeof normalizedValue === "string") {
+      const cleaned = shouldStripOrgProfileHtml(organizationKey)
+        ? sanitizeOrgProfileText(normalizedValue)
+        : normalizedValue
+      if (cleaned) nextProfile[organizationKey] = cleaned
+    } else if (Array.isArray(normalizedValue)) {
+      nextProfile[organizationKey] = shouldStripOrgProfileHtml(organizationKey)
+        ? normalizedValue.join("\n")
+        : normalizedValue
+    } else {
+      nextProfile[organizationKey] = normalizedValue
     }
   }
 
-  await supabase
+  nextProfile = updateOrganizationNarratives(
+    nextProfile,
+    narrativeUpdates
+  ).nextProfile
+
+  if (!organizationRow) {
+    return { error: "Organization not found." }
+  }
+
+  const { data: updatedRow, error: updateError } = await supabase
     .from("organizations" satisfies keyof Database["public"]["Tables"])
-    .upsert(
-      {
-        user_id: userId,
-        profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-      } as Database["public"]["Tables"]["organizations"]["Insert"],
-      { onConflict: "user_id" },
-    )
+    .update({
+      profile:
+        nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
+    } as Database["public"]["Tables"]["organizations"]["Update"])
+    .eq("user_id", organizationId)
+    .eq("updated_at", organizationRow.updated_at)
+    .select("user_id")
+    .maybeSingle<{ user_id: string }>()
+
+  if (updateError) return { error: updateError.message }
+  return updatedRow
+    ? { ok: true }
+    : { error: "Organization was updated elsewhere. Submit again." }
 }

--- a/src/app/api/modules/[id]/assignment-submission/route.ts
+++ b/src/app/api/modules/[id]/assignment-submission/route.ts
@@ -9,13 +9,20 @@ import {
   shouldTreatAssignmentSubmissionAsComplete,
 } from "@/lib/modules"
 import { revalidateClassViews } from "@/app/(admin)/admin/classes/actions"
+import {
+  canEditOrganization,
+  resolveActiveOrganization,
+} from "@/lib/organization/active-org"
 import { trackUserJourneyMilestone } from "@/lib/user-journey"
 import { processModuleCompletion } from "./_lib/completion"
 import { syncMappedAnswersToOrganizationProfile } from "./_lib/profile-sync"
 import { extractOrgKeyMappings, sanitizeAnswers } from "./_lib/sanitize"
 import type { AnswersPayload, ModuleMeta, SubmissionStatus } from "./_lib/types"
 
-export async function POST(request: Request, context: { params: Promise<{ id: string }> }) {
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
   const { id: moduleId } = await context.params
   const supabase = await createSupabaseServerClient()
 
@@ -31,6 +38,8 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
+
+  const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
 
   let payload: { answers?: AnswersPayload; status?: SubmissionStatus }
   try {
@@ -67,7 +76,10 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
     .maybeSingle<{ schema: unknown; complete_on_submit: boolean | null }>()
 
   if (assignmentError) {
-    return NextResponse.json({ error: assignmentError.message }, { status: 500 })
+    return NextResponse.json(
+      { error: assignmentError.message },
+      { status: 500 }
+    )
   }
 
   if (!assignmentRow) {
@@ -75,10 +87,16 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
   }
 
   const slug = moduleMeta.classes?.slug ?? null
-  const modulePath = slug && typeof moduleMeta.idx === "number" ? `/class/${slug}/module/${moduleMeta.idx}` : null
+  const modulePath =
+    slug && typeof moduleMeta.idx === "number"
+      ? `/class/${slug}/module/${moduleMeta.idx}`
+      : null
 
   const fields = parseAssignmentFields(assignmentRow.schema)
-  const { answers: sanitizedAnswers, missingRequired } = sanitizeAnswers(fields, answersRaw)
+  const { answers: sanitizedAnswers, missingRequired } = sanitizeAnswers(
+    fields,
+    answersRaw
+  )
 
   const orgKeyMapping = extractOrgKeyMappings(assignmentRow.schema)
 
@@ -88,33 +106,59 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
         error: "Missing required answers",
         missing: missingRequired,
       },
-      { status: 400 },
+      { status: 400 }
     )
   }
 
-  const upsertPayload: Database["public"]["Tables"]["assignment_submissions"]["Insert"] = {
-    module_id: moduleId,
-    user_id: user.id,
-    answers: sanitizedAnswers as Json,
-    status: desiredStatus,
-  }
+  const upsertPayload: Database["public"]["Tables"]["assignment_submissions"]["Insert"] =
+    {
+      module_id: moduleId,
+      user_id: user.id,
+      answers: sanitizedAnswers as Json,
+      status: desiredStatus,
+    }
 
   const { data: submissionRows, error: upsertError } = await supabase
     .from("assignment_submissions" satisfies keyof Database["public"]["Tables"])
     .upsert(upsertPayload, { onConflict: "module_id,user_id" })
     .select("module_id, answers, status, updated_at")
-    .maybeSingle<{ module_id: string; answers: Record<string, unknown>; status: SubmissionStatus; updated_at: string | null }>()
+    .maybeSingle<{
+      module_id: string
+      answers: Record<string, unknown>
+      status: SubmissionStatus
+      updated_at: string | null
+    }>()
 
   if (upsertError) {
     return NextResponse.json({ error: upsertError.message }, { status: 500 })
   }
 
-  await syncMappedAnswersToOrganizationProfile({
+  if (Object.keys(orgKeyMapping).length > 0 && !canEditOrganization(role)) {
+    return NextResponse.json(
+      {
+        error: "Homework saved, but you cannot update this organization.",
+        submissionSaved: true,
+      },
+      { status: 403 }
+    )
+  }
+
+  const profileSync = await syncMappedAnswersToOrganizationProfile({
     supabase,
-    userId: user.id,
+    organizationId: orgId,
     sanitizedAnswers,
     orgKeyMapping,
   })
+  if ("error" in profileSync) {
+    return NextResponse.json(
+      {
+        error: "Homework saved, but organization details did not update.",
+        details: profileSync.error,
+        submissionSaved: true,
+      },
+      { status: 500 }
+    )
+  }
 
   const completionMode = parseAssignmentCompletionMode(assignmentRow.schema)
   const completedOnSubmit = shouldTreatAssignmentSubmissionAsComplete({
@@ -143,7 +187,7 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
 
   await trackUserJourneyMilestone({
     userId: user.id,
-    orgId: user.id,
+    orgId,
     eventName: "homework_submitted",
     journey: "workspace_activation",
     source: "assignment_submission_route",

--- a/src/app/api/search/_lib/query-sources/fallback.ts
+++ b/src/app/api/search/_lib/query-sources/fallback.ts
@@ -1,6 +1,9 @@
 import { fetchSidebarTree } from "@/lib/academy"
 import { parseAssignmentFields } from "@/lib/modules"
-import { resolveRoadmapSections } from "@/lib/roadmap"
+import {
+  resolveOrganizationNarrativePlainText,
+  resolveRoadmapSections,
+} from "@/lib/roadmap"
 import type { SearchResult } from "@/lib/search/types"
 
 import {
@@ -197,7 +200,7 @@ async function addMyOrganizationResults({
   const profile = userOrg.profile ?? {}
   const name = extractProfileValue(profile, "name")
   const tagline = extractProfileValue(profile, "tagline")
-  const mission = extractProfileValue(profile, "mission")
+  const mission = resolveOrganizationNarrativePlainText(profile, "mission")
   const description = extractProfileValue(profile, "description")
   if (matchesQuery([name, tagline, mission, description], tokens)) {
     const logoUrl = extractProfileValue(profile, "logoUrl")
@@ -276,7 +279,7 @@ async function addCommunityResults({
     const profile = org.profile ?? {}
     const name = extractProfileValue(profile, "name")
     const tagline = extractProfileValue(profile, "tagline")
-    const mission = extractProfileValue(profile, "mission")
+    const mission = resolveOrganizationNarrativePlainText(profile, "mission")
     const description = extractProfileValue(profile, "description")
     const city = extractProfileValue(profile, "address_city")
     const state = extractProfileValue(profile, "address_state")

--- a/src/app/api/search/_lib/query-sources/organization.ts
+++ b/src/app/api/search/_lib/query-sources/organization.ts
@@ -1,4 +1,7 @@
-import { resolveRoadmapSections } from "@/lib/roadmap"
+import {
+  resolveOrganizationNarrativePlainText,
+  resolveRoadmapSections,
+} from "@/lib/roadmap"
 import type { SearchResult } from "@/lib/search/types"
 
 import {
@@ -143,7 +146,7 @@ export async function addActiveOrganizationResults({
   const profile = userOrg.profile ?? {}
   const name = extractProfileValue(profile, "name")
   const tagline = extractProfileValue(profile, "tagline")
-  const mission = extractProfileValue(profile, "mission")
+  const mission = resolveOrganizationNarrativePlainText(profile, "mission")
   const description = extractProfileValue(profile, "description")
 
   if (matchesQuery([name, tagline, mission, description], tokens)) {

--- a/src/components/organization/org-profile-card/config.ts
+++ b/src/components/organization/org-profile-card/config.ts
@@ -148,5 +148,10 @@ export function normalizeCompanyProfile(source: OrgProfile): OrgProfile {
     brandTypography: normalizeTypography(source),
     publicSlug: source.publicSlug ?? "",
     isPublic: Boolean(source.isPublic ?? false),
+    narrativeRevisions: source.narrativeRevisions ?? {
+      mission: null,
+      vision: null,
+      values: null,
+    },
   }
 }

--- a/src/components/organization/org-profile-card/hooks/use-org-profile-editor-state.ts
+++ b/src/components/organization/org-profile-card/hooks/use-org-profile-editor-state.ts
@@ -139,7 +139,17 @@ export function useOrgProfileEditorState({
       throw new Error(error)
     }
 
-    setSavedCompany((prev) => ({ ...prev, ...updates }))
+    const narrativeRevisions = (
+      res as { narrativeRevisions?: OrgProfile["narrativeRevisions"] }
+    ).narrativeRevisions
+    if (narrativeRevisions) {
+      setCompany((prev) => ({ ...prev, narrativeRevisions }))
+    }
+    setSavedCompany((prev) => ({
+      ...prev,
+      ...updates,
+      ...(narrativeRevisions ? { narrativeRevisions } : {}),
+    }))
     setErrors((prev) => clearOrgProfileErrors(prev, updates))
   }, [])
 
@@ -203,15 +213,30 @@ export function useOrgProfileEditorState({
         }
       }
 
-      const res = await updateOrganizationProfileAction(company)
+      let res: Awaited<ReturnType<typeof updateOrganizationProfileAction>>
+      try {
+        res = await updateOrganizationProfileAction(company)
+      } catch {
+        toast.error(
+          "The organization could not save. Your edits are still available; retry or refresh.",
+        )
+        return
+      }
       if ((res as { error?: string })?.error) {
         toast.error((res as { error?: string }).error as string)
         return
       }
       toast.success("Organization updated")
+      const narrativeRevisions = (
+        res as { narrativeRevisions?: OrgProfile["narrativeRevisions"] }
+      ).narrativeRevisions
+      const savedCompany = narrativeRevisions
+        ? { ...company, narrativeRevisions }
+        : company
       setEditMode(false)
       setDirty(false)
-      setSavedCompany(company)
+      setCompany(savedCompany)
+      setSavedCompany(savedCompany)
     })
   }, [company, canEdit, slugStatus])
 

--- a/src/components/organization/org-profile-card/organization-narrative-content.tsx
+++ b/src/components/organization/org-profile-card/organization-narrative-content.tsx
@@ -1,0 +1,23 @@
+import { sanitizeHtml } from "@/lib/markdown/sanitize"
+import { cn } from "@/lib/utils"
+
+export function OrganizationNarrativeContent({
+  value,
+  className,
+}: {
+  value: string
+  className?: string
+}) {
+  if (!value.trim()) return null
+
+  return (
+    <div
+      className={cn(
+        "prose prose-sm dark:prose-invert max-w-none break-words",
+        "prose-p:my-2 prose-ul:list-disc prose-ol:list-decimal prose-ul:pl-5 prose-ol:pl-5",
+        className
+      )}
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(value) }}
+    />
+  )
+}

--- a/src/components/organization/org-profile-card/public-card-sections.tsx
+++ b/src/components/organization/org-profile-card/public-card-sections.tsx
@@ -1,4 +1,5 @@
 import { ProgramCard } from "@/components/programs/program-card"
+import { OrganizationNarrativeContent } from "./organization-narrative-content"
 import { cn } from "@/lib/utils"
 import {
   resolveProgramBannerImageUrl,
@@ -71,7 +72,7 @@ export function OrgProfilePublicAboutSection({
             <p className="text-muted-foreground text-xs tracking-wide uppercase">
               Mission
             </p>
-            <FieldText text={mission} multiline />
+            <OrganizationNarrativeContent value={mission} />
           </div>
         ) : null}
         {vision.trim().length > 0 ? (
@@ -79,7 +80,7 @@ export function OrgProfilePublicAboutSection({
             <p className="text-muted-foreground text-xs tracking-wide uppercase">
               Vision
             </p>
-            <FieldText text={vision} multiline />
+            <OrganizationNarrativeContent value={vision} />
           </div>
         ) : null}
         {values.trim().length > 0 ? (
@@ -87,7 +88,7 @@ export function OrgProfilePublicAboutSection({
             <p className="text-muted-foreground text-xs tracking-wide uppercase">
               Values
             </p>
-            <FieldText text={values} multiline />
+            <OrganizationNarrativeContent value={values} />
           </div>
         ) : null}
         {theoryOfChange.trim().length > 0 ? (

--- a/src/components/organization/org-profile-card/public-card.tsx
+++ b/src/components/organization/org-profile-card/public-card.tsx
@@ -69,16 +69,14 @@ export function OrgProfilePublicCard({
     typeof profile.description === "string"
       ? stripHtml(profile.description)
       : ""
-  const mission =
-    typeof profile.mission === "string" ? stripHtml(profile.mission) : ""
-  const vision =
-    typeof profile.vision === "string" ? stripHtml(profile.vision) : ""
-  const need =
-    typeof profile.need === "string" ? stripHtml(profile.need) : ""
-  const values =
-    typeof profile.values === "string" ? stripHtml(profile.values) : ""
+  const mission = typeof profile.mission === "string" ? profile.mission : ""
+  const vision = typeof profile.vision === "string" ? profile.vision : ""
+  const need = typeof profile.need === "string" ? stripHtml(profile.need) : ""
+  const values = typeof profile.values === "string" ? profile.values : ""
   const originStory =
-    typeof profile.originStory === "string" ? stripHtml(profile.originStory) : ""
+    typeof profile.originStory === "string"
+      ? stripHtml(profile.originStory)
+      : ""
   const theoryOfChange =
     typeof profile.theoryOfChange === "string"
       ? stripHtml(profile.theoryOfChange)

--- a/src/components/organization/org-profile-card/tabs/company-tab/display-sections.tsx
+++ b/src/components/organization/org-profile-card/tabs/company-tab/display-sections.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-
 import {
   AddressDisplay,
   BrandLink,
@@ -9,6 +8,7 @@ import {
   LinkText,
   ProfileField,
 } from "@/components/organization/org-profile-card/shared"
+import { OrganizationNarrativeContent } from "@/components/organization/org-profile-card/organization-narrative-content"
 import type { CompanyViewProps } from "./types"
 import { stripHtml } from "@/lib/markdown/convert"
 import { cn } from "@/lib/utils"
@@ -21,12 +21,20 @@ const FORMATION_STATUS_LABELS: Record<string, string> = {
 
 export function IdentityPreview({ company }: CompanyViewProps) {
   const formationLabel =
-    typeof company.formationStatus === "string" ? FORMATION_STATUS_LABELS[company.formationStatus] : ""
-  const hasDescription = typeof company.description === "string" && company.description.trim().length > 0
-  const hasEin = typeof company.ein === "string" && company.ein.trim().length > 0
+    typeof company.formationStatus === "string"
+      ? FORMATION_STATUS_LABELS[company.formationStatus]
+      : ""
+  const hasDescription =
+    typeof company.description === "string" &&
+    company.description.trim().length > 0
+  const hasEin =
+    typeof company.ein === "string" && company.ein.trim().length > 0
   const showFormation =
     Boolean(formationLabel) &&
-    (hasDescription || hasEin || company.formationStatus === "approved" || company.formationStatus === "pre_501c3")
+    (hasDescription ||
+      hasEin ||
+      company.formationStatus === "approved" ||
+      company.formationStatus === "pre_501c3")
 
   if (!(hasDescription || hasEin || showFormation)) {
     return null
@@ -56,7 +64,11 @@ export function IdentityPreview({ company }: CompanyViewProps) {
 }
 
 export function ContactPreview({ company }: CompanyViewProps) {
-  if (!([company.rep, company.email, company.phone].some((value) => typeof value === "string" && value.trim()))) {
+  if (
+    ![company.rep, company.email, company.phone].some(
+      (value) => typeof value === "string" && value.trim()
+    )
+  ) {
     return null
   }
 
@@ -95,7 +107,10 @@ export function AddressPreview({ addressLines }: CompanyViewProps) {
   )
 }
 
-const socialFields: Array<{ key: keyof CompanyViewProps["company"]; label: string }> = [
+const socialFields: Array<{
+  key: keyof CompanyViewProps["company"]
+  label: string
+}> = [
   { key: "twitter", label: "Twitter / X" },
   { key: "facebook", label: "Facebook" },
   { key: "linkedin", label: "LinkedIn" },
@@ -106,14 +121,24 @@ const socialFields: Array<{ key: keyof CompanyViewProps["company"]; label: strin
 ]
 
 export function StoryPreview({ company }: CompanyViewProps) {
-  const originStory = typeof company.originStory === "string" ? stripHtml(company.originStory) : ""
-  const vision = typeof company.vision === "string" ? stripHtml(company.vision) : ""
+  const originStory =
+    typeof company.originStory === "string"
+      ? stripHtml(company.originStory)
+      : ""
+  const vision = typeof company.vision === "string" ? company.vision : ""
   const need = typeof company.need === "string" ? stripHtml(company.need) : ""
-  const mission = typeof company.mission === "string" ? stripHtml(company.mission) : ""
-  const values = typeof company.values === "string" ? stripHtml(company.values) : ""
-  const theoryOfChange = typeof company.theoryOfChange === "string" ? stripHtml(company.theoryOfChange) : ""
+  const mission = typeof company.mission === "string" ? company.mission : ""
+  const values = typeof company.values === "string" ? company.values : ""
+  const theoryOfChange =
+    typeof company.theoryOfChange === "string"
+      ? stripHtml(company.theoryOfChange)
+      : ""
 
-  if (!([originStory, vision, need, mission, values, theoryOfChange].some((value) => value.trim().length > 0))) {
+  if (
+    ![originStory, vision, need, mission, values, theoryOfChange].some(
+      (value) => value.trim().length > 0
+    )
+  ) {
     return null
   }
 
@@ -132,17 +157,17 @@ export function StoryPreview({ company }: CompanyViewProps) {
         ) : null}
         {mission.trim().length > 0 ? (
           <ProfileField label="Mission">
-            <FieldText text={mission} multiline />
+            <OrganizationNarrativeContent value={mission} />
           </ProfileField>
         ) : null}
         {vision.trim().length > 0 ? (
           <ProfileField label="Vision">
-            <FieldText text={vision} multiline />
+            <OrganizationNarrativeContent value={vision} />
           </ProfileField>
         ) : null}
         {values.trim().length > 0 ? (
           <ProfileField label="Values">
-            <FieldText text={values} multiline />
+            <OrganizationNarrativeContent value={values} />
           </ProfileField>
         ) : null}
         {theoryOfChange.trim().length > 0 ? (
@@ -202,9 +227,13 @@ export function SocialPreview({ company, hasAnyBrandLink }: CompanyViewProps) {
 }
 
 export function BrandKitPreview({ company }: CompanyViewProps) {
-  const boilerplate = typeof company.boilerplate === "string" ? stripHtml(company.boilerplate) : ""
+  const boilerplate =
+    typeof company.boilerplate === "string"
+      ? stripHtml(company.boilerplate)
+      : ""
   const showBrandKit =
-    (typeof company.logoUrl === "string" && company.logoUrl.trim()) || boilerplate.trim().length > 0
+    (typeof company.logoUrl === "string" && company.logoUrl.trim()) ||
+    boilerplate.trim().length > 0
 
   if (!showBrandKit) {
     return null
@@ -245,8 +274,9 @@ export function ViewModeSections(props: CompanyViewProps) {
   if (sections.length === 0) {
     return (
       <div className="mx-auto flex min-h-[220px] w-full max-w-3xl items-center justify-center">
-        <div className="w-full rounded-xl border border-dashed border-border/60 bg-muted/20 px-6 py-8 text-center text-sm text-muted-foreground">
-          No organization details yet. Add company information to populate this section.
+        <div className="border-border/60 bg-muted/20 text-muted-foreground w-full rounded-xl border border-dashed px-6 py-8 text-center text-sm">
+          No organization details yet. Add company information to populate this
+          section.
         </div>
       </div>
     )
@@ -255,9 +285,21 @@ export function ViewModeSections(props: CompanyViewProps) {
   const hasIdentity = sections.some((section) => section.id === "identity")
 
   return (
-    <div className={cn("mx-auto w-full max-w-4xl", hasIdentity ? "divide-y divide-border/60" : "space-y-6")}>
+    <div
+      className={cn(
+        "mx-auto w-full max-w-4xl",
+        hasIdentity ? "divide-border/60 divide-y" : "space-y-6"
+      )}
+    >
       {sections.map((section, index) => (
-        <div key={section.id} className={cn("py-6", index === 0 && "pt-0", index === sections.length - 1 && "pb-0")}>
+        <div
+          key={section.id}
+          className={cn(
+            "py-6",
+            index === 0 && "pt-0",
+            index === sections.length - 1 && "pb-0"
+          )}
+        >
           {section.node}
         </div>
       ))}

--- a/src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx
+++ b/src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx
@@ -1,9 +1,13 @@
 "use client"
 
+import { RichTextEditor } from "@/components/rich-text-editor"
 import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
 
-import { FormRow, ProfileField } from "@/components/organization/org-profile-card/shared"
+import {
+  FormRow,
+  ProfileField,
+} from "@/components/organization/org-profile-card/shared"
 import { ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH } from "@/components/organization/org-profile-card/validation"
 import type { CompanyEditProps } from "../types"
 
@@ -15,11 +19,21 @@ const STORY_FIELDS = [
       "We started after seeing students and families navigate fragmented support alone.",
   },
   {
-    name: "vision",
-    label: "Vision",
+    name: "need",
+    label: "Our need",
     placeholder:
-      "A city where every student has access to high-quality STEM learning.",
+      "Students in our district lack access to labs, internships, and career exposure.",
   },
+] as const
+
+const THEORY_FIELD = {
+  name: "theoryOfChange",
+  label: "Theory of change",
+  placeholder:
+    "When students, mentors, and core supports are connected early, confidence and long-term opportunity grow.",
+} as const
+
+const NARRATIVE_FIELDS = [
   {
     name: "mission",
     label: "Mission",
@@ -27,21 +41,15 @@ const STORY_FIELDS = [
       "We equip middle school students with hands-on programs and mentors in technology careers.",
   },
   {
-    name: "need",
-    label: "Our need",
+    name: "vision",
+    label: "Vision",
     placeholder:
-      "Students in our district lack access to labs, internships, and career exposure.",
+      "A city where every student has access to high-quality STEM learning.",
   },
   {
     name: "values",
     label: "Values",
     placeholder: "Equity, curiosity, community",
-  },
-  {
-    name: "theoryOfChange",
-    label: "Theory of change",
-    placeholder:
-      "When students, mentors, and core supports are connected early, confidence and long-term opportunity grow.",
   },
 ] as const
 
@@ -51,7 +59,7 @@ function StoryTextField({
   field,
   onInputChange,
 }: Pick<CompanyEditProps, "company" | "errors" | "onInputChange"> & {
-  field: (typeof STORY_FIELDS)[number]
+  field: (typeof STORY_FIELDS)[number] | typeof THEORY_FIELD
 }) {
   const value = company[field.name] ?? ""
   const error = errors[field.name] ?? ""
@@ -81,20 +89,64 @@ function StoryTextField({
         <p
           id={`${field.name}-limit`}
           className={cn(
-            "ml-auto tabular-nums text-muted-foreground",
-            overLimit && "font-medium text-destructive",
+            "text-muted-foreground ml-auto tabular-nums",
+            overLimit && "text-destructive font-medium"
           )}
         >
-          {count.toLocaleString()} / {ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH.toLocaleString()}
+          {count.toLocaleString()} /{" "}
+          {ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH.toLocaleString()}
         </p>
       </div>
     </ProfileField>
   )
 }
 
-export function StorySection({ company, errors, onInputChange }: CompanyEditProps) {
+function StoryNarrativeField({
+  company,
+  errors,
+  field,
+  onUpdate,
+  onDirty,
+}: Pick<CompanyEditProps, "company" | "errors" | "onUpdate" | "onDirty"> & {
+  field: (typeof NARRATIVE_FIELDS)[number]
+}) {
+  const value = company[field.name] ?? ""
+  const error = errors[field.name] ?? ""
+
   return (
-    <FormRow title="About us" description="What you do, why it matters, and how change happens.">
+    <ProfileField label={field.label}>
+      <RichTextEditor
+        value={value}
+        onChange={(nextValue) => {
+          onUpdate({ [field.name]: nextValue })
+          onDirty()
+        }}
+        ariaLabel={field.label}
+        placeholder={field.placeholder}
+        mode="compact"
+        minHeight={160}
+        maxHeight={360}
+        stableScrollbars
+        preserveImages
+        editorClassName="min-h-[160px]"
+      />
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+    </ProfileField>
+  )
+}
+
+export function StorySection({
+  company,
+  errors,
+  onInputChange,
+  onUpdate,
+  onDirty,
+}: CompanyEditProps) {
+  return (
+    <FormRow
+      title="About us"
+      description="What you do, why it matters, and how change happens."
+    >
       <div className="grid gap-4 md:grid-cols-2">
         {STORY_FIELDS.map((field) => (
           <StoryTextField
@@ -105,6 +157,22 @@ export function StorySection({ company, errors, onInputChange }: CompanyEditProp
             onInputChange={onInputChange}
           />
         ))}
+        {NARRATIVE_FIELDS.map((field) => (
+          <StoryNarrativeField
+            key={field.name}
+            company={company}
+            errors={errors}
+            field={field}
+            onUpdate={onUpdate}
+            onDirty={onDirty}
+          />
+        ))}
+        <StoryTextField
+          company={company}
+          errors={errors}
+          field={THEORY_FIELD}
+          onInputChange={onInputChange}
+        />
       </div>
     </FormRow>
   )

--- a/src/components/organization/org-profile-card/types.ts
+++ b/src/components/organization/org-profile-card/types.ts
@@ -1,4 +1,5 @@
 import type { OrgPersonWithImage } from "@/components/people/supporters-showcase"
+import type { OrganizationNarrativeRevisions } from "@/lib/roadmap"
 
 export type FormationStatus = "pre_501c3" | "in_progress" | "approved"
 
@@ -69,6 +70,7 @@ export type OrgProfile = {
   brandTypography?: BrandTypographyConfig | null
   publicSlug?: string | null
   isPublic?: boolean | null
+  narrativeRevisions?: OrganizationNarrativeRevisions
 }
 
 export type OrgDocument = {

--- a/src/components/rich-text-editor.tsx
+++ b/src/components/rich-text-editor.tsx
@@ -33,6 +33,7 @@ export function RichTextEditor({
   onImageUpload,
   onImageUploaded,
   insertUploadedImage = true,
+  preserveImages = false,
   onImagePickerReady,
   toolbarPortalId,
   toolbarClassName,
@@ -78,7 +79,7 @@ export function RichTextEditor({
     extensions: buildRichTextExtensions({
       placeholderRef,
       isReadOnly,
-      enableImages,
+      enableImages: enableImages || preserveImages,
       onImageUpload,
     }),
     content: value,

--- a/src/components/rich-text-editor/types.ts
+++ b/src/components/rich-text-editor/types.ts
@@ -28,6 +28,7 @@ export type RichTextEditorProps = {
     file: File
   }) => void | Promise<void>
   insertUploadedImage?: boolean
+  preserveImages?: boolean
   onImagePickerReady?: (open: (() => void) | null) => void
   toolbarPortalId?: string
   toolbarClassName?: string

--- a/src/components/roadmap/roadmap-editor/constants.ts
+++ b/src/components/roadmap/roadmap-editor/constants.ts
@@ -13,6 +13,8 @@ export const ROADMAP_TOC_GROUPS = [
   { id: "origin_story" },
   { id: "need" },
   { id: "mission_vision_values" },
+  { id: "vision" },
+  { id: "values" },
   { id: "theory_of_change" },
   { id: "program" },
   { id: "evaluation" },
@@ -25,6 +27,6 @@ export const ROADMAP_TOC_GROUPS = [
 ]
 
 export const ROADMAP_TOC_GROUP_PARENT_BY_CHILD = new Map<string, string>([
-  ...(FUNDRAISING_CHILD_IDS.map((id) => [id, "fundraising"] as const)),
-  ...(BOARD_CHILD_IDS.map((id) => [id, "board_strategy"] as const)),
+  ...FUNDRAISING_CHILD_IDS.map((id) => [id, "fundraising"] as const),
+  ...BOARD_CHILD_IDS.map((id) => [id, "board_strategy"] as const),
 ])

--- a/src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts
+++ b/src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts
@@ -176,33 +176,40 @@ export function useRoadmapEditorState({
 
       setSavingId(section.id)
       startTransition(async () => {
-        const result = await saveRoadmapSectionAction({
-          sectionId: section.id,
-          title: draft.title,
-          subtitle: draft.subtitle,
-          content: draft.content,
-          imageUrl: draft.imageUrl,
-          status: shouldMarkInProgress ? "in_progress" : undefined,
-        })
+        try {
+          const result = await saveRoadmapSectionAction({
+            sectionId: section.id,
+            expectedLastUpdated: section.lastUpdated,
+            title: draft.title,
+            subtitle: draft.subtitle,
+            content: draft.content,
+            imageUrl: draft.imageUrl,
+            status: shouldMarkInProgress ? "in_progress" : undefined,
+          })
 
-        if ("error" in result) {
-          if (showToast) toast.error(result.error)
+          if ("error" in result) {
+            toast.error(result.error)
+            return
+          }
+
+          const nextSection = result.section
+          setSections((prev) => {
+            const index = prev.findIndex((entry) => entry.id === nextSection.id)
+            if (index === -1) return [...prev, nextSection]
+            return prev.map((entry, idx) => (idx === index ? nextSection : entry))
+          })
+          setDrafts((prev) => ({
+            ...prev,
+            [nextSection.id]: createDraft(nextSection),
+          }))
+          if (showToast) toast.success("Section saved")
+        } catch {
+          toast.error(
+            "The roadmap could not save. Your draft is still available; retry or refresh."
+          )
+        } finally {
           setSavingId(null)
-          return
         }
-
-        const nextSection = result.section
-        setSections((prev) => {
-          const index = prev.findIndex((entry) => entry.id === nextSection.id)
-          if (index === -1) return [...prev, nextSection]
-          return prev.map((entry, idx) => (idx === index ? nextSection : entry))
-        })
-        setDrafts((prev) => ({
-          ...prev,
-          [nextSection.id]: createDraft(nextSection),
-        }))
-        setSavingId(null)
-        if (showToast) toast.success("Section saved")
       })
     },
     [canEdit, isPending, savingId],

--- a/src/components/roadmap/roadmap-icons.tsx
+++ b/src/components/roadmap/roadmap-icons.tsx
@@ -5,8 +5,10 @@ import CalendarIcon from "lucide-react/dist/esm/icons/calendar"
 import ClipboardListIcon from "lucide-react/dist/esm/icons/clipboard-list"
 import CompassIcon from "lucide-react/dist/esm/icons/compass"
 import DollarSignIcon from "lucide-react/dist/esm/icons/dollar-sign"
+import EyeIcon from "lucide-react/dist/esm/icons/eye"
 import FileTextIcon from "lucide-react/dist/esm/icons/file-text"
 import HandIcon from "lucide-react/dist/esm/icons/hand"
+import HeartHandshakeIcon from "lucide-react/dist/esm/icons/heart-handshake"
 import LineChartIcon from "lucide-react/dist/esm/icons/line-chart"
 import ListChecksIcon from "lucide-react/dist/esm/icons/list-checks"
 import MapIcon from "lucide-react/dist/esm/icons/map"
@@ -19,6 +21,8 @@ export const ROADMAP_SECTION_ICONS: Record<string, ComponentType<{ className?: s
   origin_story: BookOpenIcon,
   need: HandIcon,
   mission_vision_values: CompassIcon,
+  vision: EyeIcon,
+  values: HeartHandshakeIcon,
   theory_of_change: SparklesIcon,
   program: RocketIcon,
   evaluation: LineChartIcon,

--- a/src/features/member-workspace/server/admin-organization-setup.ts
+++ b/src/features/member-workspace/server/admin-organization-setup.ts
@@ -2,7 +2,10 @@ import {
   PROFILE_COMPLETENESS_KEYS,
   VERIFIED_DOC_KEYS,
 } from "@/lib/accelerator/readiness"
-import { resolveRoadmapSections } from "@/lib/roadmap"
+import {
+  resolveOrganizationNarrativePlainText,
+  resolveRoadmapSections,
+} from "@/lib/roadmap"
 import type { Json } from "@/lib/supabase"
 import type { MemberWorkspaceAdminOrganizationSetupItem } from "@/features/member-workspace/types"
 
@@ -42,6 +45,9 @@ function isProfileSetupFieldComplete(
   }
   if (key === "address_state") {
     return hasText(profile.address_state) || hasText(profile.addressState)
+  }
+  if (key === "mission" || key === "values") {
+    return hasText(resolveOrganizationNarrativePlainText(profile, key))
   }
   return hasText(profile[key])
 }
@@ -135,7 +141,7 @@ function buildSetupChecklist({
     },
     {
       id: "roadmap-mission-vision-values",
-      label: "Complete roadmap: Mission, vision, and values",
+      label: "Complete roadmap: Mission",
       complete: isRoadmapSectionComplete("mission_vision_values", roadmapSections),
     },
     {

--- a/src/lib/accelerator/readiness.ts
+++ b/src/lib/accelerator/readiness.ts
@@ -1,5 +1,8 @@
 import type { ModuleCardStatus } from "@/lib/accelerator/progress"
-import type { RoadmapSection } from "@/lib/roadmap"
+import {
+  resolveOrganizationNarrativePlainText,
+  type RoadmapSection,
+} from "@/lib/roadmap"
 
 export const ACCELERATOR_FUNDABLE_THRESHOLD = 70
 export const ACCELERATOR_VERIFIED_THRESHOLD = 90
@@ -109,7 +112,12 @@ export function resolveAcceleratorReadiness({
   const hasProgram = programs.length > 0
   const hasFundingGoal = programs.some((program) => Number(program.goal_cents ?? 0) > 0)
 
-  const profileFieldsCompleted = PROFILE_COMPLETENESS_KEYS.filter((key) => hasText(profile[key])).length
+  const profileFieldsCompleted = PROFILE_COMPLETENESS_KEYS.filter((key) => {
+    if (key === "mission" || key === "values") {
+      return hasText(resolveOrganizationNarrativePlainText(profile, key))
+    }
+    return hasText(profile[key])
+  }).length
   const profileScore = Math.round((profileFieldsCompleted / PROFILE_COMPLETENESS_KEYS.length) * 20)
 
   const roadmapCoreCompleted = roadmapSections.filter(

--- a/src/lib/markdown/sanitize.ts
+++ b/src/lib/markdown/sanitize.ts
@@ -1,6 +1,37 @@
-const BLOCKLISTED_TAGS = ["script", "style", "iframe", "object", "embed", "link", "meta"]
-const EVENT_HANDLER_REGEX = /\son\w+="[^"]*"/gi
-const JS_PROTOCOL_REGEX = /javascript:/gi
+const BLOCKLISTED_TAGS = [
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "link",
+  "meta",
+  "svg",
+  "math",
+  "form",
+  "input",
+  "button",
+  "textarea",
+  "select",
+  "option",
+  "base",
+  "template",
+]
+const EVENT_HANDLER_REGEX =
+  /\s+on[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi
+const DANGEROUS_PROTOCOL_REGEX = /(?:javascript|vbscript)\s*:/gi
+const URL_ATTRIBUTE_REGEX =
+  /\s+(href|src|xlink:href)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi
+
+function decodeNumericHtmlEntities(value: string): string {
+  return value
+    .replace(/&#x([0-9a-f]+);?/gi, (_, hex: string) =>
+      String.fromCodePoint(Number.parseInt(hex, 16)),
+    )
+    .replace(/&#([0-9]+);?/g, (_, decimal: string) =>
+      String.fromCodePoint(Number.parseInt(decimal, 10)),
+    )
+}
 
 export function sanitizeHtml(input: string): string {
   if (!input) return ""
@@ -14,7 +45,24 @@ export function sanitizeHtml(input: string): string {
   }
 
   sanitized = sanitized.replace(EVENT_HANDLER_REGEX, "")
-  sanitized = sanitized.replace(JS_PROTOCOL_REGEX, "noop:")
+  sanitized = sanitized.replace(
+    URL_ATTRIBUTE_REGEX,
+    (match, attribute: string, doubleValue, singleValue, bareValue) => {
+      const value = String(doubleValue ?? singleValue ?? bareValue ?? "")
+      const normalized = decodeNumericHtmlEntities(value)
+        .replace(/[\u0000-\u0020]+/g, "")
+        .toLowerCase()
+      if (
+        normalized.startsWith("javascript:") ||
+        normalized.startsWith("vbscript:") ||
+        normalized.startsWith("data:text/html")
+      ) {
+        return ` ${attribute}="#"`
+      }
+      return match
+    },
+  )
+  sanitized = sanitized.replace(DANGEROUS_PROTOCOL_REGEX, "noop:")
 
   return sanitized
 }

--- a/src/lib/organization/profile-cleanup.ts
+++ b/src/lib/organization/profile-cleanup.ts
@@ -2,10 +2,7 @@ import { stripHtml } from "@/lib/markdown/convert"
 
 const HTML_TEXT_FIELDS = new Set([
   "description",
-  "vision",
-  "mission",
   "need",
-  "values",
   "originStory",
   "theoryOfChange",
   "origin_story",

--- a/src/lib/queries/public-map-index.ts
+++ b/src/lib/queries/public-map-index.ts
@@ -17,6 +17,7 @@ import {
   inferPublicMapGroups,
   type PublicMapGroupKey,
 } from "@/lib/public-map/groups"
+import { resolveOrganizationNarrativePlainText } from "@/lib/roadmap"
 
 export type PublicMapProgramPreview = {
   id: string
@@ -265,6 +266,9 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
   return orgRows
     .map((row) => {
       const profile = (row.profile ?? {}) as Record<string, unknown>
+      const mission = resolveOrganizationNarrativePlainText(profile, "mission")
+      const vision = resolveOrganizationNarrativePlainText(profile, "vision")
+      const values = resolveOrganizationNarrativePlainText(profile, "values")
       const programs = topProgramsByOrgId.get(row.user_id) ?? []
       const activityLinks = activityLinksByOrgId.get(row.user_id) ?? []
       const groups = inferPublicMapGroups({
@@ -277,9 +281,7 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
         description:
           typeof profile["description"] === "string"
             ? profile["description"].trim() || null
-            : typeof profile["mission"] === "string"
-              ? profile["mission"].trim() || null
-              : null,
+            : mission || null,
         programs: activityLinks,
       })
 
@@ -298,12 +300,11 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
         name: readProfileString(profile, "name") ?? "Organization",
         tagline: readProfileString(profile, "tagline"),
         description:
-          readProfileString(profile, "description") ??
-          readProfileString(profile, "mission"),
+          (readProfileString(profile, "description") ?? mission) || null,
         boilerplate: readProfileString(profile, "boilerplate"),
-        vision: readProfileString(profile, "vision"),
-        mission: readProfileString(profile, "mission"),
-        values: readProfileString(profile, "values"),
+        vision: vision || null,
+        mission: mission || null,
+        values: values || null,
         needStatement: readProfileString(
           profile,
           "need",

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -5,6 +5,27 @@ export {
 } from "./roadmap/definitions"
 export { removeRoadmapSection, updateRoadmapSection } from "./roadmap/mutations"
 export {
+  findOrganizationNarrativeRevisionConflict,
+  getOrganizationNarrativeKeyForSectionId,
+  isOrganizationNarrativeKey,
+  normalizeOrganizationNarrativeHtml,
+  organizationNarrativeHtmlToPlainText,
+  ORGANIZATION_NARRATIVE_SECTION_IDS,
+  plainTextToNarrativeHtml,
+  resolveOrganizationNarrativePlainText,
+  resolveOrganizationNarrativeRevisions,
+  resolveOrganizationNarratives,
+  resolveLegacyOrganizationNarratives,
+  updateOrganizationNarrativeSection,
+  updateOrganizationNarratives,
+} from "./roadmap/organization-narratives"
+export { planMissionVisionValuesMigration } from "./roadmap/mvv-migration"
+export { runMissionVisionValuesMigration } from "./roadmap/mvv-migration-runner"
+export {
+  applyApprovedMissionVisionValuesReview,
+  proposeMissionVisionValuesReview,
+} from "./roadmap/mvv-review"
+export {
   cleanupRoadmapTestSections,
   resolveRoadmapHeroUrl,
   resolveRoadmapSections,
@@ -20,3 +41,20 @@ export type {
   RoadmapSectionDefinition,
   RoadmapSectionStatus,
 } from "./roadmap/types"
+export type {
+  OrganizationNarrativeKey,
+  OrganizationNarrativeRevisions,
+  OrganizationNarratives,
+} from "./roadmap/organization-narratives"
+export type {
+  MvvMigrationAction,
+  MvvMigrationPlan,
+} from "./roadmap/mvv-migration"
+export type {
+  MvvMigrationOrganizationReport,
+  MvvMigrationRun,
+} from "./roadmap/mvv-migration-runner"
+export type {
+  MvvReviewExtract,
+  MvvReviewProposal,
+} from "./roadmap/mvv-review"

--- a/src/lib/roadmap/definitions.ts
+++ b/src/lib/roadmap/definitions.ts
@@ -25,14 +25,36 @@ export const SECTION_DEFINITIONS: RoadmapSectionDefinition[] = [
   },
   {
     id: "mission_vision_values",
-    title: "Mission, Vision, Values",
+    title: "Mission",
     slug: "mission-vision-values",
-    subtitle: "Your guiding statements and principles.",
-    titleExample: "Example: Our mission and vision",
-    subtitleExample: "Example: The values that guide our decisions",
-    prompt: "State the mission, vision, and values in clear language.",
+    subtitle: "What you do, who you serve, and the difference you make.",
+    titleExample: "Example: Our mission",
+    subtitleExample: "Example: The purpose that guides our work",
+    prompt: "State your mission in clear language.",
     placeholder:
-      "State the mission in one clear sentence, then describe the vision of the future you are working toward. List 3-5 values and describe how they guide decisions.",
+      "State what your organization does, who it serves, and the difference the work makes. Keep the mission clear, specific, and grounded in real work.",
+  },
+  {
+    id: "vision",
+    title: "Vision",
+    slug: "vision",
+    subtitle: "The future you are working to create.",
+    titleExample: "Example: Our vision",
+    subtitleExample: "Example: What success looks like in the future",
+    prompt: "Describe the future your work is helping create.",
+    placeholder:
+      "Describe what will be different for people and communities if your work succeeds. Focus on the lasting future you want to help create.",
+  },
+  {
+    id: "values",
+    title: "Values",
+    slug: "values",
+    subtitle: "The principles that guide decisions and behavior.",
+    titleExample: "Example: Our core values",
+    subtitleExample: "Example: How we commit to doing the work",
+    prompt: "Define the values that guide your organization.",
+    placeholder:
+      "List the principles your organization will not compromise and explain how each value should guide decisions, relationships, and behavior.",
   },
   {
     id: "theory_of_change",

--- a/src/lib/roadmap/helpers.ts
+++ b/src/lib/roadmap/helpers.ts
@@ -16,6 +16,15 @@ import type {
 const TEST_SECTION_TITLES = new Set(["test", "testing", "foundations"])
 const DEPRECATED_SECTION_IDS = new Set(["strategic_roadmap"])
 const DEPRECATED_SECTION_SLUGS = new Set(["strategic-roadmap"])
+const LEGACY_TEMPLATE_TITLES = new Map([
+  ["mission_vision_values", new Set(["Mission, Vision, Values"])],
+])
+const LEGACY_TEMPLATE_SUBTITLES = new Map([
+  [
+    "mission_vision_values",
+    new Set(["Your guiding statements and principles."]),
+  ],
+])
 const ROADMAP_SECTION_LAYOUTS = new Set<RoadmapSection["layout"]>([
   "square",
   "vertical",
@@ -25,6 +34,20 @@ const ROADMAP_SECTION_STATUSES = new Set<RoadmapSectionStatus>([
   "not_started",
   "in_progress",
   "complete",
+])
+const STORED_SECTION_KEYS = new Set([
+  "id",
+  "title",
+  "subtitle",
+  "slug",
+  "content",
+  "imageUrl",
+  "lastUpdated",
+  "isPublic",
+  "layout",
+  "status",
+  "ctaLabel",
+  "ctaUrl",
 ])
 
 export const isRecord = (
@@ -97,9 +120,12 @@ export function buildRoadmapSection(
   const templateTitle = fallback?.title ?? ""
   const templateSubtitle = fallback?.subtitle || ""
   const storedTitleIsTemplate =
-    templateTitle.length > 0 && storedTitle === templateTitle.trim()
+    (templateTitle.length > 0 && storedTitle === templateTitle.trim()) ||
+    Boolean(LEGACY_TEMPLATE_TITLES.get(id)?.has(storedTitle))
   const storedSubtitleIsTemplate =
-    templateSubtitle.length > 0 && storedSubtitle === templateSubtitle.trim()
+    (templateSubtitle.length > 0 &&
+      storedSubtitle === templateSubtitle.trim()) ||
+    Boolean(LEGACY_TEMPLATE_SUBTITLES.get(id)?.has(storedSubtitle))
   const effectiveStoredTitle = storedTitleIsTemplate ? "" : storedTitle
   const effectiveStoredSubtitle = storedSubtitleIsTemplate ? "" : storedSubtitle
   const title = effectiveStoredTitle || templateTitle
@@ -149,6 +175,11 @@ export function buildRoadmapSection(
       : storedTitle.length > 0
         ? `Write about ${storedTitle}.`
         : "Start writing...")
+  const storageExtras = stored
+    ? Object.fromEntries(
+        Object.entries(stored).filter(([key]) => !STORED_SECTION_KEYS.has(key)),
+      )
+    : {}
 
   return {
     id,
@@ -171,6 +202,7 @@ export function buildRoadmapSection(
     templateSubtitle,
     titleIsTemplate,
     subtitleIsTemplate,
+    storageExtras,
   }
 }
 
@@ -234,6 +266,7 @@ export function ensureUniqueSlugs(sections: RoadmapSection[]): RoadmapSection[] 
 
 export function serializeRoadmapSections(sections: RoadmapSection[]) {
   return sections.map((section) => ({
+    ...(section.storageExtras ?? {}),
     id: section.id,
     title: section.title,
     subtitle: section.subtitle,

--- a/src/lib/roadmap/homework.ts
+++ b/src/lib/roadmap/homework.ts
@@ -39,13 +39,37 @@ const ROADMAP_HOMEWORK_TARGETS: Record<
   mission_vision_values: [
     {
       classSlug: "mission-vision-values",
+      moduleSlug: "mission",
+      label: "Mission statement",
+    },
+    {
+      classSlug: "mission-vision-values",
+      moduleIdx: 1,
+      label: "Mission statement",
+    },
+  ],
+  vision: [
+    {
+      classSlug: "mission-vision-values",
+      moduleSlug: "vision",
+      label: "Vision statement",
+    },
+    {
+      classSlug: "mission-vision-values",
+      moduleIdx: 2,
+      label: "Vision statement",
+    },
+  ],
+  values: [
+    {
+      classSlug: "mission-vision-values",
       moduleSlug: "values",
-      label: "Mission, vision, values summary",
+      label: "Core values",
     },
     {
       classSlug: "mission-vision-values",
       moduleIdx: 3,
-      label: "Mission, vision, values summary",
+      label: "Core values",
     },
   ],
   theory_of_change: [

--- a/src/lib/roadmap/mvv-migration-runner.ts
+++ b/src/lib/roadmap/mvv-migration-runner.ts
@@ -1,0 +1,102 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database, Json } from "@/lib/supabase"
+
+import {
+  planMissionVisionValuesMigration,
+  type MvvMigrationAction,
+} from "./mvv-migration"
+import {
+  proposeMissionVisionValuesReview,
+  type MvvReviewProposal,
+} from "./mvv-review"
+
+export type MvvMigrationOrganizationReport = {
+  organizationId: string
+  organizationName: string | null
+  actions: MvvMigrationAction[]
+  changed: boolean
+  reviewRequired: boolean
+  reviewProposal: MvvReviewProposal | null
+  applied: boolean
+  error?: string
+}
+
+export type MvvMigrationRun = {
+  mode: "dry-run" | "apply"
+  reports: MvvMigrationOrganizationReport[]
+}
+
+/**
+ * Runs a read-only inventory by default. Applying is intentionally limited to
+ * one explicit organization and uses the row revision to reject stale writes.
+ */
+export async function runMissionVisionValuesMigration({
+  supabase,
+  organizationId,
+  apply = false,
+}: {
+  supabase: SupabaseClient<Database, "public">
+  organizationId?: string
+  apply?: boolean
+}): Promise<MvvMigrationRun> {
+  const normalizedOrganizationId = organizationId?.trim() ?? ""
+  if (apply && !normalizedOrganizationId) {
+    throw new Error("Apply requires one explicit organization id.")
+  }
+
+  let query = supabase
+    .from("organizations")
+    .select("user_id, profile, updated_at")
+    .order("created_at", { ascending: true })
+
+  if (normalizedOrganizationId) {
+    query = query.eq("user_id", normalizedOrganizationId)
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+
+  const reports: MvvMigrationOrganizationReport[] = []
+  for (const row of data ?? []) {
+    const profile = (row.profile ?? {}) as Record<string, unknown>
+    const plan = planMissionVisionValuesMigration(profile)
+    const organizationName =
+      typeof profile.name === "string" && profile.name.trim()
+        ? profile.name.trim()
+        : null
+    const report: MvvMigrationOrganizationReport = {
+      organizationId: row.user_id,
+      organizationName,
+      actions: plan.actions,
+      changed: plan.changed,
+      reviewRequired: plan.reviewRequired,
+      reviewProposal: plan.reviewRequired
+        ? proposeMissionVisionValuesReview(profile)
+        : null,
+      applied: false,
+    }
+
+    if (apply && plan.changed) {
+      const { data: updatedRow, error: updateError } = await supabase
+        .from("organizations")
+        .update({ profile: plan.nextProfile as Json })
+        .eq("user_id", row.user_id)
+        .eq("updated_at", row.updated_at)
+        .select("user_id")
+        .maybeSingle<{ user_id: string }>()
+
+      if (updateError) {
+        report.error = updateError.message
+      } else if (!updatedRow) {
+        report.error = "Organization changed after the migration was planned."
+      } else {
+        report.applied = true
+      }
+    }
+
+    reports.push(report)
+  }
+
+  return { mode: apply ? "apply" : "dry-run", reports }
+}

--- a/src/lib/roadmap/mvv-migration.ts
+++ b/src/lib/roadmap/mvv-migration.ts
@@ -1,0 +1,114 @@
+import {
+  normalizeOrganizationNarrativeHtml,
+  resolveLegacyOrganizationNarratives,
+  resolveOrganizationNarratives,
+  updateOrganizationNarratives,
+  type OrganizationNarrativeKey,
+  type OrganizationNarratives,
+} from "./organization-narratives"
+import { isRecord } from "./helpers"
+
+export type MvvMigrationAction = {
+  key: OrganizationNarrativeKey
+  result: "preserved" | "copied_legacy" | "empty" | "conflict"
+  sourceHash: string | null
+  targetHash: string | null
+}
+
+export type MvvMigrationPlan = {
+  actions: MvvMigrationAction[]
+  changed: boolean
+  nextProfile: Record<string, unknown>
+  reviewRequired: boolean
+}
+
+function stableTextHash(value: string): string | null {
+  if (!value) return null
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+function comparable(value: string): string {
+  return value.replace(/\s+/g, " ").trim()
+}
+
+export function planMissionVisionValuesMigration(
+  profile: Record<string, unknown> | null | undefined,
+  options: { now?: string } = {}
+): MvvMigrationPlan {
+  const sourceProfile = isRecord(profile) ? profile : {}
+  const canonical = resolveOrganizationNarratives(sourceProfile, {
+    includeLegacyFallback: false,
+  })
+  const legacy = resolveLegacyOrganizationNarratives(sourceProfile)
+  const updates: Partial<OrganizationNarratives> = {}
+  const actions = (
+    ["mission", "vision", "values"] as OrganizationNarrativeKey[]
+  ).map<MvvMigrationAction>((key) => {
+    const targetValue = canonical[key]
+    const sourceValue = legacy[key]
+    const normalizedSource = normalizeOrganizationNarrativeHtml(sourceValue)
+
+    if (targetValue.trim()) {
+      const conflict =
+        normalizedSource.trim().length > 0 &&
+        comparable(normalizedSource) !== comparable(targetValue)
+      return {
+        key,
+        result: conflict ? "conflict" : "preserved",
+        sourceHash: stableTextHash(normalizedSource),
+        targetHash: stableTextHash(targetValue),
+      }
+    }
+
+    if (!normalizedSource.trim()) {
+      return {
+        key,
+        result: "empty",
+        sourceHash: null,
+        targetHash: null,
+      }
+    }
+
+    updates[key] = normalizedSource
+    return {
+      key,
+      result: "copied_legacy",
+      sourceHash: stableTextHash(normalizedSource),
+      targetHash: stableTextHash(normalizedSource),
+    }
+  })
+
+  const changed = Object.keys(updates).length > 0
+  let nextProfile = changed
+    ? updateOrganizationNarratives(sourceProfile, updates).nextProfile
+    : { ...sourceProfile }
+
+  if (changed) {
+    const roadmap = isRecord(nextProfile.roadmap)
+      ? { ...(nextProfile.roadmap as Record<string, unknown>) }
+      : {}
+    const migrations = isRecord(roadmap.migrations)
+      ? { ...(roadmap.migrations as Record<string, unknown>) }
+      : {}
+    migrations.mvvSplitV1 = {
+      appliedAt: options.now ?? new Date().toISOString(),
+      actions,
+    }
+    roadmap.migrations = migrations
+    nextProfile = { ...nextProfile, roadmap }
+  }
+
+  return {
+    actions,
+    changed,
+    nextProfile,
+    reviewRequired:
+      canonical.mission.trim().length > 0 ||
+      actions.some((action) => action.result === "conflict"),
+  }
+}

--- a/src/lib/roadmap/mvv-review.ts
+++ b/src/lib/roadmap/mvv-review.ts
@@ -1,0 +1,182 @@
+import { stripHtml } from "@/lib/markdown/convert"
+
+import {
+  resolveLegacyOrganizationNarratives,
+  resolveOrganizationNarratives,
+  updateOrganizationNarratives,
+  type OrganizationNarrativeKey,
+  type OrganizationNarratives,
+} from "./organization-narratives"
+
+type ReviewableNarrativeKey = Exclude<OrganizationNarrativeKey, "mission">
+
+export type MvvReviewExtract = {
+  content: string
+  heading: string
+  sourceStart: number
+  sourceEnd: number
+}
+
+export type MvvReviewProposal = {
+  combinedContent: string
+  combinedContentHash: string
+  legacy: OrganizationNarratives
+  extracts: Record<ReviewableNarrativeKey, MvvReviewExtract | null>
+  notes: Record<ReviewableNarrativeKey, string>
+}
+
+const HEADING_PATTERN = /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi
+const HEADING_LABELS: Record<ReviewableNarrativeKey, Set<string>> = {
+  vision: new Set(["vision", "our vision", "vision statement"]),
+  values: new Set([
+    "values",
+    "our values",
+    "core values",
+    "our core values",
+    "values statement",
+  ]),
+}
+
+function hashContent(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+function normalizeHeading(value: string): string {
+  return stripHtml(value)
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+export function proposeMissionVisionValuesReview(
+  profile: Record<string, unknown> | null | undefined
+): MvvReviewProposal {
+  const combinedContent = resolveOrganizationNarratives(profile, {
+    includeLegacyFallback: false,
+  }).mission
+  const headings = Array.from(combinedContent.matchAll(HEADING_PATTERN)).map(
+    (match) => ({
+      heading: stripHtml(match[2] ?? ""),
+      label: normalizeHeading(match[2] ?? ""),
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + match[0].length,
+    })
+  )
+
+  const extracts = { vision: null, values: null } as Record<
+    ReviewableNarrativeKey,
+    MvvReviewExtract | null
+  >
+  const notes = { vision: "", values: "" } as Record<
+    ReviewableNarrativeKey,
+    string
+  >
+
+  for (const key of ["vision", "values"] as const) {
+    const matches = headings.filter((heading) =>
+      HEADING_LABELS[key].has(heading.label)
+    )
+    if (matches.length === 0) {
+      notes[key] = `No explicit ${key} heading found.`
+      continue
+    }
+    if (matches.length > 1) {
+      notes[key] = `Multiple ${key} headings found; manual selection required.`
+      continue
+    }
+
+    const heading = matches[0]
+    const nextHeading = headings.find((entry) => entry.start > heading.end)
+    const sourceEnd = nextHeading?.start ?? combinedContent.length
+    const content = combinedContent.slice(heading.end, sourceEnd).trim()
+    if (stripHtml(content).length < 3) {
+      notes[key] = `The ${key} heading has no usable content.`
+      continue
+    }
+
+    extracts[key] = {
+      content,
+      heading: heading.heading,
+      sourceStart: heading.end,
+      sourceEnd,
+    }
+    notes[key] =
+      `Reliable extract found under the explicit ${heading.heading} heading.`
+  }
+
+  return {
+    combinedContent,
+    combinedContentHash: hashContent(combinedContent),
+    legacy: resolveLegacyOrganizationNarratives(profile),
+    extracts,
+    notes,
+  }
+}
+
+export function applyApprovedMissionVisionValuesReview({
+  profile,
+  proposal,
+  approved,
+}: {
+  profile: Record<string, unknown> | null | undefined
+  proposal: MvvReviewProposal
+  approved: Partial<Record<ReviewableNarrativeKey, boolean>>
+}): {
+  nextProfile: Record<string, unknown>
+  applied: ReviewableNarrativeKey[]
+  skipped: Record<ReviewableNarrativeKey, string>
+  error?: string
+} {
+  const currentCombined = resolveOrganizationNarratives(profile, {
+    includeLegacyFallback: false,
+  }).mission
+  if (hashContent(currentCombined) !== proposal.combinedContentHash) {
+    return {
+      nextProfile: { ...(profile ?? {}) },
+      applied: [],
+      skipped: { vision: "", values: "" },
+      error:
+        "Combined Mission content changed after review. Generate a new proposal.",
+    }
+  }
+
+  const canonical = resolveOrganizationNarratives(profile, {
+    includeLegacyFallback: false,
+  })
+  const updates: Partial<OrganizationNarratives> = {}
+  const applied: ReviewableNarrativeKey[] = []
+  const skipped = { vision: "", values: "" } as Record<
+    ReviewableNarrativeKey,
+    string
+  >
+
+  for (const key of ["vision", "values"] as const) {
+    if (!approved[key]) {
+      skipped[key] = "Not approved."
+      continue
+    }
+    if (canonical[key].trim()) {
+      skipped[key] = "Canonical section is already populated."
+      continue
+    }
+    const extract = proposal.extracts[key]
+    if (!extract) {
+      skipped[key] = "No reliable extract is available."
+      continue
+    }
+    updates[key] = extract.content
+    applied.push(key)
+  }
+
+  return {
+    nextProfile: updateOrganizationNarratives(profile, updates).nextProfile,
+    applied,
+    skipped,
+  }
+}

--- a/src/lib/roadmap/organization-narratives.ts
+++ b/src/lib/roadmap/organization-narratives.ts
@@ -1,0 +1,225 @@
+import { stripHtml } from "@/lib/markdown/convert"
+import { sanitizeHtml } from "@/lib/markdown/sanitize"
+
+import { updateRoadmapSection } from "./mutations"
+import { resolveRoadmapSections } from "./sections"
+import type { RoadmapSection } from "./types"
+
+export const ORGANIZATION_NARRATIVE_SECTION_IDS = {
+  mission: "mission_vision_values",
+  vision: "vision",
+  values: "values",
+} as const
+
+export type OrganizationNarrativeKey =
+  keyof typeof ORGANIZATION_NARRATIVE_SECTION_IDS
+
+export type OrganizationNarratives = Record<OrganizationNarrativeKey, string>
+export type OrganizationNarrativeRevisions = Record<
+  OrganizationNarrativeKey,
+  string | null
+>
+
+const ORGANIZATION_NARRATIVE_KEYS = Object.keys(
+  ORGANIZATION_NARRATIVE_SECTION_IDS
+) as OrganizationNarrativeKey[]
+
+function readLegacyNarrative(
+  profile: Record<string, unknown> | null | undefined,
+  key: OrganizationNarrativeKey
+): string {
+  const value = profile?.[key]
+  if (typeof value === "string") return value.trim()
+  if (!Array.isArray(value)) return ""
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean)
+    .join("\n")
+}
+
+export function resolveLegacyOrganizationNarratives(
+  profile: Record<string, unknown> | null | undefined
+): OrganizationNarratives {
+  return ORGANIZATION_NARRATIVE_KEYS.reduce<OrganizationNarratives>(
+    (result, key) => {
+      result[key] = readLegacyNarrative(profile, key)
+      return result
+    },
+    { mission: "", vision: "", values: "" }
+  )
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+export function plainTextToNarrativeHtml(value: string): string {
+  return value
+    .trim()
+    .split(/\n{2,}/)
+    .map(
+      (paragraph) => `<p>${escapeHtml(paragraph).replaceAll("\n", "<br>")}</p>`
+    )
+    .join("")
+}
+
+export function normalizeOrganizationNarrativeHtml(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ""
+  const hasHtmlElement = /<[a-z][^>]*>/i.test(trimmed)
+  return sanitizeHtml(
+    hasHtmlElement ? trimmed : plainTextToNarrativeHtml(trimmed)
+  ).trim()
+}
+
+export function organizationNarrativeHtmlToPlainText(value: string): string {
+  return stripHtml(
+    value
+      .replace(
+        /<\/(?:h[1-6]|div|blockquote|pre|table|thead|tbody|tfoot|tr)>/gi,
+        "\n\n"
+      )
+      .replace(
+        /<(?:h[1-6]|div|blockquote|pre|table|thead|tbody|tfoot|tr)\b[^>]*>/gi,
+        ""
+      )
+  )
+}
+
+export function isOrganizationNarrativeKey(
+  value: string
+): value is OrganizationNarrativeKey {
+  return ORGANIZATION_NARRATIVE_KEYS.includes(value as OrganizationNarrativeKey)
+}
+
+export function getOrganizationNarrativeKeyForSectionId(
+  sectionId: string
+): OrganizationNarrativeKey | null {
+  const normalized = sectionId.trim()
+  return (
+    ORGANIZATION_NARRATIVE_KEYS.find(
+      (key) => ORGANIZATION_NARRATIVE_SECTION_IDS[key] === normalized
+    ) ?? null
+  )
+}
+
+export function resolveOrganizationNarratives(
+  profile: Record<string, unknown> | null | undefined,
+  options: { includeLegacyFallback?: boolean } = {}
+): OrganizationNarratives {
+  const includeLegacyFallback = options.includeLegacyFallback !== false
+  const sectionById = new Map(
+    resolveRoadmapSections(profile).map((section) => [section.id, section])
+  )
+
+  return ORGANIZATION_NARRATIVE_KEYS.reduce<OrganizationNarratives>(
+    (result, key) => {
+      const sectionId = ORGANIZATION_NARRATIVE_SECTION_IDS[key]
+      const section = sectionById.get(sectionId)
+      const content = section?.content ?? ""
+      result[key] =
+        content.trim().length > 0 ||
+        Boolean(section && section.lastUpdated !== null) ||
+        !includeLegacyFallback
+          ? content
+          : normalizeOrganizationNarrativeHtml(
+              readLegacyNarrative(profile, key)
+            )
+      return result
+    },
+    { mission: "", vision: "", values: "" }
+  )
+}
+
+export function resolveOrganizationNarrativePlainText(
+  profile: Record<string, unknown> | null | undefined,
+  key: OrganizationNarrativeKey
+): string {
+  return organizationNarrativeHtmlToPlainText(
+    resolveOrganizationNarratives(profile)[key]
+  )
+}
+
+export function resolveOrganizationNarrativeRevisions(
+  profile: Record<string, unknown> | null | undefined
+): OrganizationNarrativeRevisions {
+  const sectionById = new Map(
+    resolveRoadmapSections(profile).map((section) => [section.id, section])
+  )
+  return ORGANIZATION_NARRATIVE_KEYS.reduce<OrganizationNarrativeRevisions>(
+    (result, key) => {
+      result[key] =
+        sectionById.get(ORGANIZATION_NARRATIVE_SECTION_IDS[key])?.lastUpdated ??
+        null
+      return result
+    },
+    { mission: null, vision: null, values: null }
+  )
+}
+
+export function findOrganizationNarrativeRevisionConflict({
+  profile,
+  updates,
+  expectedRevisions,
+}: {
+  profile: Record<string, unknown> | null | undefined
+  updates: Partial<OrganizationNarratives>
+  expectedRevisions: Partial<OrganizationNarrativeRevisions> | null | undefined
+}): OrganizationNarrativeKey | null {
+  if (!expectedRevisions) return null
+  const current = resolveOrganizationNarrativeRevisions(profile)
+  return (
+    ORGANIZATION_NARRATIVE_KEYS.find(
+      (key) =>
+        typeof updates[key] === "string" &&
+        Object.prototype.hasOwnProperty.call(expectedRevisions, key) &&
+        expectedRevisions[key] !== current[key]
+    ) ?? null
+  )
+}
+
+export function updateOrganizationNarratives(
+  profile: Record<string, unknown> | null | undefined,
+  updates: Partial<OrganizationNarratives>
+): {
+  nextProfile: Record<string, unknown>
+  sections: Partial<Record<OrganizationNarrativeKey, RoadmapSection>>
+} {
+  let nextProfile = { ...(profile ?? {}) }
+  const sections: Partial<Record<OrganizationNarrativeKey, RoadmapSection>> = {}
+
+  for (const key of ORGANIZATION_NARRATIVE_KEYS) {
+    const value = updates[key]
+    if (typeof value !== "string") continue
+    const result = updateOrganizationNarrativeSection(nextProfile, key, {
+      content: value,
+    })
+    nextProfile = result.nextProfile
+    sections[key] = result.section
+  }
+
+  return { nextProfile, sections }
+}
+
+export function updateOrganizationNarrativeSection(
+  profile: Record<string, unknown> | null | undefined,
+  key: OrganizationNarrativeKey,
+  updates: Parameters<typeof updateRoadmapSection>[2]
+): { nextProfile: Record<string, unknown>; section: RoadmapSection } {
+  return updateRoadmapSection(
+    profile,
+    ORGANIZATION_NARRATIVE_SECTION_IDS[key],
+    {
+      ...updates,
+      content:
+        typeof updates.content === "string"
+          ? normalizeOrganizationNarrativeHtml(updates.content)
+          : updates.content,
+    }
+  )
+}

--- a/src/lib/roadmap/types.ts
+++ b/src/lib/roadmap/types.ts
@@ -37,6 +37,7 @@ export type RoadmapSection = RoadmapSectionDefinition & {
   templateSubtitle: string
   titleIsTemplate: boolean
   subtitleIsTemplate: boolean
+  storageExtras?: Record<string, unknown>
 }
 
 export type StoredSection = {
@@ -52,6 +53,7 @@ export type StoredSection = {
   status?: unknown
   ctaLabel?: unknown
   ctaUrl?: unknown
+  [key: string]: unknown
 }
 
 export type StoredRoadmap = {

--- a/supabase/migrations/20260801190000_split_mission_vision_values_roadmap_sections.sql
+++ b/supabase/migrations/20260801190000_split_mission_vision_values_roadmap_sections.sql
@@ -1,0 +1,22 @@
+set search_path = public;
+
+-- Keep the historical Mission roadmap id for link and completion compatibility,
+-- while giving Vision and Values their own canonical roadmap sections.
+update module_assignments as assignment
+set schema = jsonb_set(
+  coalesce(assignment.schema, '{}'::jsonb),
+  '{roadmap_section}',
+  to_jsonb(
+    case module.slug
+      when 'mission' then 'mission_vision_values'
+      when 'vision' then 'vision'
+      when 'values' then 'values'
+    end
+  ),
+  true
+)
+from modules as module
+join classes as class on class.id = module.class_id
+where assignment.module_id = module.id
+  and class.slug = 'mission-vision-values'
+  and module.slug in ('mission', 'vision', 'values');

--- a/supabase/migrations/20260801191000_update_search_index_canonical_mission.sql
+++ b/supabase/migrations/20260801191000_update_search_index_canonical_mission.sql
@@ -1,0 +1,250 @@
+set check_function_bodies = off;
+set search_path = public;
+
+create or replace function public.organization_narrative_plain_text(
+  p_profile jsonb,
+  p_section_id text,
+  p_legacy_key text
+)
+returns text
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  with target as (
+    select section
+    from (
+      select entry as section
+      from jsonb_array_elements(
+        case
+          when jsonb_typeof(p_profile->'roadmap'->'sections') = 'array'
+            then p_profile->'roadmap'->'sections'
+          else '[]'::jsonb
+        end
+      ) as entry
+      where entry->>'id' = p_section_id
+
+      union all
+
+      select entry as section
+      from jsonb_each(
+        case
+          when jsonb_typeof(p_profile->'roadmap'->'sections') = 'object'
+            then p_profile->'roadmap'->'sections'
+          else '{}'::jsonb
+        end
+      ) as stored(key, entry)
+      where coalesce(entry->>'id', stored.key) = p_section_id
+    ) candidates
+    limit 1
+  ),
+  resolved as (
+    select case
+      when target.section is not null
+        and (
+          btrim(coalesce(target.section->>'content', '')) <> ''
+          or target.section->>'lastUpdated' is not null
+        )
+        then coalesce(target.section->>'content', '')
+      when jsonb_typeof(p_profile->p_legacy_key) = 'string'
+        then coalesce(p_profile->>p_legacy_key, '')
+      when jsonb_typeof(p_profile->p_legacy_key) = 'array'
+        then coalesce((
+          select string_agg(value, E'\n')
+          from jsonb_array_elements_text(p_profile->p_legacy_key) as value
+        ), '')
+      else ''
+    end as content
+    from (select 1) seed
+    left join target on true
+  )
+  select btrim(
+    regexp_replace(
+      regexp_replace(content, '<[^>]*>', ' ', 'g'),
+      '[[:space:]]+',
+      ' ',
+      'g'
+    )
+  )
+  from resolved;
+$$;
+
+create or replace view search_index as
+  select
+    'class:' || c.id::text as id,
+    c.title as label,
+    coalesce(c.subtitle, c.description) as subtitle,
+    '/accelerator/class/' || c.slug as href,
+    'Classes'::text as group_name,
+    'academy'::text as scope,
+    null::uuid as user_id,
+    false::boolean as is_public,
+    c.is_published as is_published,
+    setweight(to_tsvector('english', coalesce(c.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(c.subtitle, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(c.description, '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(c.slug, '')), 'D') as tsv
+  from classes c
+
+  union all
+
+  select
+    'module:' || m.id::text as id,
+    m.title as label,
+    c.title as subtitle,
+    '/accelerator/class/' || c.slug || '/module/' || coalesce(m.index_in_class, m.idx, 1) as href,
+    'Modules'::text as group_name,
+    'academy'::text as scope,
+    null::uuid as user_id,
+    false::boolean as is_public,
+    (m.is_published and c.is_published) as is_published,
+    setweight(to_tsvector('english', coalesce(m.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(m.description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(c.title, '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(c.slug, '')), 'D') as tsv
+  from modules m
+  join classes c on c.id = m.class_id
+
+  union all
+
+  select
+    'question:' || ma.module_id::text || ':' || field.ordinality::text as id,
+    coalesce(field.value->>'label', field.value->>'name') as label,
+    concat_ws(' · ', c.title, m.title) as subtitle,
+    '/accelerator/class/' || c.slug || '/module/' || coalesce(m.index_in_class, m.idx, 1) as href,
+    'Questions'::text as group_name,
+    'academy'::text as scope,
+    null::uuid as user_id,
+    false::boolean as is_public,
+    (m.is_published and c.is_published) as is_published,
+    setweight(to_tsvector('english', coalesce(field.value->>'label', '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(field.value->>'name', '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(field.value->>'description', '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(m.title, '')), 'D') ||
+    setweight(to_tsvector('english', coalesce(c.title, '')), 'D') as tsv
+  from module_assignments ma
+  join modules m on m.id = ma.module_id
+  join classes c on c.id = m.class_id
+  cross join lateral jsonb_array_elements(
+    case
+      when jsonb_typeof(ma.schema->'fields') = 'array' then ma.schema->'fields'
+      else '[]'::jsonb
+    end
+  ) with ordinality as field(value, ordinality)
+  where btrim(coalesce(field.value->>'label', field.value->>'name', '')) <> ''
+
+  union all
+
+  select
+    'program:' || p.id::text as id,
+    coalesce(p.title, 'Untitled program') as label,
+    coalesce(p.subtitle, p.status_label) as subtitle,
+    '/my-organization?tab=programs&programId=' || p.id::text as href,
+    'Programs'::text as group_name,
+    'owner'::text as scope,
+    p.user_id as user_id,
+    false::boolean as is_public,
+    true::boolean as is_published,
+    setweight(to_tsvector('english', coalesce(p.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(p.subtitle, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(p.status_label, '')), 'C') as tsv
+  from programs p
+
+  union all
+
+  select
+    'org:' || o.user_id::text as id,
+    coalesce(o.profile->>'name', 'My organization') as label,
+    'Your organization'::text as subtitle,
+    '/my-organization'::text as href,
+    'My organization'::text as group_name,
+    'owner'::text as scope,
+    o.user_id as user_id,
+    false::boolean as is_public,
+    true::boolean as is_published,
+    setweight(to_tsvector('english', coalesce(o.profile->>'name', '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(o.profile->>'tagline', '')), 'B') ||
+    setweight(to_tsvector('english', public.organization_narrative_plain_text(o.profile, 'mission_vision_values', 'mission')), 'C') ||
+    setweight(to_tsvector('english', coalesce(o.profile->>'description', '')), 'C') as tsv
+  from organizations o
+
+  union all
+
+  select
+    'roadmap:' || o.user_id::text || ':' || coalesce(section.value->>'slug', section.value->>'id', section.ordinality::text) as id,
+    coalesce(section.value->>'title', 'Roadmap section') as label,
+    coalesce(section.value->>'subtitle', '') as subtitle,
+    '/my-organization/roadmap#' || coalesce(section.value->>'slug', section.value->>'id', section.ordinality::text) as href,
+    'Roadmap'::text as group_name,
+    'owner'::text as scope,
+    o.user_id as user_id,
+    o.is_public_roadmap as is_public,
+    true::boolean as is_published,
+    setweight(to_tsvector('english', coalesce(section.value->>'title', '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(section.value->>'subtitle', '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(section.value->>'content', '')), 'C') as tsv
+  from organizations o
+  cross join lateral jsonb_array_elements(
+    case
+      when jsonb_typeof(o.profile->'roadmap'->'sections') = 'array' then o.profile->'roadmap'->'sections'
+      else '[]'::jsonb
+    end
+  ) with ordinality as section(value, ordinality)
+
+  union all
+
+  select
+    'doc:' || o.user_id::text || ':' || doc.key as id,
+    coalesce(doc.value->>'name', doc.key) as label,
+    case doc.key
+      when 'verificationLetter' then '501(c)(3) determination letter'
+      when 'articlesOfIncorporation' then 'Articles of incorporation'
+      when 'bylaws' then 'Bylaws'
+      when 'stateRegistration' then 'State registration'
+      when 'goodStandingCertificate' then 'Certificate of good standing'
+      when 'w9' then 'W-9 form'
+      when 'taxExemptCertificate' then 'Tax exempt certificate'
+      else 'Document'
+    end as subtitle,
+    '/my-organization/documents'::text as href,
+    'Documents'::text as group_name,
+    'owner'::text as scope,
+    o.user_id as user_id,
+    false::boolean as is_public,
+    true::boolean as is_published,
+    setweight(to_tsvector('english', coalesce(doc.value->>'name', '')), 'A') ||
+    setweight(to_tsvector('english', doc.key), 'B') as tsv
+  from organizations o
+  cross join lateral jsonb_each(
+    case
+      when jsonb_typeof(o.profile->'documents') = 'object' then o.profile->'documents'
+      else '{}'::jsonb
+    end
+  ) as doc(key, value)
+
+  union all
+
+  select
+    'public-org:' || o.user_id::text as id,
+    coalesce(o.profile->>'name', o.public_slug) as label,
+    coalesce(o.profile->>'tagline', concat_ws(', ', o.profile->>'address_city', o.profile->>'address_state')) as subtitle,
+    '/' || o.public_slug as href,
+    'Community'::text as group_name,
+    'public'::text as scope,
+    o.user_id as user_id,
+    true::boolean as is_public,
+    true::boolean as is_published,
+    setweight(to_tsvector('english', coalesce(o.profile->>'name', '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(o.profile->>'tagline', '')), 'B') ||
+    setweight(to_tsvector('english', public.organization_narrative_plain_text(o.profile, 'mission_vision_values', 'mission')), 'C') ||
+    setweight(to_tsvector('english', coalesce(o.public_slug, '')), 'D') ||
+    setweight(to_tsvector('english', coalesce(o.profile->>'address_city', '')), 'D') ||
+    setweight(to_tsvector('english', coalesce(o.profile->>'address_state', '')), 'D') as tsv
+  from organizations o
+  where o.is_public and o.public_slug is not null;
+
+alter view public.search_index set (security_invoker = true);
+revoke all on public.search_index from public;
+revoke all on public.search_index from anon;
+revoke all on public.search_index from authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1757,7 +1757,7 @@ select
     when mv.slug = 'vision' then
       jsonb_build_object(
         'title', 'Vision Statement',
-        'roadmap_section', 'mission_vision_values',
+        'roadmap_section', 'vision',
         'completion_mode', 'all_answered',
         'fields', jsonb_build_array(
           jsonb_build_object(
@@ -1947,7 +1947,7 @@ select
     else
       jsonb_build_object(
         'title', 'Core Values',
-        'roadmap_section', 'mission_vision_values',
+        'roadmap_section', 'values',
         'completion_mode', 'all_answered',
         'fields', jsonb_build_array(
           jsonb_build_object(

--- a/tests/acceptance/mission-vision-values-unification.test.ts
+++ b/tests/acceptance/mission-vision-values-unification.test.ts
@@ -1,0 +1,449 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  applyApprovedMissionVisionValuesReview,
+  findOrganizationNarrativeRevisionConflict,
+  normalizeOrganizationNarrativeHtml,
+  organizationNarrativeHtmlToPlainText,
+  planMissionVisionValuesMigration,
+  proposeMissionVisionValuesReview,
+  resolveOrganizationNarratives,
+  resolveRoadmapSections,
+  updateOrganizationNarratives,
+} from "@/lib/roadmap"
+import { SECTION_DEFINITIONS } from "@/lib/roadmap/definitions"
+import { syncMappedAnswersToOrganizationProfile } from "@/app/api/modules/[id]/assignment-submission/_lib/profile-sync"
+
+const ROOT = process.cwd()
+
+function readSource(relativePath: string) {
+  return readFileSync(join(ROOT, relativePath), "utf8")
+}
+
+describe("Mission, Vision, and Values canonical roadmap contract", () => {
+  it("keeps the historical Mission id and inserts Vision and Values in order", () => {
+    expect(
+      SECTION_DEFINITIONS.slice(0, 6).map(({ id, title, slug }) => ({
+        id,
+        title,
+        slug,
+      }))
+    ).toEqual([
+      { id: "origin_story", title: "Origin Story", slug: "origin-story" },
+      { id: "need", title: "Need", slug: "need" },
+      {
+        id: "mission_vision_values",
+        title: "Mission",
+        slug: "mission-vision-values",
+      },
+      { id: "vision", title: "Vision", slug: "vision" },
+      { id: "values", title: "Values", slug: "values" },
+      {
+        id: "theory_of_change",
+        title: "Theory of Change",
+        slug: "theory-of-change",
+      },
+    ])
+  })
+
+  it("shows the renamed template without rewriting stored Mission content", () => {
+    const combined = "<h2>Mission</h2><p>Exact existing content.</p>\n"
+    const sections = resolveRoadmapSections({
+      roadmap: {
+        sections: [
+          {
+            id: "mission_vision_values",
+            title: "Mission, Vision, Values",
+            subtitle: "Your guiding statements and principles.",
+            slug: "mission-vision-values",
+            content: combined,
+            lastUpdated: "2026-07-01T12:00:00.000Z",
+            isPublic: true,
+            status: "complete",
+            customMetadata: { source: "member" },
+          },
+        ],
+      },
+    })
+    const mission = sections.find(({ id }) => id === "mission_vision_values")
+
+    expect(mission).toMatchObject({
+      title: "Mission",
+      slug: "mission-vision-values",
+      content: combined,
+      lastUpdated: "2026-07-01T12:00:00.000Z",
+      isPublic: true,
+      status: "complete",
+      storageExtras: { customMetadata: { source: "member" } },
+    })
+  })
+
+  it("copies legacy fields only into empty canonical sections", () => {
+    const combined = "<h2>Mission</h2><p>Do not alter this byte.  </p>\n"
+    const profile = {
+      mission: "A different legacy mission",
+      vision: "A future where everyone thrives.",
+      values: ["Equity", "Care"],
+      roadmap: {
+        heroUrl: "https://example.com/hero.jpg",
+        sections: [
+          {
+            id: "mission_vision_values",
+            title: "Mission, Vision, Values",
+            subtitle: "Your guiding statements and principles.",
+            slug: "mission-vision-values",
+            content: combined,
+            lastUpdated: "2026-07-01T12:00:00.000Z",
+            isPublic: true,
+            status: "complete",
+            customMetadata: { source: "member" },
+          },
+        ],
+      },
+    }
+    const plan = planMissionVisionValuesMigration(profile, {
+      now: "2026-08-01T12:00:00.000Z",
+    })
+    const nextSections = resolveRoadmapSections(plan.nextProfile)
+    const mission = nextSections.find(
+      ({ id }) => id === "mission_vision_values"
+    )
+    const vision = nextSections.find(({ id }) => id === "vision")
+    const values = nextSections.find(({ id }) => id === "values")
+
+    expect(plan.changed).toBe(true)
+    expect(plan.reviewRequired).toBe(true)
+    expect(plan.actions.map(({ key, result }) => [key, result])).toEqual([
+      ["mission", "conflict"],
+      ["vision", "copied_legacy"],
+      ["values", "copied_legacy"],
+    ])
+    expect(mission).toMatchObject({
+      content: combined,
+      lastUpdated: "2026-07-01T12:00:00.000Z",
+      isPublic: true,
+      status: "complete",
+      storageExtras: { customMetadata: { source: "member" } },
+    })
+    expect(vision).toMatchObject({
+      content: "<p>A future where everyone thrives.</p>",
+      isPublic: false,
+    })
+    expect(values).toMatchObject({
+      content: "<p>Equity<br>Care</p>",
+      isPublic: false,
+    })
+    expect(plan.nextProfile).toMatchObject({
+      mission: profile.mission,
+      vision: profile.vision,
+      values: profile.values,
+      roadmap: {
+        heroUrl: profile.roadmap.heroUrl,
+        migrations: {
+          mvvSplitV1: {
+            appliedAt: "2026-08-01T12:00:00.000Z",
+            actions: plan.actions,
+          },
+        },
+      },
+    })
+  })
+
+  it("never overwrites populated roadmap content and is idempotent", () => {
+    const profile = {
+      mission: "Legacy mission",
+      vision: "Legacy vision",
+      values: "Legacy values",
+      roadmap: {
+        sections: [
+          {
+            id: "mission_vision_values",
+            content: "<p>Canonical mission</p>",
+          },
+          { id: "vision", content: "<p>Canonical vision</p>" },
+          { id: "values", content: "<p>Canonical values</p>" },
+        ],
+      },
+    }
+    const first = planMissionVisionValuesMigration(profile)
+    const second = planMissionVisionValuesMigration(first.nextProfile)
+
+    expect(first.changed).toBe(false)
+    expect(first.actions.every(({ result }) => result === "conflict")).toBe(
+      true
+    )
+    expect(resolveOrganizationNarratives(first.nextProfile)).toEqual({
+      mission: "<p>Canonical mission</p>",
+      vision: "<p>Canonical vision</p>",
+      values: "<p>Canonical values</p>",
+    })
+    expect(second.changed).toBe(false)
+    expect(second.nextProfile).toEqual(first.nextProfile)
+  })
+
+  it("does not resurrect a legacy backup after a canonical section is cleared", () => {
+    expect(
+      resolveOrganizationNarratives({
+        vision: "Legacy backup",
+        roadmap: {
+          sections: [
+            {
+              id: "vision",
+              content: "",
+              lastUpdated: "2026-08-01T12:00:00.000Z",
+            },
+          ],
+        },
+      }).vision
+    ).toBe("")
+  })
+
+  it("preserves safe rich formatting and removes unsafe HTML", () => {
+    const rich =
+      '<h2>Purpose</h2><ul><li><strong>Care</strong></li></ul><img src="https://example.com/a.jpg"><script>alert(1)</script><svg onload=alert(2)></svg><a href="java&#x73;cript:alert(3)" onclick="alert(4)">link</a><img src=x onerror=alert(5)>'
+    const result = updateOrganizationNarratives({}, { mission: rich })
+    const mission = resolveOrganizationNarratives(result.nextProfile).mission
+
+    expect(mission).toContain("<h2>Purpose</h2>")
+    expect(mission).toContain("<strong>Care</strong>")
+    expect(mission).toContain('<img src="https://example.com/a.jpg">')
+    expect(mission).not.toContain("<script")
+    expect(mission).not.toContain("javascript:")
+    expect(mission).not.toContain("onclick")
+    expect(mission).not.toContain("onerror")
+    expect(mission).not.toContain("<svg")
+    expect(mission).not.toContain("&#x73;cript")
+    expect(
+      organizationNarrativeHtmlToPlainText(
+        "<h2>Mission</h2><p>Serve people.</p><h2>Values</h2><ul><li>Care</li></ul>"
+      )
+    ).toBe("Mission\n\nServe people.\n\nValues\n\n- Care")
+  })
+
+  it("detects stale narrative revisions", () => {
+    const profile = updateOrganizationNarratives(
+      {},
+      {
+        mission: "Current mission",
+      }
+    ).nextProfile
+
+    expect(
+      findOrganizationNarrativeRevisionConflict({
+        profile,
+        updates: { mission: "New mission" },
+        expectedRevisions: { mission: null },
+      })
+    ).toBe("mission")
+  })
+
+  it("proposes only explicit Vision and Values heading extracts", () => {
+    const combined =
+      "<h2>Mission</h2><p>Keep all combined content.</p><h2>Our Vision</h2><p>A thriving future.</p><h2>Core Values</h2><ul><li>Care</li><li>Equity</li></ul><h2>Notes</h2><p>Not part of values.</p>"
+    const profile = {
+      vision: "Legacy vision beside proposal",
+      values: ["Legacy value"],
+      roadmap: {
+        sections: [{ id: "mission_vision_values", content: combined }],
+      },
+    }
+    const proposal = proposeMissionVisionValuesReview(profile)
+
+    expect(proposal.combinedContent).toBe(combined)
+    expect(proposal.legacy).toEqual({
+      mission: "",
+      vision: "Legacy vision beside proposal",
+      values: "Legacy value",
+    })
+    expect(proposal.extracts.vision?.content).toBe("<p>A thriving future.</p>")
+    expect(proposal.extracts.values?.content).toBe(
+      "<ul><li>Care</li><li>Equity</li></ul>"
+    )
+
+    const applied = applyApprovedMissionVisionValuesReview({
+      profile,
+      proposal,
+      approved: { vision: true, values: true },
+    })
+    expect(applied.applied).toEqual(["vision", "values"])
+    expect(resolveOrganizationNarratives(applied.nextProfile)).toEqual({
+      mission: combined,
+      vision: "<p>A thriving future.</p>",
+      values: "<ul><li>Care</li><li>Equity</li></ul>",
+    })
+  })
+
+  it("refuses stale or unapproved manual-review proposals", () => {
+    const profile = {
+      roadmap: {
+        sections: [
+          {
+            id: "mission_vision_values",
+            content: "<h2>Vision</h2><p>Original proposal.</p>",
+          },
+        ],
+      },
+    }
+    const proposal = proposeMissionVisionValuesReview(profile)
+    const stale = applyApprovedMissionVisionValuesReview({
+      profile: {
+        roadmap: {
+          sections: [
+            {
+              id: "mission_vision_values",
+              content: "<h2>Vision</h2><p>Changed.</p>",
+            },
+          ],
+        },
+      },
+      proposal,
+      approved: { vision: true },
+    })
+    const unapproved = applyApprovedMissionVisionValuesReview({
+      profile,
+      proposal,
+      approved: {},
+    })
+
+    expect(stale.error).toContain("changed after review")
+    expect(stale.applied).toEqual([])
+    expect(unapproved.applied).toEqual([])
+    expect(unapproved.skipped.vision).toBe("Not approved.")
+  })
+})
+
+describe("Mission, Vision, and Values integration guardrails", () => {
+  it("writes invited-member answers to the supplied organization only", async () => {
+    const filters: Array<[string, unknown]> = []
+    let updatePayload: Record<string, unknown> | null = null
+    const selectQuery = {
+      eq(key: string, value: unknown) {
+        filters.push([key, value])
+        return this
+      },
+      async maybeSingle() {
+        return {
+          data: {
+            profile: { vision: "Legacy backup" },
+            updated_at: "2026-08-01T12:00:00.000Z",
+          },
+          error: null,
+        }
+      },
+    }
+    const updateQuery = {
+      eq(key: string, value: unknown) {
+        filters.push([key, value])
+        return this
+      },
+      select() {
+        return this
+      },
+      async maybeSingle() {
+        return { data: { user_id: "defy-org-id" }, error: null }
+      },
+    }
+    const supabase = {
+      from() {
+        return {
+          select() {
+            return selectQuery
+          },
+          update(payload: Record<string, unknown>) {
+            updatePayload = payload
+            return updateQuery
+          },
+        }
+      },
+    }
+
+    const result = await syncMappedAnswersToOrganizationProfile({
+      supabase: supabase as never,
+      organizationId: "defy-org-id",
+      sanitizedAnswers: { vision_final: "A thriving future." },
+      orgKeyMapping: { vision_final: "vision" },
+    })
+    const writtenProfile = updatePayload?.profile as Record<string, unknown>
+
+    expect(result).toEqual({ ok: true })
+    expect(filters).toContainEqual(["user_id", "defy-org-id"])
+    expect(filters).not.toContainEqual(["user_id", "invited-user-id"])
+    expect(writtenProfile.vision).toBe("Legacy backup")
+    expect(resolveOrganizationNarratives(writtenProfile).vision).toBe(
+      "<p>A thriving future.</p>"
+    )
+  })
+
+  it("updates curriculum mappings without changing the historical Mission id", () => {
+    const migration = readSource(
+      "supabase/migrations/20260801190000_split_mission_vision_values_roadmap_sections.sql"
+    )
+    const seed = readSource("supabase/seed.sql")
+
+    expect(migration).toContain("when 'mission' then 'mission_vision_values'")
+    expect(migration).toContain("when 'vision' then 'vision'")
+    expect(migration).toContain("when 'values' then 'values'")
+    expect(seed).toContain("'roadmap_section', 'vision'")
+    expect(seed).toContain("'roadmap_section', 'values'")
+  })
+
+  it("indexes canonical Mission content with legacy fallback", () => {
+    const migration = readSource(
+      "supabase/migrations/20260801191000_update_search_index_canonical_mission.sql"
+    )
+
+    expect(migration).toContain(
+      "public.organization_narrative_plain_text(o.profile, 'mission_vision_values', 'mission')"
+    )
+    expect(migration).toContain("target.section->>'lastUpdated' is not null")
+    expect(migration).toContain("p_profile->>p_legacy_key")
+    expect(migration).not.toContain("coalesce(o.profile->>'mission', '')")
+  })
+
+  it("syncs invited members through the active organization and surfaces failures", () => {
+    const route = readSource(
+      "src/app/api/modules/[id]/assignment-submission/route.ts"
+    )
+    const sync = readSource(
+      "src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts"
+    )
+
+    expect(route).toContain("organizationId: orgId")
+    expect(route).toContain("submissionSaved: true")
+    expect(route).not.toContain("organizationId: user.id")
+    expect(sync).toContain("updateOrganizationNarratives")
+    expect(sync).toContain('.eq("updated_at", organizationRow.updated_at)')
+  })
+
+  it("routes both editors through the shared narrative writer and stale-write checks", () => {
+    const roadmapAction = readSource("src/actions/roadmap.ts")
+    const organizationAction = readSource("src/actions/organization.ts")
+    const organizationEditor = readSource(
+      "src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx"
+    )
+
+    expect(roadmapAction).toContain("updateOrganizationNarrativeSection")
+    expect(roadmapAction).toContain("expectedLastUpdated")
+    expect(roadmapAction).toContain('.eq("updated_at", orgRow.updated_at)')
+    expect(organizationAction).toContain("updateOrganizationNarratives")
+    expect(organizationAction).toContain(
+      "findOrganizationNarrativeRevisionConflict"
+    )
+    expect(organizationAction).toContain('.eq("updated_at", orgRow.updated_at)')
+    expect(organizationEditor).toContain("<RichTextEditor")
+    expect(organizationEditor).toContain('name: "mission"')
+    expect(organizationEditor).toContain('name: "vision"')
+    expect(organizationEditor).toContain('name: "values"')
+  })
+
+  it("keeps migration execution dry-run by default and blocks bulk apply", () => {
+    const runner = readSource("src/lib/roadmap/mvv-migration-runner.ts")
+
+    expect(runner).toContain("apply = false")
+    expect(runner).toContain("Apply requires one explicit organization id.")
+    expect(runner).toContain('.eq("updated_at", row.updated_at)')
+  })
+})

--- a/tests/acceptance/origin-story-assignment-flow.test.ts
+++ b/tests/acceptance/origin-story-assignment-flow.test.ts
@@ -236,7 +236,7 @@ function visionStatementSchema() {
 
   return {
     title: "Vision Statement",
-    roadmap_section: "mission_vision_values",
+    roadmap_section: "vision",
     completion_mode: "all_answered",
     fields: [
       intro("vision_intro", "Defining your vision"),
@@ -294,7 +294,7 @@ function valuesStatementSchema() {
 
   return {
     title: "Core Values",
-    roadmap_section: "mission_vision_values",
+    roadmap_section: "values",
     completion_mode: "all_answered",
     fields: [
       intro("values_intro", "Defining your core values"),


### PR DESCRIPTION
## Summary

- keep `mission_vision_values` as the canonical Mission section and add first-class Vision and Values sections
- make roadmap and organization-profile editors write the same sanitized rich-text sections with optimistic concurrency protection
- fix invited-member assignment synchronization to resolve the active organization and surface failures
- route readiness, search, public map, admin, and curriculum readers through the canonical narrative contract
- add dry-run-first, idempotent migration planning and human-approved extraction review tooling

## Migration safety

- no production data was changed
- existing combined Mission content and legacy profile fields remain intact
- automatic apply is restricted to one explicit organization at a time
- Defy Ventures remains manual-only because its 5,646-character combined content has no reliable explicit Vision or Values headings

## Verification

- pre-push suite: 315 files passed, 1 skipped; 1,565 tests passed, 1 skipped
- lint, snapshots, build, visual regression, performance, structural guardrails, SQL helper, and browser checks passed locally
- RLS execution was skipped without an isolated test Supabase environment; existing membership policies were inspected
