### PR TITLE
[STEP S24] Refresh public map organizations after profile saves

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -28,3 +28,9 @@
 - Preserved all legacy organization fields and populated roadmap content. Defy Ventures' 5,646-character combined Mission remained unchanged and had no reliable automatic Vision or Values extract.
 - Generated read-only proposals for the 16 original combined-content organizations: five reliable Vision extracts and two reliable Values extracts. No proposal was written without human approval.
 - Verified production while authenticated: Southside Community Table showed the same migrated Values content in its roadmap and organization-profile editors; Defy Ventures' public profile rendered the unchanged canonical Mission. No browser write was submitted and no console errors appeared.
+
+2026-08-02 21:57 EDT - fixed stale public-organization map data after profile saves.
+
+- Added tagged public-map cache invalidation whenever a public organization profile changes, while leaving private-only profile saves out of the public cache path.
+- Advanced the public-organization cache generation once so the corrected FOCUOS address and coordinates load immediately when this release reaches production.
+- Focused formatting, lint, cache acceptance tests, all `1,576` acceptance tests, snapshots, build, isolated `/find` visual checks, and performance budgets passed. RLS execution skipped without local test Supabase credentials. The branch remains gated by CI before merge and production verification.

--- a/src/actions/organization.ts
+++ b/src/actions/organization.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 "use server"
 
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 
 import { requireServerSession } from "@/lib/auth"
 import { geocodeOrganizationLocation } from "@/lib/geocoding/geocode"
@@ -434,6 +434,7 @@ function revalidateOrganizationViews({
   revalidatePath("/find")
 
   if (isPublic || wasPublic) {
+    revalidateTag("public-map-organizations", "max")
     revalidatePath("/community")
   }
 

--- a/src/lib/queries/public-map-index.ts
+++ b/src/lib/queries/public-map-index.ts
@@ -414,7 +414,7 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
 const fetchPublicMapOrganizationsCached = unstable_cache(
   async (): Promise<PublicMapOrganization[]> =>
     fetchPublicMapOrganizationsUncached(),
-  ["public-map-organizations-v5"],
+  ["public-map-organizations-v6"],
   { revalidate: 300, tags: ["public-map-organizations"] }
 )
 

--- a/tests/acceptance/public-map-organization-curation.test.ts
+++ b/tests/acceptance/public-map-organization-curation.test.ts
@@ -10,6 +10,16 @@ function readSource(relativePath: string) {
 }
 
 describe("public map organization curation", () => {
+  it("refreshes cached public organizations after profile changes", () => {
+    const organizationAction = readSource("src/actions/organization.ts")
+    const publicMapQuery = readSource("src/lib/queries/public-map-index.ts")
+
+    expect(organizationAction).toContain(
+      'revalidateTag("public-map-organizations", "max")'
+    )
+    expect(publicMapQuery).toContain('["public-map-organizations-v6"]')
+  })
+
   it("uses an admin-gated unpublish action instead of deleting org data", () => {
     const action = readSource("src/actions/public-map-organization-curation.ts")
     const migration = readSource(


### PR DESCRIPTION
## Summary
- invalidate the tagged public-map organization cache after public profile saves
- advance the cache generation so production reloads FOCUOS immediately
- cover the invalidation contract with an acceptance test

## Verification
- 1,576 acceptance tests passed
- production build passed
- isolated desktop/mobile `/find` visual checks passed
- performance budgets passed
- RLS skipped locally without test Supabase credentials