### PR TITLE
[STEP S25] Fix durable organization setup recovery

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -34,3 +34,10 @@
 - Added tagged public-map cache invalidation whenever a public organization profile changes, while leaving private-only profile saves out of the public cache path.
 - Advanced the public-organization cache generation once so the corrected FOCUOS address and coordinates load immediately when this release reaches production.
 - Focused formatting, lint, cache acceptance tests, all `1,576` acceptance tests, snapshots, build, isolated `/find` visual checks, and performance budgets passed. RLS execution skipped without local test Supabase credentials. The branch remains gated by CI before merge and production verification.
+
+2026-08-05 15:35 EDT - prepared durable organization-setup completion recovery.
+
+- Persisted accelerator completion when organization setup saves, recovered saved organizations during workspace loads, and advanced stale canvas state past the recovered setup step.
+- Added an idempotent migration for existing saved-organization owners and members without rewriting completed timestamps. Production read-only verification found 40 of 41 eligible users needed reconciliation, including Karissa.
+- The linked migration dry-run selected only `20260805145856_reconcile_organization_setup_progress.sql`; no production database write occurred.
+- `pnpm check:quality` passed against a dedicated clean-worktree server: lint, structure and boundary guards, snapshots, 1,583 acceptance tests, build, 29 visual tests, and performance budgets. RLS execution safely skipped because the isolated worktree had no test Supabase credentials.

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-accelerator-progress.ts
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-accelerator-progress.ts
@@ -1,11 +1,17 @@
 import type { FormationStatus } from "@/components/organization/org-profile-card/types"
 import { isCoreFormationModule } from "@/lib/accelerator/module-order"
+import {
+  applyOrganizationSetupAcceleratorProgressOverride,
+  hasSavedOrganizationSetup,
+} from "@/lib/accelerator/organization-setup"
 import type {
   AcceleratorProgressSummary,
   ModuleCardStatus,
 } from "@/lib/accelerator/progress"
 
