### PR TITLE
[STEP S30] Roll workspace foundation out to all users

### DIFF
--- a/docs/plans/2026-08-06-batch-2-release-candidate.md
+++ b/docs/plans/2026-08-06-batch-2-release-candidate.md
@@ -70,13 +70,11 @@ Status: Preview PR #119 open; connected disposable preview proof passed
   migration source, now lists every migration, and passes the connected RLS
   suite. The badge must not be represented as green.
 
-## Private rollout gate
+## Rollout gate
 
 - Default off: `WORKSPACE_FOUNDATION_ROLLOUT_ENABLED` must equal `1`.
-- Selective access additionally requires a matching UUID in
-  `WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS` or
-  `WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS`.
-- Global access requires `*` in either allowlist variable.
+- When enabled, the workspace foundation is available to every authenticated
+  organization member.
 - Compatibility reads/writes remain unconditional. Finance remains inactive.
 
 ## Rollback plan

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2409,3 +2409,14 @@
   acceptance tests with one intentional skip, connected fiscal and Finance RLS,
   the `108`-route production build, `30/30` visuals, and performance budgets.
   The optional generic RLS suite skipped without its separate credentials.
+
+2026-08-10 14:35 EDT - removed the organization-scoped workspace restriction.
+
+- Simplified the workspace foundation gate so the existing enabled flag serves
+  every authenticated organization member. The global kill switch remains the
+  rollback control; organization and user allowlists no longer limit access.
+- Updated acceptance coverage and the release contract for the all-user mode.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,028`
+  acceptance tests with one intentional skip, connected fiscal and Finance RLS,
+  the `108`-route production build, `30/30` visuals, and performance budgets.
+  The optional generic RLS suite skipped without its separate credentials.

--- a/src/lib/workspace/foundation-rollout.ts
+++ b/src/lib/workspace/foundation-rollout.ts
@@ -7,28 +7,10 @@ import {
 
 export const WORKSPACE_FOUNDATION_ROLLOUT_ENABLED_ENV =
   "WORKSPACE_FOUNDATION_ROLLOUT_ENABLED"
-export const WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS_ENV =
-  "WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS"
-export const WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS_ENV =
-  "WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS"
 
 type WorkspaceFoundationRolloutEnvironment = Partial<
-  Record<
-    | typeof WORKSPACE_FOUNDATION_ROLLOUT_ENABLED_ENV
-    | typeof WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS_ENV
-    | typeof WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS_ENV,
-    string | undefined
-  >
+  Record<typeof WORKSPACE_FOUNDATION_ROLLOUT_ENABLED_ENV, string | undefined>
 >
-
-function parseIdentifierAllowlist(value: string | undefined) {
-  return new Set(
-    (value ?? "")
-      .split(",")
-      .map((entry) => entry.trim().toLowerCase())
-      .filter(Boolean)
-  )
-}
 
 export function isWorkspaceFoundationRolloutEnabled({
   environment,
@@ -42,33 +24,13 @@ export function isWorkspaceFoundationRolloutEnabled({
   const rolloutEnvironment = environment ?? {
     WORKSPACE_FOUNDATION_ROLLOUT_ENABLED:
       process.env.WORKSPACE_FOUNDATION_ROLLOUT_ENABLED,
-    WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS:
-      process.env.WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS,
-    WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS:
-      process.env.WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS,
   }
 
   if (rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_ENABLED !== "1") {
     return false
   }
 
-  const normalizedOrgId = orgId.trim().toLowerCase()
-  const normalizedUserId = userId.trim().toLowerCase()
-  if (!normalizedOrgId || !normalizedUserId) return false
-
-  const organizationAllowlist = parseIdentifierAllowlist(
-    rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS
-  )
-  const userAllowlist = parseIdentifierAllowlist(
-    rolloutEnvironment.WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS
-  )
-
-  return (
-    organizationAllowlist.has("*") ||
-    userAllowlist.has("*") ||
-    organizationAllowlist.has(normalizedOrgId) ||
-    userAllowlist.has(normalizedUserId)
-  )
+  return Boolean(orgId.trim() && userId.trim())
 }
 
 function appendOptionalParam(

--- a/tests/acceptance/workspace-foundation-rollout.test.ts
+++ b/tests/acceptance/workspace-foundation-rollout.test.ts
@@ -22,7 +22,7 @@ describe("workspace foundation rollout", () => {
     vi.unstubAllEnvs()
   })
 
-  it("defaults off and requires the private kill switch plus an allowlist match", () => {
+  it("defaults off and requires the global kill switch", () => {
     expect(
       isWorkspaceFoundationRolloutEnabled({
         ...identity,
@@ -33,60 +33,18 @@ describe("workspace foundation rollout", () => {
       isWorkspaceFoundationRolloutEnabled({
         ...identity,
         environment: {
-          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-        },
-      })
-    ).toBe(false)
-    expect(
-      isWorkspaceFoundationRolloutEnabled({
-        ...identity,
-        environment: {
           WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "0",
-          WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS: "org-1",
-          WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS: "user-1",
         },
       })
     ).toBe(false)
   })
 
-  it("allows only a matching organization or user when enabled", () => {
+  it("enables every authenticated workspace identity", () => {
     expect(
       isWorkspaceFoundationRolloutEnabled({
         ...identity,
         environment: {
           WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-          WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS: "other, ORG-1 ",
-        },
-      })
-    ).toBe(true)
-    expect(
-      isWorkspaceFoundationRolloutEnabled({
-        ...identity,
-        environment: {
-          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-          WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS: " USER-1 ",
-        },
-      })
-    ).toBe(true)
-    expect(
-      isWorkspaceFoundationRolloutEnabled({
-        ...identity,
-        environment: {
-          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-          WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS: "org-2",
-          WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS: "user-2",
-        },
-      })
-    ).toBe(false)
-  })
-
-  it("allows every authenticated workspace identity with an explicit wildcard", () => {
-    expect(
-      isWorkspaceFoundationRolloutEnabled({
-        ...identity,
-        environment: {
-          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-          WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS: "*",
         },
       })
     ).toBe(true)
@@ -96,10 +54,27 @@ describe("workspace foundation rollout", () => {
         userId: "user-2",
         environment: {
           WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
-          WORKSPACE_FOUNDATION_ROLLOUT_USER_IDS: "*",
         },
       })
     ).toBe(true)
+    expect(
+      isWorkspaceFoundationRolloutEnabled({
+        orgId: "",
+        userId: "user-2",
+        environment: {
+          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
+        },
+      })
+    ).toBe(false)
+    expect(
+      isWorkspaceFoundationRolloutEnabled({
+        orgId: "org-2",
+        userId: "",
+        environment: {
+          WORKSPACE_FOUNDATION_ROLLOUT_ENABLED: "1",
+        },
+      })
+    ).toBe(false)
   })
 
   it("preserves legacy destinations when later drawer routes are disabled", () => {
@@ -156,7 +131,6 @@ describe("workspace foundation rollout", () => {
 
   it("keeps page mode default-off and preserves legacy editor routing", async () => {
     vi.stubEnv("WORKSPACE_FOUNDATION_ROLLOUT_ENABLED", "0")
-    vi.stubEnv("WORKSPACE_FOUNDATION_ROLLOUT_ORG_IDS", identity.orgId)
     const searchState = await resolveMyOrganizationPageSearchState(
       Promise.resolve({
         programId: "program-1",


### PR DESCRIPTION
## Summary
- remove organization and user allowlist restrictions from the workspace foundation
- keep `WORKSPACE_FOUNDATION_ROLLOUT_ENABLED` as the global kill switch
- enable the new workspace, drawer, Documents, People, Finance, and Accelerator surfaces for every authenticated organization member

## Validation
- `pnpm check:quality`
- 2,028 acceptance tests passed; one intentional skip
- connected fiscal and Finance RLS passed
- 108-route production build passed
- 30 visual checks passed
- performance budgets passed

## Rollback
Set `WORKSPACE_FOUNDATION_ROLLOUT_ENABLED=0` and redeploy.