### PR TITLE
[STEP S31] Repair organization console failures

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2414,12 +2414,14 @@
 
 - Prevented recreated but equivalent coach-assignment props from repeatedly
   replacing local state and triggering React's maximum-update-depth guard.
+- Applied the same semantic-signature synchronization to organization Kanban
+  visibility after live localhost verification exposed the adjacent loop.
 - Classified missing linked Stripe subscriptions as a recoverable unavailable
   billing state with warning-level telemetry. Unexpected billing failures still
   emit error telemetry; no Stripe or subscription data was changed.
 - Added focused acceptance coverage for stable assignment comparison and the
   missing-link billing recovery contract.
-- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,030`
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,031`
   acceptance tests with one intentional skip, connected fiscal and Finance RLS,
   the `108`-route production build, `30/30` visuals, and performance budgets.
   The optional generic RLS suite skipped without its separate credentials.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2409,3 +2409,17 @@
   acceptance tests with one intentional skip, connected fiscal and Finance RLS,
   the `108`-route production build, `30/30` visuals, and performance budgets.
   The optional generic RLS suite skipped without its separate credentials.
+
+2026-08-10 15:39 EDT - repaired organization-list console failures.
+
+- Prevented recreated but equivalent coach-assignment props from repeatedly
+  replacing local state and triggering React's maximum-update-depth guard.
+- Classified missing linked Stripe subscriptions as a recoverable unavailable
+  billing state with warning-level telemetry. Unexpected billing failures still
+  emit error telemetry; no Stripe or subscription data was changed.
+- Added focused acceptance coverage for stable assignment comparison and the
+  missing-link billing recovery contract.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,030`
+  acceptance tests with one intentional skip, connected fiscal and Finance RLS,
+  the `108`-route production build, `30/30` visuals, and performance budgets.
+  The optional generic RLS suite skipped without its separate credentials.

--- a/src/features/admin-organization-billing/server/context.ts
+++ b/src/features/admin-organization-billing/server/context.ts
@@ -32,6 +32,13 @@ export type LatestAdminOrganizationBillingPayment = {
   invoice: Stripe.Invoice
 }
 
+export class MissingLinkedStripeSubscriptionError extends Error {
+  constructor() {
+    super("The linked Stripe subscription was not found.")
+    this.name = "MissingLinkedStripeSubscriptionError"
+  }
+}
+
 function asMetadata(value: Json | null) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {}
   return value as Record<string, unknown>
@@ -39,6 +46,15 @@ function asMetadata(value: Json | null) {
 
 function stripeErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Stripe request failed."
+}
+
+function isStripeResourceMissingError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "resource_missing"
+  )
 }
 
 function orderConfigsByMode(configs: StripeRuntimeConfig[], mode: unknown) {
@@ -82,6 +98,7 @@ export async function resolveAdminOrganizationBillingContext({
   }
 
   let lastError: unknown = null
+  let everyLookupFailureWasMissing = true
   for (const config of configs) {
     try {
       const subscription = await config.client.subscriptions.retrieve(
@@ -90,7 +107,13 @@ export async function resolveAdminOrganizationBillingContext({
       return { config, record, subscription }
     } catch (error) {
       lastError = error
+      everyLookupFailureWasMissing =
+        everyLookupFailureWasMissing && isStripeResourceMissingError(error)
     }
+  }
+
+  if (lastError && everyLookupFailureWasMissing) {
+    throw new MissingLinkedStripeSubscriptionError()
   }
 
   throw new Error(

--- a/src/features/admin-organization-billing/server/loaders.ts
+++ b/src/features/admin-organization-billing/server/loaders.ts
@@ -7,6 +7,7 @@ import { resolveAdminOrganizationBillingPlan } from "../lib"
 import type { AdminOrganizationBillingState } from "../types"
 import {
   loadLatestAdminOrganizationBillingPayment,
+  MissingLinkedStripeSubscriptionError,
   resolveAdminOrganizationBillingContext,
   subscriptionCurrentPeriodEnd,
 } from "./context"
@@ -71,6 +72,16 @@ export async function loadAdminOrganizationBilling(
       },
     }
   } catch (error) {
+    if (error instanceof MissingLinkedStripeSubscriptionError) {
+      logger.warn("admin_organization_billing_link_unavailable", { orgId })
+      return {
+        mode: "unavailable",
+        message:
+          "The linked Stripe subscription was not found. Open Stripe to reconnect this account.",
+        orgId,
+      }
+    }
+
     logger.error("admin_organization_billing_load_failed", error, { orgId })
     return {
       mode: "unavailable",

--- a/src/features/organization-coach-assignments/hooks/use-organization-coach-assignments-controller.ts
+++ b/src/features/organization-coach-assignments/hooks/use-organization-coach-assignments-controller.ts
@@ -1,9 +1,10 @@
 "use client"
 
-import { useEffect, useMemo, useState, useTransition } from "react"
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
+import { getOrganizationCoachAssignmentsSignature } from "../lib"
 import type {
   OrganizationCoachAssignment,
   OrganizationCoachOption,
@@ -30,8 +31,14 @@ export function useOrganizationCoachAssignmentController({
   const [assignments, setAssignments] = useState(initialAssignments)
   const [open, setOpen] = useState(false)
   const [pending, startTransition] = useTransition()
+  const initialAssignmentsRef = useRef(initialAssignments)
+  initialAssignmentsRef.current = initialAssignments
+  const initialAssignmentsSignature =
+    getOrganizationCoachAssignmentsSignature(initialAssignments)
 
-  useEffect(() => setAssignments(initialAssignments), [initialAssignments])
+  useEffect(() => {
+    setAssignments(initialAssignmentsRef.current)
+  }, [initialAssignmentsSignature])
 
   const assignedCoachIds = useMemo(
     () => new Set(assignments.map((assignment) => assignment.coach.id)),

--- a/src/features/organization-coach-assignments/index.ts
+++ b/src/features/organization-coach-assignments/index.ts
@@ -10,6 +10,7 @@ export {
   filterByOrganizationCoachScope,
   filterProjectsByOrganizationCoach,
   getOrganizationCoachInitials,
+  getOrganizationCoachAssignmentsSignature,
   normalizeOrganizationCoachFilter,
   ORGANIZATION_COACH_FILTER_ALL,
   ORGANIZATION_COACH_FILTER_UNASSIGNED,

--- a/src/features/organization-coach-assignments/lib/index.ts
+++ b/src/features/organization-coach-assignments/lib/index.ts
@@ -6,12 +6,29 @@ export {
 } from "@/lib/organization-coach-scope"
 import type { OrganizationCoachOption } from "../types"
 import type {
+  OrganizationCoachAssignment,
   OrganizationCoachAssignmentCoverage,
   OrganizationCoachFilterValue,
 } from "../types"
 
 export const ORGANIZATION_COACH_FILTER_ALL = "all"
 export const ORGANIZATION_COACH_FILTER_UNASSIGNED = "unassigned"
+
+export function getOrganizationCoachAssignmentsSignature(
+  assignments: OrganizationCoachAssignment[]
+) {
+  return JSON.stringify(
+    assignments.map(({ assignedBy, coach, organizationId, updatedAt }) => [
+      organizationId,
+      assignedBy,
+      updatedAt,
+      coach.id,
+      coach.name,
+      coach.email,
+      coach.avatarUrl,
+    ])
+  )
+}
 
 export function getOrganizationCoachInitials(coach: OrganizationCoachOption) {
   return coach.name

--- a/src/features/organization-kanban-visibility/hooks/use-organization-kanban-visibility-controller.ts
+++ b/src/features/organization-kanban-visibility/hooks/use-organization-kanban-visibility-controller.ts
@@ -1,9 +1,10 @@
 "use client"
 
-import { useEffect, useMemo, useState, useTransition } from "react"
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
+import { getOrganizationKanbanVisibilityIdsSignature } from "../lib"
 import type { UpdateOrganizationKanbanVisibilityAction } from "../types"
 
 export function useOrganizationKanbanVisibilityController({
@@ -21,11 +22,14 @@ export function useOrganizationKanbanVisibilityController({
     string[]
   >([])
   const [, startTransition] = useTransition()
+  const initialHiddenOrganizationIdsRef = useRef(initialHiddenOrganizationIds)
+  initialHiddenOrganizationIdsRef.current = initialHiddenOrganizationIds
+  const initialHiddenOrganizationIdsSignature =
+    getOrganizationKanbanVisibilityIdsSignature(initialHiddenOrganizationIds)
 
-  useEffect(
-    () => setHiddenOrganizationIds(initialHiddenOrganizationIds),
-    [initialHiddenOrganizationIds]
-  )
+  useEffect(() => {
+    setHiddenOrganizationIds(initialHiddenOrganizationIdsRef.current)
+  }, [initialHiddenOrganizationIdsSignature])
 
   const hiddenOrganizationIdSet = useMemo(
     () => new Set(hiddenOrganizationIds),

--- a/src/features/organization-kanban-visibility/index.ts
+++ b/src/features/organization-kanban-visibility/index.ts
@@ -8,6 +8,7 @@ export {
   applyOrganizationKanbanVisibilityToParams,
   computeOrganizationKanbanVisibilityCounts,
   filterProjectsByOrganizationKanbanVisibility,
+  getOrganizationKanbanVisibilityIdsSignature,
   normalizeOrganizationKanbanVisibilityMode,
   ORGANIZATION_KANBAN_VISIBILITY_HIDDEN,
   ORGANIZATION_KANBAN_VISIBILITY_VISIBLE,

--- a/src/features/organization-kanban-visibility/lib/index.ts
+++ b/src/features/organization-kanban-visibility/lib/index.ts
@@ -8,6 +8,10 @@ type OrganizationProject = {
   projectKind?: string
 }
 
+export function getOrganizationKanbanVisibilityIdsSignature(ids: string[]) {
+  return JSON.stringify(Array.from(new Set(ids)).sort())
+}
+
 export function normalizeOrganizationKanbanVisibilityMode(
   value: string | null | undefined
 ): OrganizationKanbanVisibilityMode {

--- a/tests/acceptance/admin-organization-billing.test.ts
+++ b/tests/acceptance/admin-organization-billing.test.ts
@@ -113,6 +113,13 @@ describe("admin organization billing", () => {
       ),
       "utf8"
     )
+    const loader = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/admin-organization-billing/server/loaders.ts"
+      ),
+      "utf8"
+    )
     const route = readFileSync(
       join(process.cwd(), "src/app/(dashboard)/organizations/[id]/page.tsx"),
       "utf8"
@@ -132,6 +139,16 @@ describe("admin organization billing", () => {
     expect(actions).toContain("idempotencyKey")
     expect(context).toContain("client.invoicePayments.list")
     expect(context).toContain('status: "paid"')
+    expect(context).toContain("MissingLinkedStripeSubscriptionError")
+    expect(loader).toContain(
+      "error instanceof MissingLinkedStripeSubscriptionError"
+    )
+    expect(loader).toContain(
+      'logger.warn("admin_organization_billing_link_unavailable"'
+    )
+    expect(loader).toContain(
+      'logger.error("admin_organization_billing_load_failed"'
+    )
     expect(route).toContain('staff.accessLevel === "developer"')
     expect(route).toContain("<AdminOrganizationBillingPanel")
     expect(rightPanel).toContain("{adminBilling}")

--- a/tests/acceptance/organization-coach-assignments.test.ts
+++ b/tests/acceptance/organization-coach-assignments.test.ts
@@ -9,6 +9,7 @@ import {
   filterProjectsByOrganizationCoach,
   filterByOrganizationCoachScope,
   getOrganizationCoachInitials,
+  getOrganizationCoachAssignmentsSignature,
   normalizeOrganizationCoachFilter,
 } from "@/features/organization-coach-assignments"
 import type { PlatformAdminDashboardLabProject } from "@/features/platform-admin-dashboard"
@@ -62,6 +63,18 @@ describe("organization-coach-assignments feature contract", () => {
         avatarUrl: null,
       })
     ).toBe("PC")
+  })
+
+  it("treats recreated equivalent assignment props as stable", () => {
+    const current = [assignment(paula)]
+    const recreated = [assignment({ ...paula })]
+
+    expect(getOrganizationCoachAssignmentsSignature(current)).toBe(
+      getOrganizationCoachAssignmentsSignature(recreated)
+    )
+    expect(
+      getOrganizationCoachAssignmentsSignature(current)
+    ).not.toBe(getOrganizationCoachAssignmentsSignature([assignment(joel)]))
   })
 
   it("keeps writes developer-only and reads internal", () => {

--- a/tests/acceptance/organization-kanban-visibility.test.ts
+++ b/tests/acceptance/organization-kanban-visibility.test.ts
@@ -6,6 +6,7 @@ import {
   applyOrganizationKanbanVisibilityToParams,
   computeOrganizationKanbanVisibilityCounts,
   filterProjectsByOrganizationKanbanVisibility,
+  getOrganizationKanbanVisibilityIdsSignature,
   normalizeOrganizationKanbanVisibilityMode,
 } from "@/features/organization-kanban-visibility"
 
@@ -36,6 +37,15 @@ const projects = [
 ]
 
 describe("organization Kanban visibility", () => {
+  it("keeps recreated equivalent visibility props stable", () => {
+    expect(getOrganizationKanbanVisibilityIdsSignature(["b", "a", "a"])).toBe(
+      getOrganizationKanbanVisibilityIdsSignature(["a", "b"])
+    )
+    expect(getOrganizationKanbanVisibilityIdsSignature(["a"])).not.toBe(
+      getOrganizationKanbanVisibilityIdsSignature(["b"])
+    )
+  })
+
   it("normalizes the URL-backed visibility mode", () => {
     expect(normalizeOrganizationKanbanVisibilityMode("hidden")).toBe("hidden")
     expect(normalizeOrganizationKanbanVisibilityMode("invalid")).toBe("visible")


### PR DESCRIPTION
## Summary
- synchronize coach-assignment and Kanban-visibility state by semantic content instead of recreated array identity
- prevent the organizations card view from entering maximum-update-depth loops
- treat missing linked Stripe subscriptions as a recoverable unavailable state with warning telemetry
- preserve error telemetry for unexpected billing failures
- do not mutate Stripe or subscription data

## Validation
- reproduced both update-depth loops on localhost before the fixes
- active localhost page stopped emitting the loops after the fixes
- `pnpm check:quality`
- 2,031 acceptance tests passed; one intentional skip
- connected fiscal and Finance RLS passed
- 108-route production build passed
- 30 visual checks passed
- performance budgets passed