-function buildAcceleratorProgressTotals(groups: AcceleratorProgressSummary["groups"]) {
+function buildAcceleratorProgressTotals(
+  groups: AcceleratorProgressSummary["groups"]
+) {
   let totalModules = 0
   let completedModules = 0
   let inProgressModules = 0
@@ -45,7 +51,7 @@ function resolveFormationOverrideStatus({
 
 export function applyFormationStatusAcceleratorProgressOverrides(
   summary: AcceleratorProgressSummary,
-  formationStatus: FormationStatus | null | undefined,
+  formationStatus: FormationStatus | null | undefined
 ): AcceleratorProgressSummary {
   const groups = summary.groups.map((group) => {
     let groupChanged = false
@@ -78,4 +84,24 @@ export function applyFormationStatusAcceleratorProgressOverrides(
     groups,
     ...buildAcceleratorProgressTotals(groups),
   }
+}
+
+export function applyOrganizationAcceleratorProgressOverrides(
+  summary: AcceleratorProgressSummary,
+  organization: {
+    name?: string | null
+    formationStatus?: FormationStatus | null
+  },
+  publicSlug: string | null | undefined
+) {
+  return applyFormationStatusAcceleratorProgressOverrides(
+    applyOrganizationSetupAcceleratorProgressOverride(
+      summary,
+      hasSavedOrganizationSetup({
+        organizationName: organization.name,
+        publicSlug,
+      })
+    ),
+    organization.formationStatus
+  )
 }

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers.ts
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers.ts
@@ -103,20 +103,43 @@ export function resolveOrganizationProfileComplete(initialProfile: {
 export function hydrateWorkspaceSeedAcceleratorState<
   TSeed extends WorkspaceSeedWithAcceleratorBoardState,
 >(workspaceSeed: TSeed, acceleratorTimeline: WorkspaceAcceleratorCardStep[]) {
-  const hasPersistedAcceleratorState =
-    Boolean(workspaceSeed.boardState.accelerator.activeStepId) ||
-    workspaceSeed.boardState.accelerator.completedStepIds.length > 0
   const hasTimeline = acceleratorTimeline.length > 0
-  if (!hasTimeline || hasPersistedAcceleratorState) return workspaceSeed
+  if (!hasTimeline) return workspaceSeed
 
-  const completedStepIds = acceleratorTimeline
-    .filter((step) => step.status === "completed")
-    .map((step) => step.id)
+  const completedStepIds = Array.from(
+    new Set([
+      ...workspaceSeed.boardState.accelerator.completedStepIds,
+      ...acceleratorTimeline
+        .filter((step) => step.status === "completed")
+        .map((step) => step.id),
+    ])
+  )
+  const persistedActiveStep = acceleratorTimeline.find(
+    (step) => step.id === workspaceSeed.boardState.accelerator.activeStepId
+  )
+  const recoveredOrganizationSetup =
+    persistedActiveStep?.status === "completed" &&
+    persistedActiveStep.moduleContext?.workspaceOnboarding?.view ===
+      "organization-setup" &&
+    !workspaceSeed.boardState.accelerator.completedStepIds.includes(
+      persistedActiveStep.id
+    )
   const activeStep =
-    acceleratorTimeline.find((step) => step.status === "in_progress") ??
-    acceleratorTimeline.find((step) => step.status !== "completed") ??
-    acceleratorTimeline[0] ??
-    null
+    persistedActiveStep && !recoveredOrganizationSetup
+      ? persistedActiveStep
+      : (acceleratorTimeline.find((step) => step.status === "in_progress") ??
+        acceleratorTimeline.find((step) => step.status !== "completed") ??
+        acceleratorTimeline.at(-1) ??
+        null)
+
+  if (
+    workspaceSeed.boardState.accelerator.activeStepId ===
+      (activeStep?.id ?? null) &&
+    completedStepIds.length ===
+      workspaceSeed.boardState.accelerator.completedStepIds.length
+  ) {
+    return workspaceSeed
+  }
 
   return {
     ...workspaceSeed,

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
@@ -20,7 +20,7 @@ import { loadFiscalSponsorshipProjectWorkflowSummary } from "@/features/fiscal-s
 import { completeOnboardingAction } from "../../onboarding/actions"
 import { buildOnboardingFlowDefaults } from "@/lib/onboarding/defaults"
 import { buildMyOrganizationCalendarView } from "./calendar"
-import { applyFormationStatusAcceleratorProgressOverrides } from "./my-organization-accelerator-progress"
+import { applyOrganizationAcceleratorProgressOverrides } from "./my-organization-accelerator-progress"
 import {
   buildAcceleratorTimelineModules,
   buildModuleGroupMetaById,
@@ -223,7 +223,6 @@ export default async function MyOrganizationPage({
       ]),
     { thresholdMs: 1_000 }
   )
-  const programs = programsResult
   const upcomingEvents = mapUpcomingEvents(upcomingEventsResult.data)
   const currentPlanTier = resolvePricingPlanTier(
     activeSubscriptionResult.data ?? null
@@ -232,9 +231,10 @@ export default async function MyOrganizationPage({
   const hasWorkspaceAcceleratorAccess =
     entitlements.hasAcceleratorAccess || entitlements.hasElectiveAccess
   const acceleratorProgressSummary =
-    applyFormationStatusAcceleratorProgressOverrides(
+    applyOrganizationAcceleratorProgressOverrides(
       acceleratorProgress,
-      initialProfile.formationStatus ?? null
+      initialProfile,
+      orgRow?.public_slug
     )
   const calendarView = buildMyOrganizationCalendarView({
     monthParam,
@@ -277,7 +277,7 @@ export default async function MyOrganizationPage({
   const initialTab = allowedTabs.includes(tabParam as ProfileTab)
     ? (tabParam as ProfileTab)
     : undefined
-  const programRows = (programs ?? []) as Array<{
+  const programRows = (programsResult ?? []) as Array<{
     goal_cents: number | null
     raised_cents: number | null
   }>
@@ -308,7 +308,7 @@ export default async function MyOrganizationPage({
       initialProgramId: programIdParam || null,
       initialTab,
       peopleNormalized,
-      programs,
+      programs: programsResult,
     })
   }
   const moduleGroupMetaById = buildModuleGroupMetaById(
@@ -335,7 +335,6 @@ export default async function MyOrganizationPage({
     if (!hasWorkspaceAcceleratorAccess) {
       redirect(getWorkspaceAcceleratorPaywallPath())
     }
-
     const boardResult = await supabase
       .from("organization_workspace_boards")
       .select("state")
@@ -467,7 +466,7 @@ export default async function MyOrganizationPage({
         initialProfile,
         peopleNormalized,
         profile,
-        programs,
+        programs: programsResult,
         publicSlug: orgRow?.public_slug ?? null,
         roadmapSections,
       }),

--- a/src/app/(dashboard)/onboarding/actions.ts
+++ b/src/app/(dashboard)/onboarding/actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation"
 
 import { fetchLearningEntitlements } from "@/lib/accelerator/entitlements"
+import { markOrganizationSetupModuleCompleted } from "@/lib/accelerator/organization-setup"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 import type { Json } from "@/lib/supabase"
 import { isSupabaseAuthSessionMissingError } from "@/lib/supabase/auth-errors"
@@ -337,6 +338,7 @@ export async function completeOnboardingAction(form: FormData) {
             workspace_onboarding_stage: 2,
             workspace_onboarding_active: true,
             workspace_onboarding_started_at: new Date().toISOString(),
+            workspace_onboarding_completed_at: null,
           }
         : {}),
     },
@@ -348,6 +350,13 @@ export async function completeOnboardingAction(form: FormData) {
       message: updateUserError.message,
     })
     throw supabaseErrorToError(updateUserError, "Unable to finish onboarding.")
+  }
+
+  if (requiresOrganizationSetup) {
+    await markOrganizationSetupModuleCompleted({
+      supabase,
+      userId: user.id,
+    })
   }
 
   if (intentFocus === "build") {

--- a/src/lib/accelerator/organization-setup.ts
+++ b/src/lib/accelerator/organization-setup.ts
@@ -1,0 +1,154 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type {
+  AcceleratorProgressSummary,
+  ModuleCard,
+} from "@/lib/accelerator/progress"
+import { supabaseErrorToError } from "@/lib/supabase/errors"
+import type { Database } from "@/lib/supabase/types"
+
+export const ORGANIZATION_SETUP_MODULE_SLUG = "organization-setup"
+
+export const ORGANIZATION_SETUP_MODULE_SLUGS = [
+  ORGANIZATION_SETUP_MODULE_SLUG,
+  "workspace-setup",
+  "workspace-onboarding-organization-setup",
+] as const
+
+const ORGANIZATION_SETUP_MODULE_SLUG_SET = new Set<string>(
+  ORGANIZATION_SETUP_MODULE_SLUGS
+)
+
+function isOrganizationSetupModule(module: Pick<ModuleCard, "slug" | "title">) {
+  const slug = module.slug.trim().toLowerCase()
+  const title = module.title.trim().toLowerCase()
+  return (
+    ORGANIZATION_SETUP_MODULE_SLUG_SET.has(slug) ||
+    title === "organization setup"
+  )
+}
+
+export function hasSavedOrganizationSetup({
+  organizationName,
+  publicSlug,
+}: {
+  organizationName: string | null | undefined
+  publicSlug: string | null | undefined
+}) {
+  return Boolean(organizationName?.trim() && publicSlug?.trim())
+}
+
+function buildProgressTotals(groups: AcceleratorProgressSummary["groups"]) {
+  const modules = groups.flatMap((group) => group.modules)
+  const completedModules = modules.filter(
+    (module) => module.status === "completed"
+  ).length
+  const inProgressModules = modules.filter(
+    (module) => module.status === "in_progress"
+  ).length
+
+  return {
+    totalModules: modules.length,
+    completedModules,
+    inProgressModules,
+    percent:
+      modules.length > 0
+        ? Math.round((completedModules / modules.length) * 100)
+        : 0,
+  }
+}
+
+export function applyOrganizationSetupAcceleratorProgressOverride(
+  summary: AcceleratorProgressSummary,
+  organizationSetupComplete: boolean
+): AcceleratorProgressSummary {
+  if (!organizationSetupComplete) return summary
+
+  let changed = false
+  const groups = summary.groups.map((group) => ({
+    ...group,
+    modules: group.modules.map((module) => {
+      if (module.status === "completed" || !isOrganizationSetupModule(module)) {
+        return module
+      }
+      changed = true
+      return { ...module, status: "completed" as const }
+    }),
+  }))
+
+  if (!changed) return summary
+  return { ...summary, groups, ...buildProgressTotals(groups) }
+}
+
+export async function markOrganizationSetupModuleCompleted({
+  supabase,
+  userId,
+}: {
+  supabase: SupabaseClient<Database, "public">
+  userId: string
+}) {
+  const { data: setupModules, error: moduleError } = await supabase
+    .from("modules")
+    .select("id, slug")
+    .in("slug", [...ORGANIZATION_SETUP_MODULE_SLUGS])
+    .eq("is_published", true)
+    .returns<Array<{ id: string; slug: string }>>()
+
+  if (moduleError) {
+    throw supabaseErrorToError(
+      moduleError,
+      "Unable to load organization setup progress."
+    )
+  }
+  const setupModule = ORGANIZATION_SETUP_MODULE_SLUGS.map((slug) =>
+    setupModules?.find((module) => module.slug === slug)
+  ).find((module): module is { id: string; slug: string } => Boolean(module))
+  if (!setupModule) {
+    throw new Error("Organization setup progress is unavailable.")
+  }
+
+  const { data: existingProgress, error: existingProgressError } =
+    await supabase
+      .from("module_progress")
+      .select("status, completed_at")
+      .eq("user_id", userId)
+      .eq("module_id", setupModule.id)
+      .maybeSingle<{ status: string; completed_at: string | null }>()
+
+  if (existingProgressError) {
+    throw supabaseErrorToError(
+      existingProgressError,
+      "Unable to load organization setup progress."
+    )
+  }
+  if (existingProgress?.status === "completed") {
+    return {
+      changed: false,
+      completedAt: existingProgress.completed_at,
+      moduleId: setupModule.id,
+    }
+  }
+
+  const completedAt = new Date().toISOString()
+  const { error: progressError } = await supabase
+    .from("module_progress")
+    .upsert(
+      {
+        user_id: userId,
+        module_id: setupModule.id,
+        status: "completed",
+        completed_at: completedAt,
+        updated_at: completedAt,
+      },
+      { onConflict: "user_id,module_id" }
+    )
+
+  if (progressError) {
+    throw supabaseErrorToError(
+      progressError,
+      "Unable to complete organization setup."
+    )
+  }
+
+  return { changed: true, completedAt, moduleId: setupModule.id }
+}

--- a/supabase/migrations/20260805145856_reconcile_organization_setup_progress.sql
+++ b/supabase/migrations/20260805145856_reconcile_organization_setup_progress.sql
@@ -1,0 +1,71 @@
+set check_function_bodies = off;
+set search_path = public;
+
+do $$
+declare
+  v_completed_at timestamptz := timezone('utc', now());
+  v_setup_module_id uuid;
+begin
+  select id
+  into v_setup_module_id
+  from modules
+  where slug in (
+    'organization-setup',
+    'workspace-setup',
+    'workspace-onboarding-organization-setup'
+  )
+    and is_published = true
+  order by
+    case slug
+      when 'organization-setup' then 0
+      when 'workspace-setup' then 1
+      else 2
+    end
+  limit 1;
+
+  if v_setup_module_id is null then
+    raise exception 'Unable to reconcile organization setup progress: published setup module not found.';
+  end if;
+
+  with saved_organizations as (
+    select organizations.user_id as org_id
+    from organizations
+    where trim(coalesce(organizations.profile ->> 'name', '')) <> ''
+      and trim(coalesce(organizations.public_slug, '')) <> ''
+  ),
+  affected_users as (
+    select saved_organizations.org_id as user_id
+    from saved_organizations
+    inner join profiles on profiles.id = saved_organizations.org_id
+
+    union
+
+    select organization_memberships.member_id as user_id
+    from saved_organizations
+    inner join organization_memberships
+      on organization_memberships.org_id = saved_organizations.org_id
+    inner join profiles
+      on profiles.id = organization_memberships.member_id
+  )
+  insert into module_progress (
+    user_id,
+    module_id,
+    status,
+    completed_at,
+    updated_at
+  )
+  select
+    affected_users.user_id,
+    v_setup_module_id,
+    'completed'::module_progress_status,
+    v_completed_at,
+    v_completed_at
+  from affected_users
+  on conflict (user_id, module_id) do update
+  set
+    status = excluded.status,
+    completed_at = coalesce(module_progress.completed_at, excluded.completed_at),
+    updated_at = excluded.updated_at
+  where module_progress.status is distinct from 'completed'::module_progress_status
+    or module_progress.completed_at is null;
+end $$;

--- a/tests/acceptance/my-organization-page-content-helpers.test.ts
+++ b/tests/acceptance/my-organization-page-content-helpers.test.ts
@@ -1,13 +1,80 @@
 import { describe, expect, it } from "vitest"
 
 import { buildDefaultBoardState } from "@/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-layout"
-import { applyWorkspaceTutorialActivationToSeed } from "@/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers"
+import {
+  applyWorkspaceTutorialActivationToSeed,
+  hydrateWorkspaceSeedAcceleratorState,
+} from "@/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers"
+import type { WorkspaceAcceleratorCardStep } from "@/features/workspace-accelerator-card"
 import {
   buildWorkspaceCanvasTutorialCompletionHiddenCardIds,
   resolveWorkspaceCanvasTutorialStepCount,
 } from "@/features/workspace-canvas-tutorial"
 
 describe("my organization page content helpers", () => {
+  it("advances past recovered organization setup progress", () => {
+    const boardState = buildDefaultBoardState()
+    boardState.accelerator = {
+      activeStepId: "setup:lesson",
+      completedStepIds: [],
+    }
+    const baseStep = {
+      published: true,
+      stepKind: "lesson" as const,
+      stepDescription: null,
+      href: "/accelerator",
+      stepSequenceIndex: 0,
+      stepSequenceTotal: 2,
+      moduleSequenceIndex: 0,
+      moduleSequenceTotal: 2,
+      groupTitle: "Formation",
+      groupOrder: 0,
+      videoUrl: null,
+      durationMinutes: null,
+      resources: [],
+      hasAssignment: false,
+      hasDeck: false,
+    }
+    const steps: WorkspaceAcceleratorCardStep[] = [
+      {
+        ...baseStep,
+        id: "setup:lesson",
+        moduleId: "setup",
+        moduleSlug: "organization-setup",
+        moduleTitle: "Organization setup",
+        stepTitle: "Organization setup",
+        status: "completed",
+        moduleContext: {
+          classTitle: "Formation",
+          lessonNotesContent: null,
+          moduleResources: [],
+          assignmentFields: [],
+          assignmentSubmission: null,
+          completeOnSubmit: false,
+          workspaceOnboarding: { view: "organization-setup" },
+        },
+      },
+      {
+        ...baseStep,
+        id: "naming:lesson",
+        moduleId: "naming",
+        moduleSlug: "naming-your-nfp",
+        moduleTitle: "Naming your NFP",
+        stepTitle: "Naming your NFP",
+        status: "not_started",
+        stepSequenceIndex: 1,
+        moduleSequenceIndex: 1,
+      },
+    ]
+
+    const next = hydrateWorkspaceSeedAcceleratorState({ boardState }, steps)
+
+    expect(next.boardState.accelerator).toEqual({
+      activeStepId: "naming:lesson",
+      completedStepIds: ["setup:lesson"],
+    })
+  })
+
   it("preserves the current tutorial step on refresh activation", () => {
     const boardState = buildDefaultBoardState()
     boardState.onboardingFlow = {

--- a/tests/acceptance/onboarding-actions.test.ts
+++ b/tests/acceptance/onboarding-actions.test.ts
@@ -162,6 +162,20 @@ describe("completeOnboardingAction", () => {
       error: null,
     })
     const organizationsUpsertMock = vi.fn().mockResolvedValue({ error: null })
+    const setupModulesReturnsMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "organization_setup_module",
+          slug: "organization-setup",
+        },
+      ],
+      error: null,
+    })
+    const moduleProgressMaybeSingleMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    })
+    const moduleProgressUpsertMock = vi.fn().mockResolvedValue({ error: null })
     const updateUserMock = vi.fn().mockResolvedValue({ error: null })
 
     createSupabaseServerClientServerMock.mockResolvedValue({
@@ -210,6 +224,29 @@ describe("completeOnboardingAction", () => {
             upsert: organizationsUpsertMock,
           }
         }
+        if (table === "modules") {
+          return {
+            select: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  returns: setupModulesReturnsMock,
+                }),
+              }),
+            }),
+          }
+        }
+        if (table === "module_progress") {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: moduleProgressMaybeSingleMock,
+                }),
+              }),
+            }),
+            upsert: moduleProgressUpsertMock,
+          }
+        }
         throw new Error(`Unexpected table lookup: ${table}`)
       }),
     })
@@ -246,7 +283,22 @@ describe("completeOnboardingAction", () => {
       }),
       { onConflict: "user_id" },
     )
-    expect(updateUserMock).toHaveBeenCalled()
+    expect(updateUserMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workspace_onboarding_active: true,
+        workspace_onboarding_completed_at: null,
+        workspace_onboarding_stage: 2,
+      }),
+    })
+    expect(moduleProgressUpsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user_123",
+        module_id: "organization_setup_module",
+        status: "completed",
+        completed_at: expect.any(String),
+      }),
+      { onConflict: "user_id,module_id" },
+    )
     expect(destination).toBe("/workspace?onboarding_flow=1&onboarding_stage=2&source=onboarding")
   })
 

