### PR TITLE
[STEP S21] Restore production migration source history

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -9,3 +9,9 @@
 - Production dry-run only: 56 organizations, 10 profile-only, 8 combined-only, 8 both, 30 neither; 41 safe field copies; 16 manual reviews; 5 Vision and 2 Values heading extracts. Defy Ventures remains manual-only because its unchanged 5,646-character content has no explicit section headings. No production write occurred.
 - Full lint, snapshots, acceptance tests, build, visual regression, performance budgets, structure, routes, features, scaffold, thresholds, boundaries, storage, interaction, React Grab, workspace-surface, raw-button, supply-chain, large-file, SQL helper, and browser checks passed. RLS test execution skipped without a local test Supabase environment; existing membership policies were inspected. No deployment or data migration occurred.
 - Continue by reconciling the isolated branch with the dirty root's overlapping organization `brandVoice*`, roadmap `budgetRows`, and existing August runlog work. Deploy compatible code before any migration; then review and approve Defy manually before running copy-only migrations.
+
+2026-08-01 16:53 EDT - restored production migration source history.
+
+- Ran the explicitly approved Defy Ventures canary in single-organization apply mode. Mission remained unchanged, Vision and Values had no safe source content, the plan reported `changed: false` and `applied: false`, and the organization profile and revision remained identical.
+- Restored exact source copies of five migrations already applied to production but missing from `main`: `20260729223500`, `20260730223700`, `20260730223800`, `20260801130500`, and `20260801143000`.
+- Byte parity checks passed and the linked Supabase dry-run reported the remote database is up to date. No database or organization data changed during this source-history repair.

--- a/supabase/migrations/20260729223500_expand_org_brand_kit_profile_contract.sql
+++ b/supabase/migrations/20260729223500_expand_org_brand_kit_profile_contract.sql
@@ -1,0 +1,46 @@
+set check_function_bodies = off;
+set search_path = public;
+
+-- Organization profile data remains additive JSONB. This contract documents the
+-- Brand Kit keys written by the Organization editor and consumed by exports.
+comment on column public.organizations.profile is $$
+Organization profile JSON schema (selected keys):
+  name                       text
+  tagline                    text
+  description                text
+  publicUrl                  text (website URL)
+  newsletter                 text (URL)
+  twitter                    text (URL)
+  facebook                   text (URL)
+  linkedin                   text (URL)
+  instagram                  text (URL)
+  youtube                    text (URL)
+  tiktok                     text (URL)
+  github                     text (URL)
+
+Brand Kit assets:
+  logoUrl                    text (primary logo URL)
+  brandMarkUrl               text (compact logo mark URL)
+  headerUrl                  text (banner image URL)
+
+Brand Kit colors and typography:
+  brandPrimary               text (six-digit hex color)
+  brandColors                text[] (Dark, Light, Accent, then optional supporting colors)
+  brandThemePresetId         text
+  brandAccentPresetId        text
+  brandTypographyPresetId    text
+  brandTypography            jsonb ({ headings, body, code })
+
+Brand Voice:
+  brandVoiceAudience         text
+  brandVoiceTone             text
+  brandVoiceStyle            text
+  brandVoicePersonality      text
+  brandVoiceGuidelines       text
+  brandVoiceAvoid            text (newline-delimited guidance)
+
+Legacy:
+  boilerplate                text (retained for backward compatibility; no longer edited)
+
+Other keys may be present. The profile object is additive and backward-compatible.
+$$;

--- a/supabase/migrations/20260730223700_repair_misclassified_fiscal_documents.sql
+++ b/supabase/migrations/20260730223700_repair_misclassified_fiscal_documents.sql
@@ -1,0 +1,26 @@
+set check_function_bodies = off;
+set search_path = public;
+
+-- Older workflow versions allowed Form B agreement files to be accepted as
+-- supporting documents and allowed unverified uploads to satisfy the W-9 slot.
+-- Return those records to an actionable review state without deleting evidence.
+update public.fiscal_sponsorship_documents
+set
+  review_status = 'needs_info',
+  review_notes = case
+    when document_key = 'tax_id_confirmation'
+      then 'Complete and sign the IRS Form W-9 in Coach House, or upload the correct signed W-9 PDF.'
+    else 'This is a Form B agreement, not the supporting document requested for this requirement.'
+  end,
+  reviewed_at = timezone('utc', now()),
+  updated_at = timezone('utc', now())
+where review_status = 'accepted'
+  and document_key is not null
+  and (
+    (
+      document_key = 'tax_id_confirmation'
+      and (kind <> 'tax_form' or status <> 'executed')
+    )
+    or lower(title) ~ '(^|[^a-z0-9])form[-_[:space:]]*b([^a-z0-9]|$)'
+    or lower(title) like '%fiscal sponsorship agreement%'
+  );

