### PR TITLE
[STEP S29] Enable workspace foundation for all organizations

### DIFF
--- a/docs/plans/2026-08-06-batch-2-release-candidate.md
+++ b/docs/plans/2026-08-06-batch-2-release-candidate.md
@@ -76,6 +76,7 @@ Status: Preview PR #119 open; connected disposable preview proof passed
 - Selective access additionally requires a matching UUID in
   `WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS` or
   `WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS`.
+- Global access requires `*` in either allowlist variable.
 - Compatibility reads/writes remain unconditional. Finance remains inactive.
 
 ## Rollback plan

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2397,3 +2397,15 @@
   Finance RLS matrices, the `108`-route production build, `30/30` visuals, and
   performance budgets. The optional generic RLS suite skipped without its
   separate credentials.
+
+2026-08-10 13:58 EDT - prepared the workspace drawer for global rollout.
+
+- Added an explicit `*` allowlist mode so the enabled workspace foundation can
+  serve every authenticated organization while retaining UUID-scoped rollout
+  and the existing kill switch.
+- Added acceptance coverage for global organization and user wildcard modes and
+  documented the production configuration contract.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,029`
+  acceptance tests with one intentional skip, connected fiscal and Finance RLS,
+  the `108`-route production build, `30/30` visuals, and performance budgets.
+  The optional generic RLS suite skipped without its separate credentials.

--- a/src/lib/workspace/foundation-rollout.ts
+++ b/src/lib/workspace/foundation-rollout.ts
@@ -56,13 +56,18 @@ export function isWorkspaceFoundationRolloutEnabled({
   const normalizedUserId = userId.trim().toLowerCase()
   if (!normalizedOrgId || !normalizedUserId) return false
 
+  const organizationAllowlist = parseIdentifierAllowlist(
+    rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS
+  )
+  const userAllowlist = parseIdentifierAllowlist(
+    rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS
+  )
+
   return (
-    parseIdentifierAllowlist(
-      rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS
-    ).has(normalizedOrgId) ||
-    parseIdentifierAllowlist(
-      rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS
-    ).has(normalizedUserId)
+    organizationAllowlist.has("*") ||
+    userAllowlist.has("*") ||
+    organizationAllowlist.has(normalizedOrgId) ||
+    userAllowlist.has(normalizedUserId)
   )
 }
 

--- a/tests/acceptance/workspace-foundation-rollout.test.ts
+++ b/tests/acceptance/workspace-foundation-rollout.test.ts
@@ -80,6 +80,28 @@ describe("workspace foundation rollout", () => {
     ).toBe(false)
   })
 
+  it("allows every authenticated workspace identity with an explicit wildcard", () => {
+    expect(
+      isWorkspaceFoundationRolloutEnabled({
+        ...identity,
+        environment: {
+          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
+          WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS: "*",
+        },
+      })
+    ).toBe(true)
+    expect(
+      isWorkspaceFoundationRolloutEnabled({
+        orgId: "org-2",
+        userId: "user-2",
+        environment: {
+          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
+          WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS: "*",
+        },
+      })
+    ).toBe(true)
+  })
+
   it("preserves legacy destinations when later drawer routes are disabled", () => {
     const baseRequest = {
       acceleratorGroup: null,


### PR DESCRIPTION
## Summary
- add an explicit wildcard mode to the workspace foundation rollout gate
- preserve UUID-scoped rollout and the global kill switch
- document and test the global production configuration

## Validation
- `pnpm check:quality`
- 2,029 acceptance tests passed; one intentional skip
- connected fiscal and Finance RLS passed
- 108-route production build passed
- 30 visual checks passed
- performance budgets passed

## Rollout
After merge, set `WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS=*` for Production and Preview, redeploy, and verify the authenticated workspace drawer.