### PR TITLE
[STEP S38] Parallelize organization detail reads

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2169,7 +2169,6 @@
 - `pnpm check:quality` passed against the isolated candidate server: lint, all guardrails, snapshots, 1,680 acceptance tests, production build, 26 visual tests, and performance budgets.
 - RLS execution skipped without Supabase credentials. Connected RLS, authenticated preview QA, rollback rehearsal, commit, push, PR, deployment, and live verification remain approval-gated. No remote or production change occurred.
 
-
 2026-08-06 15:42 EDT - removed unplanned Accelerator release-candidate scope.
 
 - Removed the donor-only test-fixture class filter and drawer introduction banner
@@ -2180,7 +2179,6 @@
 - Focused Prettier, ESLint, `24/24` Accelerator drawer tests, and diff checks
   passed. No commit, push, deployment, donor change, or production mutation
   occurred.
-
 
 2026-08-06 16:19 EDT - hardened Batch 2 People rollout regressions.
 
@@ -2196,7 +2194,6 @@
   TypeScript and structure checks retain unrelated candidate failures. No
   commit, push, deployment, donor change, or production access occurred.
 
-
 2026-08-06 16:32 EDT - closed the Batch 2 organization-page source budget.
 
 - Reduced `my-organization-page-content.tsx` from 615 to 412 lines by moving
@@ -2208,7 +2205,6 @@
 - Focused page and route coverage passed `35/35`; focused ESLint, diff checks,
   scoped TypeScript, and the full structure check passed. No donor change,
   commit, push, deployment, or production access occurred.
-
 
 2026-08-06 16:21 EDT - stopped Batch 2 authenticated QA after an unintended workspace autosave.
 
@@ -2223,7 +2219,6 @@
 - No deployment, migration, commit, push, PR, or other production write
   occurred. Further authenticated QA is paused until it cannot persist remote
   workspace state.
-
 
 2026-08-06 16:50 EDT - completed Batch 2 local release-candidate validation.
 
@@ -2240,14 +2235,12 @@
 - Connected RLS, non-persisting authenticated preview QA, rollback rehearsal,
   commit, push, PR, deployment, and live verification remain approval-gated.
 
-
 2026-08-06 17:02 EDT - created the Batch 2 rollback checkpoint.
 
 - Committed the exact eight-file forward-compatibility reader/writer and test
   set as reachable local commit `7609daa`; its focused proof passes `52/52`.
 - Removed two formatting-only files from the remaining candidate diff. No push,
   preview, deployment, database, or production change occurred.
-
 
 2026-08-06 17:08 EDT - opened the Batch 2 preview pull request.
 
@@ -2258,7 +2251,6 @@
   Vercel previews are building. Supabase Preview was cancelled, so connected
   RLS and authenticated preview evidence remain open. No merge or production
   deployment occurred.
-
 
 2026-08-06 17:50 EDT - completed Batch 2 connected preview proof.
 
@@ -2277,7 +2269,6 @@
   original automated replay failure despite the repaired branch and connected
   proof. No merge or production deployment occurred.
 
-
 2026-08-06 18:34 EDT - closed Batch 2 review and preview-replay defects.
 
 - Made partial organization-profile patch optionality explicit and added direct
@@ -2294,7 +2285,6 @@
   credentials; the prior connected disposable-preview RLS run remains green.
 - No merge, deployment, donor change, or production mutation occurred.
 
-
 2026-08-06 21:55 EDT - stabilized Batch 2 ontology visual proof.
 
 - The recovered GitHub Actions run reached the full quality suite and exposed
@@ -2305,7 +2295,6 @@
   `6/6`; and the complete candidate visual suite passes `26/26` on the isolated
   port `3020` server. Prettier, ESLint, and diff checks pass. No merge,
   deployment, database, or production mutation occurred.
-
 
 2026-08-06 22:07 EDT - refreshed the two intentional ontology node baselines.
 
@@ -2319,7 +2308,6 @@
   on isolated port `3020`. No merge, deployment, database, or production
   mutation occurred.
 
-
 2026-08-06 22:26 EDT - isolated ontology snapshots by rendering platform.
 
 - Retained failed Playwright output in CI and inspected the exact Linux actual,
@@ -2331,7 +2319,6 @@
 - Prettier and ESLint pass; focused repeats pass `6/6`; the complete local
   visual suite passes `26/26` on isolated port `3020`. Hosted validation remains
   pending. No merge, deployment, database, or production mutation occurred.
-
 
 2026-08-07 00:03 EDT - completed the Batch 3 fiscal and project-operations release candidate.
 
@@ -2511,7 +2498,7 @@
   historical. No product behavior, schema, deployment, Stripe data, or database
   data changed.
 - Focused Prototype Lab acceptance passes `36/36`.
-2026-08-11 02:02 EDT - started Wave 1 with the public Find light-mode repair.
+  2026-08-11 02:02 EDT - started Wave 1 with the public Find light-mode repair.
 
 - Confirmed production forced the public-map drawer and organization detail
   subtree into dark mode even when the application theme was light, producing
