### PR TITLE
[STEP S32] Fix Vercel production font build

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2436,3 +2436,15 @@
   acceptance tests with one intentional skip, connected fiscal and Finance RLS,
   the `108`-route production build, `30/30` visuals, and performance budgets.
   The optional generic RLS suite skipped without its separate credentials.
+
+2026-08-10 16:35 EDT - removed the failing Space Grotesk production build dependency.
+
+- Reused the existing Inter font instance for the legacy public-home body copy
+  after both Vercel production projects failed to resolve Space Grotesk's
+  generated `next/font` asset imports.
+- Preserved the existing typography loading behavior without adding a new
+  remote font request.
+- Clean `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,030`
+  acceptance tests with one intentional skip, fiscal and Finance RLS, the
+  `108`-route production build, `30/30` visuals, and performance budgets. The
+  optional generic RLS suite skipped without its separate credentials.

--- a/src/components/public/legacy-home-sections/fonts.ts
+++ b/src/components/public/legacy-home-sections/fonts.ts
@@ -1,4 +1,4 @@
-import { Inter, Sora, Space_Grotesk } from "next/font/google"
+import { Inter, Sora } from "next/font/google"
 
 export const legacyHomeHeadingFont = Sora({
   subsets: ["latin"],
@@ -15,11 +15,4 @@ export const legacyHomeInterFont = Inter({
   preload: false,
 })
 
-const body = Space_Grotesk({
-  subsets: ["latin"],
-  weight: ["400", "500", "600"],
-  variable: "--font-body",
-  preload: false,
-})
-
-export const LEGACY_HOME_BODY_CLASSNAME = body.className
+export const LEGACY_HOME_BODY_CLASSNAME = legacyHomeInterFont.className


### PR DESCRIPTION
## Summary
- remove the failing Space Grotesk `next/font` dependency
- reuse the existing Inter instance for legacy public-home body copy
- record the production build incident and validation

## Validation
- `pnpm check:quality`
- 2,030 acceptance tests passed; 1 intentional skip
- fiscal and Finance RLS passed
- 108-route production build passed
- 30 visual tests passed
- performance budgets passed

## Release context
Both production Vercel projects failed after PR #126 merged because generated Space Grotesk asset URLs returned 404. Two redeploy attempts reproduced the failure.