### PR TITLE
[STEP S23] Record MVV production rollout

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -20,3 +20,11 @@
 - Ran the explicitly approved Defy Ventures canary in single-organization apply mode. Mission remained unchanged, Vision and Values had no safe source content, the plan reported `changed: false` and `applied: false`, and the organization profile and revision remained identical.
 - Restored exact source copies of five migrations already applied to production but missing from `main`: `20260729223500`, `20260730223700`, `20260730223800`, `20260801130500`, and `20260801143000`.
 - Byte parity checks passed and the linked Supabase dry-run reported the remote database is up to date. No database or organization data changed during this source-history repair.
+
+2026-08-01 18:49 EDT - completed the copy-only Mission, Vision, and Values production migration.
+
+- Reconfirmed the approved inventory before writing: 56 organizations, 18 organizations with safe changes, 41 field copies, 16 original combined-content reviews, and no existing Vision or Values roadmap content.
+- Migrated all 18 eligible organizations and immediately verified each result. The idempotent resume path safely completed after the first test harness exceeded its five-second test timeout; the final audit reported 41 copied fields, zero remaining copies, and exact migration markers for every write.
+- Preserved all legacy organization fields and populated roadmap content. Defy Ventures' 5,646-character combined Mission remained unchanged and had no reliable automatic Vision or Values extract.
+- Generated read-only proposals for the 16 original combined-content organizations: five reliable Vision extracts and two reliable Values extracts. No proposal was written without human approval.
+- Verified production while authenticated: Southside Community Table showed the same migrated Values content in its roadmap and organization-profile editors; Defy Ventures' public profile rendered the unchanged canonical Mission. No browser write was submitted and no console errors appeared.


### PR DESCRIPTION
## Summary
- record the completed copy-only Mission, Vision, and Values production migration
- document exact migration and manual-review counts
- record authenticated production verification without additional writes

## Verification
- `git diff --check`
- focused resource-map acceptance file: 40 passed
- pre-push: 316 files passed, 1 skipped; 1,575 tests passed, 1 skipped
- browser: Southside roadmap/profile parity and Defy public Mission; no console errors