### PR TITLE
[STEP S36] Fix Find light mode contrast

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2487,3 +2487,24 @@
 - Hosted CI then confirmed the build fix and produced the same dark ontology
   screenshot twice. Self-hosted Inter changed only text glyph rendering, so the
   Linux baseline was updated; layout, color, and node geometry were unchanged.
+
+2026-08-11 02:02 EDT - started Wave 1 with the public Find light-mode repair.
+
+- Confirmed production forced the public-map drawer and organization detail
+  subtree into dark mode even when the application theme was light, producing
+  a dark profile card and low-contrast text over a light map.
+- Removed the forced dark-theme boundary and gave the shared overlay glass
+  explicit semantic light and dark surfaces. The existing drawer, organization
+  profile, resource profile, location prompt, status pill, and map alerts retain
+  one shared theme contract.
+- Browser proof passed for authenticated desktop and mobile light mode and
+  desktop and mobile dark mode. Opening the organization profile intentionally
+  added it to the tester's recent-organization preference through the existing
+  account API; no favorite, organization, billing, or Finance data changed.
+- Focused coverage passed `34/34`. Full `pnpm check:quality` passed: lint and all
+  guardrails, snapshots, `2,030` acceptance tests with one intentional skip,
+  connected fiscal, Finance, and generic RLS, the `108`-route production build,
+  `30/30` visuals, and performance budgets. Production remains unchanged until
+  the focused branch is reviewed, merged, deployed, and smoke-tested.
+- Continue Wave 1 with the remaining paid/free/member/coach/admin journey audit
+  after this narrow light-mode repair ships.

--- a/src/components/public/public-map-index/sidebar-theme.ts
+++ b/src/components/public/public-map-index/sidebar-theme.ts
@@ -2,7 +2,7 @@ export const PUBLIC_MAP_SIDEBAR_RAIL_CLASSNAME =
   "border-r border-sidebar-border/70 bg-sidebar/86 text-sidebar-foreground shadow-sm backdrop-blur-xl supports-[backdrop-filter]:bg-sidebar/76"
 
 export const PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME =
-  "dark border-input bg-input/35 text-foreground backdrop-blur-xl"
+  "border border-border/70 bg-background/88 text-foreground backdrop-blur-xl supports-[backdrop-filter]:bg-background/76 dark:border-input dark:bg-input/35 dark:supports-[backdrop-filter]:bg-input/28"
 
 export const PUBLIC_MAP_SIDEBAR_CARD_CLASSNAME =
   "rounded-2xl border border-border/75 bg-sidebar-accent/92 shadow-sm backdrop-blur-md"

--- a/tests/acceptance/public-find-route.test.ts
+++ b/tests/acceptance/public-find-route.test.ts
@@ -365,8 +365,10 @@ describe("public find routes", () => {
     expect(sidebarSource).toContain("resolvePublicMapDrawerSnapPointIndex({")
     expect(sidebarSource).not.toContain("snapPoints.findIndex")
     expect(sidebarThemeSource).toContain(
-      '"dark border-input bg-input/35 text-foreground backdrop-blur-xl"'
+      "bg-background/88 text-foreground backdrop-blur-xl"
     )
+    expect(sidebarThemeSource).toContain("dark:border-input dark:bg-input/35")
+    expect(sidebarThemeSource).not.toContain('"dark border-input')
     expect(sidebarSource).toContain("PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME")
     expect(statusPillSource).toContain("PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME")
     expect(welcomeControlSource).toContain("PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME")

--- a/tests/acceptance/public-map-user-location.test.ts
+++ b/tests/acceptance/public-map-user-location.test.ts
@@ -125,8 +125,10 @@ describe("public map user location", () => {
       "absolute inset-0 flex items-center justify-center p-4"
     )
     expect(sidebarThemeSource).toContain(
-      '"dark border-input bg-input/35 text-foreground backdrop-blur-xl"'
+      "bg-background/88 text-foreground backdrop-blur-xl"
     )
+    expect(sidebarThemeSource).toContain("dark:border-input dark:bg-input/35")
+    expect(sidebarThemeSource).not.toContain('"dark border-input')
     expect(locationControlSource).toContain(
       "PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME"
     )


### PR DESCRIPTION
## What changed

- Removed the forced dark-theme boundary from the shared Find overlay glass.
- Added explicit semantic light and dark surfaces for the drawer, organization/resource profiles, location prompt, status pill, and map alerts.
- Updated acceptance guards and the August runlog.

## Why

Production light mode rendered organization profiles as dark cards and made text low contrast over the light map.

## Evidence

- Production before and local after checked in authenticated desktop and mobile light mode.
- Desktop and mobile dark mode remained readable.
- Focused tests: 34 passed.
- `pnpm check:quality`: 2,030 acceptance tests passed with one intentional skip; connected fiscal, Finance, and generic RLS passed; 108-route build passed; 30 visual tests passed; performance budgets passed.
- Pre-push structural and acceptance gates passed again.

## Data and rollback

Opening the test organization updated only the tester's existing recent-organization preference. No favorite, organization, billing, Finance, Stripe, or migration data changed.

Rollback is a single shared theme-token revert. Stored data is unaffected.

Production remains unchanged until merge, deployment, and live smoke verification.