--- a/supabase/migrations/20260730223800_restore_human_reviewed_fiscal_documents.sql
+++ b/supabase/migrations/20260730223800_restore_human_reviewed_fiscal_documents.sql
@@ -1,0 +1,30 @@
+set check_function_bodies = off;
+set search_path = public;
+
+-- Coach review is the authority for uploaded test documents. Restore only
+-- records changed by the prior filename-based repair, preserving their assets
+-- and reviewer.
+update public.fiscal_sponsorship_documents
+set
+  kind = 'tax_form',
+  status = 'executed',
+  review_status = 'accepted',
+  review_notes = null,
+  reviewed_at = timezone('utc', now()),
+  updated_at = timezone('utc', now())
+where document_key = 'tax_id_confirmation'
+  and review_status = 'needs_info'
+  and review_notes =
+    'Complete and sign the IRS Form W-9 in Coach House, or upload the correct signed W-9 PDF.'
+  and asset_id is not null
+  and mime = 'application/pdf';
+
+update public.fiscal_sponsorship_documents
+set
+  review_status = 'accepted',
+  review_notes = null,
+  reviewed_at = timezone('utc', now()),
+  updated_at = timezone('utc', now())
+where review_status = 'needs_info'
+  and review_notes =
+    'This is a Form B agreement, not the supporting document requested for this requirement.';

--- a/supabase/migrations/20260801130500_add_organization_people_segments.sql
+++ b/supabase/migrations/20260801130500_add_organization_people_segments.sql
@@ -1,0 +1,251 @@
+set check_function_bodies = off;
+set search_path = public;
+
+create table if not exists organization_people_segments (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references organizations(user_id) on delete cascade,
+  label text not null,
+  sort_order integer not null default 0,
+  created_by uuid references profiles(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint organization_people_segments_label_check
+    check (char_length(trim(label)) between 1 and 48),
+  constraint organization_people_segments_sort_order_check
+    check (sort_order >= 0)
+);
+
+create index if not exists organization_people_segments_org_order_idx
+  on organization_people_segments (org_id, sort_order, created_at, id);
+
+create table if not exists organization_people_segment_members (
+  segment_id uuid not null references organization_people_segments(id) on delete cascade,
+  person_id text not null,
+  added_by uuid references profiles(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  primary key (segment_id, person_id),
+  constraint organization_people_segment_members_person_id_check
+    check (char_length(trim(person_id)) between 1 and 128)
+);
+
+create index if not exists organization_people_segment_members_person_idx
+  on organization_people_segment_members (person_id, segment_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'set_updated_at_organization_people_segments'
+  ) then
+    create trigger set_updated_at_organization_people_segments
+      before update on organization_people_segments
+      for each row execute procedure public.handle_updated_at();
+  end if;
+end $$;
+
+-- Preserve any segments written to the compatibility profile key before this
+-- migration reached an environment.
+insert into organization_people_segments (
+  id,
+  org_id,
+  label,
+  sort_order,
+  created_by
+)
+select
+  (segment_entry ->> 'id')::uuid,
+  organization.user_id,
+  left(trim(segment_entry ->> 'label'), 48),
+  (segment_ordinality - 1)::integer,
+  organization.user_id
+from organizations organization
+cross join lateral jsonb_array_elements(
+  case
+    when jsonb_typeof(
+      organization.profile::jsonb -> 'workspace_people_segments_v1'
+    ) = 'array'
+      then organization.profile::jsonb -> 'workspace_people_segments_v1'
+    else '[]'::jsonb
+  end
+) with ordinality as legacy_segment(segment_entry, segment_ordinality)
+where coalesce(segment_entry ->> 'id', '')
+  ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+  and char_length(trim(coalesce(segment_entry ->> 'label', ''))) between 1 and 48
+on conflict (id) do nothing;
+
+insert into organization_people_segment_members (
+  segment_id,
+  person_id,
+  added_by
+)
+select
+  segment.id,
+  left(trim(member.value), 128),
+  organization.user_id
+from organizations organization
+cross join lateral jsonb_array_elements(
+  case
+    when jsonb_typeof(
+      organization.profile::jsonb -> 'workspace_people_segments_v1'
+    ) = 'array'
+      then organization.profile::jsonb -> 'workspace_people_segments_v1'
+    else '[]'::jsonb
+  end
+) as legacy_segment(segment_entry)
+join organization_people_segments segment
+  on segment.id = case
+    when coalesce(legacy_segment.segment_entry ->> 'id', '')
+      ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      then (legacy_segment.segment_entry ->> 'id')::uuid
+    else null
+  end
+  and segment.org_id = organization.user_id
+cross join lateral jsonb_array_elements_text(
+  case
+    when jsonb_typeof(legacy_segment.segment_entry -> 'memberIds') = 'array'
+      then legacy_segment.segment_entry -> 'memberIds'
+    else '[]'::jsonb
+  end
+) as member(value)
+where coalesce(legacy_segment.segment_entry ->> 'id', '')
+  ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+  and char_length(trim(member.value)) between 1 and 128
+on conflict (segment_id, person_id) do nothing;
+
+alter table organization_people_segments enable row level security;
+alter table organization_people_segments force row level security;
+alter table organization_people_segment_members enable row level security;
+alter table organization_people_segment_members force row level security;
+
+create policy "organization_people_segments_select"
+  on organization_people_segments
+  for select
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_segments.org_id
+        and membership.member_id = (select auth.uid())
+    )
+  );
+
+create policy "organization_people_segments_insert"
+  on organization_people_segments
+  for insert
+  to authenticated
+  with check (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_segments.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_segments_update"
+  on organization_people_segments
+  for update
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_segments.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  )
+  with check (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_segments.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_segments_delete"
+  on organization_people_segments
+  for delete
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_segments.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_segment_members_select"
+  on organization_people_segment_members
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from organization_people_segments segment
+      where segment.id = organization_people_segment_members.segment_id
+    )
+  );
+
+create policy "organization_people_segment_members_insert"
+  on organization_people_segment_members
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from organization_people_segments segment
+      where segment.id = organization_people_segment_members.segment_id
+        and (
+          public.is_admin()
+          or segment.org_id = (select auth.uid())
+          or exists (
+            select 1
+            from organization_memberships membership
+            where membership.org_id = segment.org_id
+              and membership.member_id = (select auth.uid())
+              and membership.role in ('owner', 'admin', 'staff')
+          )
+        )
+    )
+  );
+
+create policy "organization_people_segment_members_delete"
+  on organization_people_segment_members
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from organization_people_segments segment
+      where segment.id = organization_people_segment_members.segment_id
+        and (
+          public.is_admin()
+          or segment.org_id = (select auth.uid())
+          or exists (
+            select 1
+            from organization_memberships membership
+            where membership.org_id = segment.org_id
+              and membership.member_id = (select auth.uid())
+              and membership.role in ('owner', 'admin', 'staff')
+          )
+        )
+    )
+  );