@@ -2531,3 +2518,24 @@
   the focused branch is reviewed, merged, deployed, and smoke-tested.
 - Continue Wave 1 with the remaining paid/free/member/coach/admin journey audit
   after this narrow light-mode repair ships.
+
+2026-08-11 02:56 EDT - reduced organization-detail server read latency.
+
+- Confirmed the merged Find light-mode repair is live. Authenticated production
+  checks also confirmed the Workspace Documents and Finance deep links render
+  their intended drawers without changing organization, billing, or Finance
+  data.
+- Found that organization detail pages waited serially for fiscal permission,
+  fiscal workflow, and developer billing reads after the main project load.
+  Started those independent reads together while preserving the existing role
+  checks, missing-subscription recovery, and rendered data.
+- Added acceptance coverage for the parallel route contract. Focused checks
+  pass `13/13`; the broader Wave 1 route and billing slice passes `108/108`.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,030`
+  acceptance tests with one intentional skip, connected fiscal and Finance RLS,
+  the `108`-route production build, `30/30` visuals, and performance budgets.
+  The optional generic RLS suite skipped without its separate credentials.
+- Authenticated rendering passed in production light mode and local dark mode.
+  Cold development compilation was excluded from the performance conclusion;
+  hosted proof still requires the focused PR preview. Continue Wave 1 with
+  role-complete browser journeys after this slice ships.

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -86,29 +86,33 @@ export default async function OrganizationDetailPage({ params }: PageProps) {
     result.scope === "organization" || result.scope === "platform-admin"
   const canEditProjectDetails =
     result.scope === "organization" || result.scope === "platform-admin"
-  const canManageFiscalSponsorship =
-    result.scope === "platform-admin" &&
-    (await canManageFiscalSponsorshipForOrganization({
-      accessLevel: staff.accessLevel,
-      organizationId: result.organizationSummary.orgId,
-      supabase: staff.supabase,
-      userId: staff.userId,
-    }))
   const projectKind = getOrganizationAdminProjectKind(result.project.source)
   const canManageProjectTasks =
     result.scope === "organization" || result.scope === "platform-admin"
   const canDeleteProject =
     canEditProjectDetails && projectKind !== "organization_admin"
-  const fiscalSponsorshipWorkflowSummary =
-    await loadFiscalSponsorshipProjectWorkflowSummary(result.project.id)
+  const [
+    canManageFiscalSponsorship,
+    fiscalSponsorshipWorkflowSummary,
+    adminBilling,
+  ] = await Promise.all([
+    result.scope === "platform-admin"
+      ? canManageFiscalSponsorshipForOrganization({
+          accessLevel: staff.accessLevel,
+          organizationId: result.organizationSummary.orgId,
+          supabase: staff.supabase,
+          userId: staff.userId,
+        })
+      : Promise.resolve(false),
+    loadFiscalSponsorshipProjectWorkflowSummary(result.project.id),
+    staff.accessLevel === "developer"
+      ? loadAdminOrganizationBilling(result.organizationSummary.orgId)
+      : Promise.resolve(null),
+  ])
   const fiscalSponsorshipWorkflowData =
     "error" in fiscalSponsorshipWorkflowSummary
       ? null
       : fiscalSponsorshipWorkflowSummary
-  const adminBilling =
-    staff.accessLevel === "developer"
-      ? await loadAdminOrganizationBilling(result.organizationSummary.orgId)
-      : null
 
   return (
     <MemberWorkspaceProjectDetailPage

--- a/tests/acceptance/admin-organization-billing.test.ts
+++ b/tests/acceptance/admin-organization-billing.test.ts
@@ -150,6 +150,13 @@ describe("admin organization billing", () => {
       'logger.error("admin_organization_billing_load_failed"'
     )
     expect(route).toContain('staff.accessLevel === "developer"')
+    expect(route).toContain("await Promise.all([")
+    expect(route).toContain(
+      "loadFiscalSponsorshipProjectWorkflowSummary(result.project.id)"
+    )
+    expect(route).toContain(
+      "loadAdminOrganizationBilling(result.organizationSummary.orgId)"
+    )
     expect(route).toContain("<AdminOrganizationBillingPanel")
     expect(rightPanel).toContain("{adminBilling}")
   })


### PR DESCRIPTION
## What changed

- start fiscal permission, fiscal workflow, and developer billing reads together
- preserve existing authorization and missing-subscription recovery
- add an acceptance guard and Wave 1 runlog evidence

## Why

Organization detail pages waited for three independent server reads in sequence after the main project load. This made an already data-heavy page slower for platform staff.

## Impact

The page returns the same data and controls, but independent reads no longer add their latency one after another. No schema, billing mutation, Stripe object, or production data changes.

## Validation

- `pnpm check:quality`
- 2,030 acceptance tests passed; 1 intentional skip
- connected fiscal and Finance RLS passed
- 108-route production build passed
- 30 visual tests passed
- performance budgets passed
- authenticated production light-mode and local dark-mode rendering checked

## Rollback

Revert this commit; no stored data requires repair.