### PR TITLE
[STEP S28] Open workspace Documents in data drawer

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2376,3 +2376,24 @@
 - Public production `/find` was independently confirmed healthy with `870`
   active resources and no browser errors before this fix. NWS weather and
   cooling-center promotion remains intentionally deferred.
+
+2026-08-10 13:16 EDT - enabled the scoped workspace drawer rollout and repaired Documents entry.
+
+- Confirmed the merged S27 code was live but the entire workspace-foundation
+  drawer remained disabled by its production rollout gate. Added
+  `WORKSPACE_FOUNDATION_ROLLOUT_ENABLED=1` and the active Southside Community
+  Table organization to `WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS` in the
+  `coachhouse` Vercel project for Production and Preview, then redeployed the
+  merged `9d5cd2bf` production build. Rollback is to disable the enabled flag.
+- Authenticated production verification confirms the drawer now renders on
+  `/workspace`, Documents opens the document index, Finance opens Activity and
+  History, and both `/workspace?drawer=documents` and
+  `/workspace?drawer=finance` select the requested tab.
+- Replaced the Documents ontology-group legacy route with the canonical
+  workspace Documents drawer URL, preserving link semantics and in-canvas
+  activation. Focused coverage passes `25/25`.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots,
+  `2,028` acceptance tests with one intentional skip, connected fiscal and
+  Finance RLS matrices, the `108`-route production build, `30/30` visuals, and
+  performance budgets. The optional generic RLS suite skipped without its
+  separate credentials.

--- a/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-canvas-v2/adapters/workspace-canvas-ontology-input-organization.ts
+++ b/src/app/(dashboard)/my-organization/_components/workspace-board/workspace-canvas-v2/adapters/workspace-canvas-ontology-input-organization.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/features/workspace-ontology"
 import {
   getOrganizationDocumentsPath,
+  getWorkspaceDrawerPath,
   getWorkspaceEditorPath,
 } from "@/lib/workspace/routes"
 
@@ -155,7 +156,7 @@ export function buildWorkspaceOrganizationOntologyRoot({
             ? "No documents available"
             : `${documents.filter((node) => node.status === "complete").length}/${documents.length} available`,
         relationshipLabel: "Next step",
-        href: getOrganizationDocumentsPath(),
+        href: getWorkspaceDrawerPath({ tab: "documents" }),
         actionLabel: "Open vault",
         children: documents,
       },

--- a/tests/acceptance/workspace-ontology-input.test.ts
+++ b/tests/acceptance/workspace-ontology-input.test.ts
@@ -206,7 +206,7 @@ describe("workspace ontology input", () => {
     ).toMatchObject({
       status: "missing",
       relationshipLabel: "Next step",
-      href: "/organization/documents",
+      href: "/workspace?drawer=documents",
     })
     expect(
       allNodes.find((node) => node.id === "ontology:organization:field:mission")


### PR DESCRIPTION
## Summary

- route the Documents ontology group to the canonical workspace drawer URL
- preserve legacy focused-document behavior while making the main Documents action open in-canvas
- record the scoped production workspace-foundation rollout and verification

## Validation

- focused drawer and ontology coverage: 25/25
- `pnpm check:quality`
- 2,028 acceptance tests passed with one intentional skip
- connected fiscal and Finance RLS matrices passed
- 108-route production build passed
- 30 visual checks passed
- performance budgets passed

## Production verification

The workspace-foundation rollout is enabled only for Southside Community Table. Authenticated production verification confirms the drawer renders on `/workspace`; Documents and Finance tabs work; and both deep links select the requested tab.