--- a/supabase/migrations/20260801143000_add_organization_people_tags.sql
+++ b/supabase/migrations/20260801143000_add_organization_people_tags.sql
@@ -1,0 +1,252 @@
+set check_function_bodies = off;
+set search_path = public;
+
+create table if not exists organization_people_tags (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references organizations(user_id) on delete cascade,
+  label text not null,
+  color text not null default 'blue',
+  sort_order integer not null default 0,
+  created_by uuid references profiles(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint organization_people_tags_label_check
+    check (char_length(trim(label)) between 1 and 32),
+  constraint organization_people_tags_color_check
+    check (color in ('gray', 'red', 'orange', 'amber', 'green', 'teal', 'blue', 'violet', 'pink')),
+  constraint organization_people_tags_sort_order_check
+    check (sort_order >= 0)
+);
+
+create unique index if not exists organization_people_tags_org_label_idx
+  on organization_people_tags (org_id, lower(btrim(label)));
+
+create index if not exists organization_people_tags_org_order_idx
+  on organization_people_tags (org_id, sort_order, created_at, id);
+
+create table if not exists organization_people_tag_members (
+  tag_id uuid not null references organization_people_tags(id) on delete cascade,
+  person_id text not null,
+  added_by uuid references profiles(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  primary key (tag_id, person_id),
+  constraint organization_people_tag_members_person_id_check
+    check (char_length(trim(person_id)) between 1 and 128)
+);
+
+create index if not exists organization_people_tag_members_person_idx
+  on organization_people_tag_members (person_id, tag_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'set_updated_at_organization_people_tags'
+  ) then
+    create trigger set_updated_at_organization_people_tags
+      before update on organization_people_tags
+      for each row execute procedure public.handle_updated_at();
+  end if;
+end $$;
+
+-- Promote legacy person-level string tags into reusable organization tags.
+with legacy_tags as (
+  select
+    organization.user_id as org_id,
+    left(regexp_replace(trim(tag.value), '\s+', ' ', 'g'), 32) as label,
+    organization.user_id as created_by
+  from organizations organization
+  cross join lateral jsonb_array_elements(
+    case
+      when jsonb_typeof(organization.profile::jsonb -> 'org_people') = 'array'
+        then organization.profile::jsonb -> 'org_people'
+      else '[]'::jsonb
+    end
+  ) as person(value)
+  cross join lateral jsonb_array_elements_text(
+    case
+      when jsonb_typeof(person.value -> 'tags') = 'array'
+        then person.value -> 'tags'
+      else '[]'::jsonb
+    end
+  ) as tag(value)
+  where char_length(trim(tag.value)) > 0
+), unique_legacy_tags as (
+  select distinct on (org_id, lower(label))
+    org_id,
+    label,
+    created_by
+  from legacy_tags
+  where char_length(label) between 1 and 32
+  order by org_id, lower(label), label
+)
+insert into organization_people_tags (org_id, label, color, created_by)
+select org_id, label, 'blue', created_by
+from unique_legacy_tags
+on conflict do nothing;
+
+insert into organization_people_tag_members (tag_id, person_id, added_by)
+select distinct
+  reusable_tag.id,
+  left(trim(person.value ->> 'id'), 128),
+  organization.user_id
+from organizations organization
+cross join lateral jsonb_array_elements(
+  case
+    when jsonb_typeof(organization.profile::jsonb -> 'org_people') = 'array'
+      then organization.profile::jsonb -> 'org_people'
+    else '[]'::jsonb
+  end
+) as person(value)
+cross join lateral jsonb_array_elements_text(
+  case
+    when jsonb_typeof(person.value -> 'tags') = 'array'
+      then person.value -> 'tags'
+    else '[]'::jsonb
+  end
+) as legacy_tag(value)
+join organization_people_tags reusable_tag
+  on reusable_tag.org_id = organization.user_id
+  and lower(btrim(reusable_tag.label)) = lower(
+    left(regexp_replace(trim(legacy_tag.value), '\s+', ' ', 'g'), 32)
+  )
+where char_length(trim(coalesce(person.value ->> 'id', ''))) between 1 and 128
+on conflict (tag_id, person_id) do nothing;
+
+alter table organization_people_tags enable row level security;
+alter table organization_people_tags force row level security;
+alter table organization_people_tag_members enable row level security;
+alter table organization_people_tag_members force row level security;
+
+create policy "organization_people_tags_select"
+  on organization_people_tags
+  for select
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_tags.org_id
+        and membership.member_id = (select auth.uid())
+    )
+  );
+
+create policy "organization_people_tags_insert"
+  on organization_people_tags
+  for insert
+  to authenticated
+  with check (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_tags.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_tags_update"
+  on organization_people_tags
+  for update
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_tags.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  )
+  with check (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_tags.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_tags_delete"
+  on organization_people_tags
+  for delete
+  to authenticated
+  using (
+    public.is_admin()
+    or org_id = (select auth.uid())
+    or exists (
+      select 1
+      from organization_memberships membership
+      where membership.org_id = organization_people_tags.org_id
+        and membership.member_id = (select auth.uid())
+        and membership.role in ('owner', 'admin', 'staff')
+    )
+  );
+
+create policy "organization_people_tag_members_select"
+  on organization_people_tag_members
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from organization_people_tags tag
+      where tag.id = organization_people_tag_members.tag_id
+    )
+  );
+
+create policy "organization_people_tag_members_insert"
+  on organization_people_tag_members
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from organization_people_tags tag
+      where tag.id = organization_people_tag_members.tag_id
+        and (
+          public.is_admin()
+          or tag.org_id = (select auth.uid())
+          or exists (
+            select 1
+            from organization_memberships membership
+            where membership.org_id = tag.org_id
+              and membership.member_id = (select auth.uid())
+              and membership.role in ('owner', 'admin', 'staff')
+          )
+        )
+    )
+  );
+
+create policy "organization_people_tag_members_delete"
+  on organization_people_tag_members
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from organization_people_tags tag
+      where tag.id = organization_people_tag_members.tag_id
+        and (
+          public.is_admin()
+          or tag.org_id = (select auth.uid())
+          or exists (
+            select 1
+            from organization_memberships membership
+            where membership.org_id = tag.org_id
+              and membership.member_id = (select auth.uid())
+              and membership.role in ('owner', 'admin', 'staff')
+          )
+        )
+    )
+  );


### PR DESCRIPTION
## Summary

- Restores five migration files already applied to production but missing from main.
- Uses byte-identical source from the original dirty worktree.
- Records the approved Defy canary result.

## Production impact

No database command or organization-data write is performed by this PR. Linked Supabase dry-run reports the remote database is up to date.

## Verification

- Exact byte parity for all five migration files
- Linked Supabase db push dry-run: remote up to date
- Pre-push checks: 315 files passed, 1 skipped; 1,565 tests passed, 1 skipped
- Lint, structure, route, feature, threshold, boundary, workspace, snapshot, formatting, and large-file checks passed
- RLS test command skipped because the isolated worktree has no local test Supabase credentials