--- a/tests/acceptance/organization-setup-progress.test.ts
+++ b/tests/acceptance/organization-setup-progress.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  applyOrganizationSetupAcceleratorProgressOverride,
+  hasSavedOrganizationSetup,
+  markOrganizationSetupModuleCompleted,
+  ORGANIZATION_SETUP_MODULE_SLUGS,
+} from "@/lib/accelerator/organization-setup"
+import type { AcceleratorProgressSummary } from "@/lib/accelerator/progress"
+
+type OrganizationSetupSupabase = Parameters<
+  typeof markOrganizationSetupModuleCompleted
+>[0]["supabase"]
+
+function buildProgressClient({
+  existingProgress,
+}: {
+  existingProgress: { status: string; completed_at: string | null } | null
+}) {
+  const progressUpsert = vi.fn().mockResolvedValue({ error: null })
+  const from = vi.fn((table: string) => {
+    if (table === "modules") {
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              returns: vi.fn().mockResolvedValue({
+                data: [
+                  { id: "legacy", slug: "workspace-setup" },
+                  { id: "canonical", slug: "organization-setup" },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === "module_progress") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: existingProgress,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+        upsert: progressUpsert,
+      }
+    }
+    throw new Error(`Unexpected table: ${table}`)
+  })
+
+  return {
+    progressUpsert,
+    supabase: { from } as unknown as OrganizationSetupSupabase,
+  }
+}
+
+function buildSummary(): AcceleratorProgressSummary {
+  return {
+    groups: [
+      {
+        id: "formation",
+        title: "Formation",
+        description: null,
+        slug: "formation",
+        modules: [
+          {
+            id: "setup",
+            slug: "organization-setup",
+            title: "Organization setup",
+            description: null,
+            href: "/accelerator/setup",
+            status: "not_started",
+            index: 0,
+            hasNotes: false,
+          },
+          {
+            id: "next",
+            slug: "naming-your-nfp",
+            title: "Naming your NFP",
+            description: null,
+            href: "/accelerator/naming",
+            status: "in_progress",
+            index: 1,
+            hasNotes: false,
+          },
+        ],
+      },
+    ],
+    totalModules: 2,
+    completedModules: 0,
+    inProgressModules: 1,
+    percent: 0,
+  }
+}
+
+describe("organization setup accelerator progress", () => {
+  it("recognizes a saved organization as completed setup", () => {
+    expect(
+      hasSavedOrganizationSetup({
+        organizationName: "Bright Futures",
+        publicSlug: "bright-futures",
+      })
+    ).toBe(true)
+    expect(
+      hasSavedOrganizationSetup({
+        organizationName: "Bright Futures",
+        publicSlug: null,
+      })
+    ).toBe(false)
+  })
+
+  it("recovers setup completion without changing later modules", () => {
+    const next = applyOrganizationSetupAcceleratorProgressOverride(
+      buildSummary(),
+      true
+    )
+
+    expect(next.groups[0]?.modules.map((module) => module.status)).toEqual([
+      "completed",
+      "in_progress",
+    ])
+    expect(next.completedModules).toBe(1)
+    expect(next.inProgressModules).toBe(1)
+    expect(next.percent).toBe(50)
+  })
+
+  it("does not infer completion before organization details are saved", () => {
+    const summary = buildSummary()
+    expect(
+      applyOrganizationSetupAcceleratorProgressOverride(summary, false)
+    ).toBe(summary)
+  })
+
+  it("writes canonical durable progress for saved organizations", async () => {
+    const { progressUpsert, supabase } = buildProgressClient({
+      existingProgress: null,
+    })
+
+    const result = await markOrganizationSetupModuleCompleted({
+      supabase,
+      userId: "affected_user",
+    })
+
+    expect(result).toEqual({
+      changed: true,
+      completedAt: expect.any(String),
+      moduleId: "canonical",
+    })
+    expect(progressUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "affected_user",
+        module_id: "canonical",
+        status: "completed",
+      }),
+      { onConflict: "user_id,module_id" }
+    )
+  })
+
+  it("does not rewrite an existing completion timestamp", async () => {
+    const completedAt = "2026-08-01T12:00:00.000Z"
+    const { progressUpsert, supabase } = buildProgressClient({
+      existingProgress: { status: "completed", completed_at: completedAt },
+    })
+
+    const result = await markOrganizationSetupModuleCompleted({
+      supabase,
+      userId: "recovered_user",
+    })
+
+    expect(result).toEqual({
+      changed: false,
+      completedAt,
+      moduleId: "canonical",
+    })
+    expect(progressUpsert).not.toHaveBeenCalled()
+  })
+
+  it("backfills owners and members without rewriting completed rows", () => {
+    const source = readFileSync(
+      path.join(
+        process.cwd(),
+        "supabase/migrations/20260805145856_reconcile_organization_setup_progress.sql"
+      ),
+      "utf8"
+    )
+
+    for (const slug of ORGANIZATION_SETUP_MODULE_SLUGS) {
+      expect(source).toContain(`'${slug}'`)
+    }
+    expect(source).toContain("organization_memberships.member_id")
+    expect(source).toContain("on conflict (user_id, module_id) do update")
+    expect(source).toContain(
+      "module_progress.status is distinct from 'completed'::module_progress_status"
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Persist organization-setup accelerator completion when onboarding saves a real organization.
- Recover existing saved organizations on workspace load and advance stale canvas state.
- Backfill eligible owners and members without rewriting prior completion timestamps.

## Release Notes
- User-facing changes: founders with saved organization details can continue past Create your organization, including after reload.
- Operational changes: one idempotent Supabase migration reconciles 40 currently incomplete eligible users.
- Known risks or follow-ups: apply the migration after merge, then verify Karissa and the remaining candidate count.

## Checks
- [x] pnpm check:quality
- [x] pnpm check:prepush
- [x] Visual baselines unchanged; 29 visual tests passed
- [x] Current August runlog updated

## Manual QA
- [x] Authenticated local workspace showed Organization setup Complete
- [x] Completion survived reload and advanced to the next step

## Notes
Migration dry-run selected only 20260805145856_reconcile_organization_setup_progress.sql. No production database write has occurred. Rollback is code revert; the progress backfill is truthful durable completion derived from saved organization data.