### PR TITLE
[STEP S39] Protect organization document writes

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -77,8 +77,11 @@ the relevant wave rather than inferred from merge status:
 | PR #127      | Production font-build repair                                |
 | PR #128      | Production-readiness waves and release gates                |
 | PR #130      | Self-hosted Inter build dependency                          |
+| PR #131      | Find and Build product and rollout clarification            |
+| PR #132      | Public Find light-mode contrast repair                       |
+| PR #133      | Parallel organization-detail server reads                   |
 
-The baseline is `origin/main` commit `e2f5921c` on 2026-08-11. A production
+The baseline is `origin/main` commit `46ab9301` on 2026-08-11. A production
 read of `/api/public/resource-map/items` returned `853` records in a
 `2,519,484`-byte response. That is a live endpoint snapshot, not a performance
 guarantee or proof that all records rendered correctly.
@@ -117,6 +120,20 @@ wave, but unrelated scope does not accumulate in one PR.
 | 5. Finance reporting completion           | Queued, partly built | Read-only external activity connection, simple graph, activity list, History, source/freshness labels, CSV/PDF export, and board sharing                       | Connected/loading/empty/stale/error states; graph has a text equivalent; reports reconcile; sharing is explicit and revocable                      | Disable sync or reporting entry points; retain read-only records and existing CSV fallback |
 | 6. Qualified resources and varied guides  | Queued               | Promote verified cohorts toward 5,000+ useful records, then publish category- and location-varied guides after `/find` is stable                               | Exact complete/verified/publishable/promoted/public parity; cohort canary; relevant current guides and working links                               | Unpublish a cohort or guide without deleting evidence                                      |
 | 7. Integrated production release          | Queued               | Security review, support runbook, monitoring, rollback rehearsal, production smoke checks, and gradual rollout                                                 | Full quality gate; connected RLS where changed; hosted previews; production browser proof; clean monitoring                                        | Wave-specific flags and forward repair; never use a destructive data rollback              |
+
+#### Wave 1 current evidence
+
+- PR #132 is merged and production-verified for authenticated light/dark Find
+  surfaces on desktop and mobile.
+- PR #133 is merged and production-verified for organization-detail rendering
+  and recoverable missing Stripe-subscription links.
+- The organization document-safety repair is code complete on the focused
+  `fix/document-upload-atomicity-20260811` branch. It replaces stale
+  whole-profile upserts with revision-aware retries and commits document
+  references before removing replaced or deleted storage objects. Focused
+  concurrency and ordering tests, the full quality gate, and an authenticated
+  isolated Documents render pass. Hosted preview, merge, deployment, and
+  production proof remain required.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2539,3 +2539,25 @@
   Cold development compilation was excluded from the performance conclusion;
   hosted proof still requires the focused PR preview. Continue Wave 1 with
   role-complete browser journeys after this slice ships.
+
+2026-08-11 10:29 EDT - protected organization document references from stale writes and partial storage failures.
+
+- Confirmed organization documents, policies, policy documents, and public
+  documents wrote the entire organization profile without a revision check.
+  Concurrent changes could be overwritten, and replacement or deletion removed
+  storage objects before the new profile state was committed.
+- Added one revision-aware organization-profile mutation helper with bounded
+  conflict retries. The four routes now stage uploads, commit metadata, roll
+  back failed staged uploads, and remove replaced or deleted objects only after
+  the profile commit. Storage cleanup failures leave harmless orphaned objects
+  instead of broken user-facing references.
+- Added concurrency and route-ordering acceptance coverage. Focused tests pass
+  `6/6`. The full `pnpm check:quality` gate passes: lint and all guardrails,
+  snapshots, `2,036` acceptance tests with one intentional skip, fiscal and
+  Finance RLS, the `108`-route production build, `30/30` visuals against the
+  isolated branch preview, and performance budgets. The optional generic RLS
+  suite skipped without its separate credentials.
+- An authenticated read-only browser smoke rendered the Documents index and
+  existing organization files on the isolated preview. No organization,
+  document, storage, billing, or Finance data was changed. Hosted preview,
+  merge, deployment, and production proof remain required.

--- a/src/app/api/account/org-documents/route.ts
+++ b/src/app/api/account/org-documents/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server"
 
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
-import type { Database } from "@/lib/supabase"
 import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import { mutateOrganizationProfile } from "@/lib/organization/profile-mutation"
 import { createNotification } from "@/lib/notifications"
 
 const BUCKET = "org-documents"
@@ -12,10 +12,10 @@ const ALLOWED = new Set(["application/pdf"])
 const KIND_KEY_MAP = {
   "verification-letter": "verificationLetter",
   "articles-of-incorporation": "articlesOfIncorporation",
-  "bylaws": "bylaws",
+  bylaws: "bylaws",
   "state-registration": "stateRegistration",
   "good-standing-certificate": "goodStandingCertificate",
-  "w9": "w9",
+  w9: "w9",
   "tax-exempt-certificate": "taxExemptCertificate",
   "uei-confirmation": "ueiConfirmation",
   "sam-active-status": "samActiveStatus",
@@ -108,15 +108,15 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Document not found" }, { status: 404 })
     }
 
-    const { data: signed, error: signedError } = await supabase.storage
-      .from(BUCKET)
-      .createSignedUrl(
-        doc.path,
-        60 * 15,
-        downloadRequested
-          ? { download: typeof doc.name === "string" && doc.name.length > 0 ? doc.name : true }
-          : undefined,
-      )
+    const { data: signed, error: signedError } = await supabase.storage.from(BUCKET).createSignedUrl(
+      doc.path,
+      60 * 15,
+      downloadRequested
+        ? {
+            download: typeof doc.name === "string" && doc.name.length > 0 ? doc.name : true,
+          }
+        : undefined
+    )
     if (signedError || !signed?.signedUrl) {
       return NextResponse.json({ error: signedError?.message ?? "Unable to access document" }, { status: 500 })
     }
@@ -153,25 +153,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Only PDF files are supported." }, { status: 400 })
   }
   if (file.size > MAX_BYTES) {
-    return NextResponse.json(
-      { error: `File too large. Max size is ${MAX_UPLOAD_MB} MB.` },
-      { status: 400 },
-    )
+    return NextResponse.json({ error: `File too large. Max size is ${MAX_UPLOAD_MB} MB.` }, { status: 400 })
   }
 
   try {
     const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
     if (!canEditOrganization(role)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-    }
-
-    const profile = await loadProfile(supabase, orgId)
-    const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
-    const existing = documents[key]
-    const existingPath = isRecord(existing) && typeof existing.path === "string" ? existing.path : null
-
-    if (existingPath && isDocumentPathForKind(existingPath, orgId, key)) {
-      await supabase.storage.from(BUCKET).remove([existingPath])
     }
 
     const safeName = sanitizeFilename(file.name)
@@ -191,19 +179,33 @@ export async function POST(request: NextRequest) {
       updatedAt: new Date().toISOString(),
     }
 
-    const nextProfile = updateDocumentsProfile(profile, key, doc)
-    const { error: upsertError } = await supabase
-      .from("organizations")
-      .upsert(
-        {
-          user_id: orgId,
-          profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-        },
-        { onConflict: "user_id" },
-      )
+    const mutation = await mutateOrganizationProfile({
+      supabase,
+      orgId,
+      mutate: (profile) => {
+        const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
+        const existing = documents[key]
+        const existingPath = isRecord(existing) && typeof existing.path === "string" ? existing.path : null
 
-    if (upsertError) {
-      return NextResponse.json({ error: upsertError.message }, { status: 500 })
+        return {
+          changed: true,
+          nextProfile: updateDocumentsProfile(profile, key, doc),
+          value: { existingPath },
+        }
+      },
+    })
+
+    if ("error" in mutation) {
+      await supabase.storage.from(BUCKET).remove([objectName])
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
+    }
+
+    const { existingPath } = mutation.value
+    if (existingPath && existingPath !== objectName && isDocumentPathForKind(existingPath, orgId, key)) {
+      const { error: cleanupError } = await supabase.storage.from(BUCKET).remove([existingPath])
+      if (cleanupError) {
+        console.warn("Failed to remove replaced organization document")
+      }
     }
 
     const notifyResult = await createNotification(supabase, {
@@ -255,40 +257,40 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 })
     }
 
-    const profile = await loadProfile(supabase, orgId)
-    const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
-    const current = documents[key]
-    if (!isRecord(current) || typeof current.path !== "string") {
-      return NextResponse.json({ error: "Document not found" }, { status: 404 })
-    }
-    if (!isDocumentPathForKind(current.path, orgId, key)) {
-      return NextResponse.json({ error: "Document not found" }, { status: 404 })
+    const mutation = await mutateOrganizationProfile({
+      supabase,
+      orgId,
+      mutate: (profile) => {
+        const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
+        const current = documents[key]
+        if (!isRecord(current) || typeof current.path !== "string") {
+          return { error: "Document not found", status: 404 }
+        }
+        if (!isDocumentPathForKind(current.path, orgId, key)) {
+          return { error: "Document not found", status: 404 }
+        }
+
+        const doc: DocumentMeta = {
+          name: nextName,
+          path: String(current.path),
+          size: typeof current.size === "number" ? current.size : 0,
+          mime: typeof current.mime === "string" ? current.mime : "application/pdf",
+          updatedAt: new Date().toISOString(),
+        }
+
+        return {
+          changed: true,
+          nextProfile: updateDocumentsProfile(profile, key, doc),
+          value: doc,
+        }
+      },
+    })
+
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
 
-    const doc: DocumentMeta = {
-      name: nextName,
-      path: String(current.path),
-      size: typeof current.size === "number" ? current.size : 0,
-      mime: typeof current.mime === "string" ? current.mime : "application/pdf",
-      updatedAt: new Date().toISOString(),
-    }
-
-    const nextProfile = updateDocumentsProfile(profile, key, doc)
-    const { error: upsertError } = await supabase
-      .from("organizations")
-      .upsert(
-        {
-          user_id: orgId,
-          profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-        },
-        { onConflict: "user_id" },
-      )
-
-    if (upsertError) {
-      return NextResponse.json({ error: upsertError.message }, { status: 500 })
-    }
-
-    return NextResponse.json({ document: doc }, { status: 200 })
+    return NextResponse.json({ document: mutation.value }, { status: 200 })
   } catch (err: unknown) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Update failed" }, { status: 500 })
   }
@@ -317,28 +319,32 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 })
     }
 
-    const profile = await loadProfile(supabase, orgId)
-    const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
-    const current = documents[key]
-    const path = isRecord(current) && typeof current.path === "string" ? current.path : null
+    const mutation = await mutateOrganizationProfile({
+      supabase,
+      orgId,
+      mutate: (profile) => {
+        const documents = isRecord(profile["documents"]) ? (profile["documents"] as Record<string, unknown>) : {}
+        const current = documents[key]
+        const path = isRecord(current) && typeof current.path === "string" ? current.path : null
 
-    if (path && isDocumentPathForKind(path, orgId, key)) {
-      await supabase.storage.from(BUCKET).remove([path])
+        return {
+          changed: Boolean(current),
+          nextProfile: updateDocumentsProfile(profile, key, null),
+          value: { path },
+        }
+      },
+    })
+
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
 
-    const nextProfile = updateDocumentsProfile(profile, key, null)
-    const { error: upsertError } = await supabase
-      .from("organizations")
-      .upsert(
-        {
-          user_id: orgId,
-          profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-        },
-        { onConflict: "user_id" },
-      )
-
-    if (upsertError) {
-      return NextResponse.json({ error: upsertError.message }, { status: 500 })
+    const { path } = mutation.value
+    if (path && isDocumentPathForKind(path, orgId, key)) {
+      const { error: cleanupError } = await supabase.storage.from(BUCKET).remove([path])
+      if (cleanupError) {
+        console.warn("Failed to remove deleted organization document")
+      }
     }
 
     return NextResponse.json({ ok: true }, { status: 200 })

--- a/src/app/api/account/org-policies/document/route.ts
+++ b/src/app/api/account/org-policies/document/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
-import type { Database } from "@/lib/supabase"
 import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import { mutateOrganizationProfile } from "@/lib/organization/profile-mutation"
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
 
 const BUCKET = "org-documents"
@@ -57,8 +57,7 @@ function normalizeDocument(value: unknown): OrgPolicyDocument | null {
     path: value["path"],
     size: typeof value["size"] === "number" ? value["size"] : 0,
     mime: typeof value["mime"] === "string" ? value["mime"] : "application/pdf",
-    updatedAt:
-      typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date().toISOString(),
+    updatedAt: typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date().toISOString(),
   }
 }
 
@@ -69,29 +68,20 @@ function normalizePolicy(entry: unknown): OrgPolicy | null {
   if (!id || !title) return null
   const statusRaw = typeof entry["status"] === "string" ? entry["status"] : "not_started"
   const personIdsRaw = Array.isArray(entry["personIds"]) ? (entry["personIds"] as unknown[]) : []
-  const updatedAtRaw =
-    typeof entry["updatedAt"] === "string" ? entry["updatedAt"] : new Date().toISOString()
+  const updatedAtRaw = typeof entry["updatedAt"] === "string" ? entry["updatedAt"] : new Date().toISOString()
   const categories = normalizeCategories(entry["categories"])
   const legacyBoard = Boolean(entry["board"])
   return {
     id,
     title,
     summary: typeof entry["summary"] === "string" ? entry["summary"].trim() : "",
-    status:
-      statusRaw === "in_progress" || statusRaw === "complete"
-        ? statusRaw
-        : "not_started",
+    status: statusRaw === "in_progress" || statusRaw === "complete" ? statusRaw : "not_started",
     categories: categories.length > 0 ? categories : legacyBoard ? ["Board"] : [],
-    programId:
-      typeof entry["programId"] === "string" && entry["programId"].trim().length > 0
-        ? entry["programId"].trim()
-        : null,
+    programId: typeof entry["programId"] === "string" && entry["programId"].trim().length > 0 ? entry["programId"].trim() : null,
     personIds: Array.from(
       new Set(
-        personIdsRaw
-          .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-          .map((value) => value.trim()),
-      ),
+        personIdsRaw.filter((value): value is string => typeof value === "string" && value.trim().length > 0).map((value) => value.trim())
+      )
     ),
     document: normalizeDocument(entry["document"]),
     updatedAt: updatedAtRaw,
@@ -100,9 +90,7 @@ function normalizePolicy(entry: unknown): OrgPolicy | null {
 
 function readPolicies(profile: Record<string, unknown>): OrgPolicy[] {
   const raw = Array.isArray(profile["policies"]) ? (profile["policies"] as unknown[]) : []
-  return raw
-    .map((entry) => normalizePolicy(entry))
-    .filter((entry): entry is OrgPolicy => Boolean(entry))
+  return raw.map((entry) => normalizePolicy(entry)).filter((entry): entry is OrgPolicy => Boolean(entry))
 }
 
 function sanitizeFilename(name: string) {
@@ -114,10 +102,7 @@ function isPolicyDocumentPath(path: string, orgId: string, policyId: string) {
   return path.startsWith(`${orgId}/policies/${policyId}/`)
 }
 
-async function loadProfile(
-  supabase: ReturnType<typeof createSupabaseRouteHandlerClient>,
-  orgId: string,
-) {
+async function loadProfile(supabase: ReturnType<typeof createSupabaseRouteHandlerClient>, orgId: string) {
   const { data: orgRow, error } = await supabase
     .from("organizations")
     .select("profile")
@@ -125,25 +110,6 @@ async function loadProfile(
     .maybeSingle<{ profile: Record<string, unknown> | null }>()
   if (error) throw new Error(error.message)
   return (orgRow?.profile ?? {}) as Record<string, unknown>
-}
-
-async function savePolicies(
-  supabase: ReturnType<typeof createSupabaseRouteHandlerClient>,
-  orgId: string,
-  profile: Record<string, unknown>,
-  policies: OrgPolicy[],
-) {
-  const nextProfile = { ...profile, policies }
-  const { error } = await supabase
-    .from("organizations")
-    .upsert(
-      {
-        user_id: orgId,
-        profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-      },
-      { onConflict: "user_id" },
-    )
-  if (error) throw new Error(error.message)
 }
 
 async function requireOrgEditor(request: NextRequest) {
@@ -154,7 +120,9 @@ async function requireOrgEditor(request: NextRequest) {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    return { error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }) }
+    return {
+      error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }),
+    }
   }
   const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
   if (!canEditOrganization(role)) {
@@ -171,15 +139,16 @@ async function requireOrgMember(request: NextRequest) {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    return { error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }) }
+    return {
+      error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }),
+    }
   }
   const { orgId } = await resolveActiveOrganization(supabase, user.id)
   return { supabase, orgId }
 }
 
 function validatePdf(file: File) {
-  const isPdf =
-    file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+  const isPdf = file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
   if (!isPdf) return "Only PDF files are supported."
   if (file.size > MAX_BYTES) return "PDF must be 15 MB or less."
   return null
@@ -208,31 +177,25 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Policy document not found." }, { status: 404 })
     }
 
-    const { data: signed, error: signedError } = await auth.supabase.storage
-      .from(BUCKET)
-      .createSignedUrl(
-        policy.document.path,
-        60 * 15,
-        downloadRequested
-          ? {
-              download:
-                policy.document.name && policy.document.name.length > 0
-                  ? policy.document.name
-                  : true,
-            }
-          : undefined,
-      )
+    const { data: signed, error: signedError } = await auth.supabase.storage.from(BUCKET).createSignedUrl(
+      policy.document.path,
+      60 * 15,
+      downloadRequested
+        ? {
+            download: policy.document.name && policy.document.name.length > 0 ? policy.document.name : true,
+          }
+        : undefined
+    )
     if (signedError || !signed?.signedUrl) {
-      return NextResponse.json(
-        { error: signedError?.message ?? "Unable to access policy document." },
-        { status: 500 },
-      )
+      return NextResponse.json({ error: signedError?.message ?? "Unable to access policy document." }, { status: 500 })
     }
     return NextResponse.json({ url: signed.signedUrl, document: policy.document }, { status: 200 })
   } catch (error: unknown) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to load policy document." },
-      { status: 500 },
+      {
+        error: error instanceof Error ? error.message : "Unable to load policy document.",
+      },
+      { status: 500 }
     )
   }
 }
@@ -252,18 +215,6 @@ export async function POST(request: NextRequest) {
   if (validationError) return NextResponse.json({ error: validationError }, { status: 400 })
 
   try {
-    const profile = await loadProfile(auth.supabase, auth.orgId)
-    const policies = readPolicies(profile)
-    const existing = policies.find((entry) => entry.id === policyId)
-    if (!existing) return NextResponse.json({ error: "Policy not found." }, { status: 404 })
-
-    if (
-      existing.document?.path &&
-      isPolicyDocumentPath(existing.document.path, auth.orgId, policyId)
-    ) {
-      await auth.supabase.storage.from(BUCKET).remove([existing.document.path])
-    }
-
     const objectName = `${auth.orgId}/policies/${policyId}/${Date.now()}-${sanitizeFilename(file.name)}`
     const buf = Buffer.from(await file.arrayBuffer())
     const { error: uploadError } = await auth.supabase.storage.from(BUCKET).upload(objectName, buf, {
@@ -281,18 +232,44 @@ export async function POST(request: NextRequest) {
       mime: file.type || "application/pdf",
       updatedAt: now,
     }
-    const nextPolicy: OrgPolicy = {
-      ...existing,
-      document: nextDocument,
-      updatedAt: now,
+    const mutation = await mutateOrganizationProfile({
+      supabase: auth.supabase,
+      orgId: auth.orgId,
+      mutate: (profile) => {
+        const policies = readPolicies(profile)
+        const existing = policies.find((entry) => entry.id === policyId)
+        if (!existing) return { error: "Policy not found.", status: 404 }
+
+        const nextPolicy: OrgPolicy = {
+          ...existing,
+          document: nextDocument,
+          updatedAt: now,
+        }
+        const nextPolicies = policies.map((entry) => (entry.id === policyId ? nextPolicy : entry))
+        return {
+          changed: true,
+          nextProfile: { ...profile, policies: nextPolicies },
+          value: { nextPolicy, previousPath: existing.document?.path ?? null },
+        }
+      },
+    })
+    if ("error" in mutation) {
+      await auth.supabase.storage.from(BUCKET).remove([objectName])
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
-    const nextPolicies = policies.map((entry) => (entry.id === policyId ? nextPolicy : entry))
-    await savePolicies(auth.supabase, auth.orgId, profile, nextPolicies)
+
+    const { nextPolicy, previousPath } = mutation.value
+    if (previousPath && previousPath !== objectName && isPolicyDocumentPath(previousPath, auth.orgId, policyId)) {
+      const { error: cleanupError } = await auth.supabase.storage.from(BUCKET).remove([previousPath])
+      if (cleanupError) console.warn("Failed to remove replaced policy document")
+    }
     return NextResponse.json({ policy: nextPolicy }, { status: 200 })
   } catch (error: unknown) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to upload policy document." },
-      { status: 500 },
+      {
+        error: error instanceof Error ? error.message : "Unable to upload policy document.",
+      },
+      { status: 500 }
     )
   }
 }
@@ -304,31 +281,44 @@ export async function DELETE(request: NextRequest) {
   if (!policyId) return NextResponse.json({ error: "Policy id is required." }, { status: 400 })
 
   try {
-    const profile = await loadProfile(auth.supabase, auth.orgId)
-    const policies = readPolicies(profile)
-    const existing = policies.find((entry) => entry.id === policyId)
-    if (!existing) return NextResponse.json({ error: "Policy not found." }, { status: 404 })
-    if (!existing.document?.path) {
-      return NextResponse.json({ error: "Policy document not found." }, { status: 404 })
-    }
-    if (!isPolicyDocumentPath(existing.document.path, auth.orgId, policyId)) {
-      return NextResponse.json({ error: "Policy document not found." }, { status: 404 })
+    const mutation = await mutateOrganizationProfile({
+      supabase: auth.supabase,
+      orgId: auth.orgId,
+      mutate: (profile) => {
+        const policies = readPolicies(profile)
+        const existing = policies.find((entry) => entry.id === policyId)
+        if (!existing) return { error: "Policy not found.", status: 404 }
+        if (!existing.document?.path || !isPolicyDocumentPath(existing.document.path, auth.orgId, policyId)) {
+          return { error: "Policy document not found.", status: 404 }
+        }
+
+        const nextPolicy: OrgPolicy = {
+          ...existing,
+          document: null,
+          updatedAt: new Date().toISOString(),
+        }
+        const nextPolicies = policies.map((entry) => (entry.id === policyId ? nextPolicy : entry))
+        return {
+          changed: true,
+          nextProfile: { ...profile, policies: nextPolicies },
+          value: { nextPolicy, path: existing.document.path },
+        }
+      },
+    })
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
 
-    await auth.supabase.storage.from(BUCKET).remove([existing.document.path])
-    const now = new Date().toISOString()
-    const nextPolicy: OrgPolicy = {
-      ...existing,
-      document: null,
-      updatedAt: now,
-    }
-    const nextPolicies = policies.map((entry) => (entry.id === policyId ? nextPolicy : entry))
-    await savePolicies(auth.supabase, auth.orgId, profile, nextPolicies)
+    const { nextPolicy, path } = mutation.value
+    const { error: cleanupError } = await auth.supabase.storage.from(BUCKET).remove([path])
+    if (cleanupError) console.warn("Failed to remove deleted policy document")
     return NextResponse.json({ policy: nextPolicy }, { status: 200 })
   } catch (error: unknown) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to remove policy document." },
-      { status: 500 },
+      {
+        error: error instanceof Error ? error.message : "Unable to remove policy document.",
+      },
+      { status: 500 }
     )
   }
 }

--- a/src/app/api/account/org-policies/route.ts
+++ b/src/app/api/account/org-policies/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
-import type { Database } from "@/lib/supabase"
 import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import { mutateOrganizationProfile } from "@/lib/organization/profile-mutation"
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
 
 type OrgPolicyStatus = "not_started" | "in_progress" | "complete"
@@ -27,11 +27,7 @@ type OrgPolicy = {
   updatedAt: string
 }
 
-const ALLOWED_STATUSES = new Set<OrgPolicyStatus>([
-  "not_started",
-  "in_progress",
-  "complete",
-])
+const ALLOWED_STATUSES = new Set<OrgPolicyStatus>(["not_started", "in_progress", "complete"])
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
@@ -61,8 +57,7 @@ function normalizeDocument(value: unknown): OrgPolicyDocument | null {
     path: value["path"],
     size: typeof value["size"] === "number" ? value["size"] : 0,
     mime: typeof value["mime"] === "string" ? value["mime"] : "application/pdf",
-    updatedAt:
-      typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date().toISOString(),
+    updatedAt: typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date().toISOString(),
   }
 }
 
@@ -72,9 +67,7 @@ function normalizePolicy(entry: unknown): OrgPolicy | null {
   const title = typeof entry["title"] === "string" ? entry["title"].trim() : ""
   if (!id || !title) return null
   const statusRaw = typeof entry["status"] === "string" ? entry["status"] : "not_started"
-  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus)
-    ? (statusRaw as OrgPolicyStatus)
-    : "not_started"
+  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus) ? (statusRaw as OrgPolicyStatus) : "not_started"
   const personIdsRaw = Array.isArray(entry["personIds"]) ? (entry["personIds"] as unknown[]) : []
   const updatedAtRaw = typeof entry["updatedAt"] === "string" ? entry["updatedAt"] : new Date().toISOString()
   const categories = normalizeCategories(entry["categories"])
@@ -86,16 +79,17 @@ function normalizePolicy(entry: unknown): OrgPolicy | null {
     status,
     categories: categories.length > 0 ? categories : legacyBoard ? ["Board"] : [],
     programId: typeof entry["programId"] === "string" && entry["programId"].trim().length > 0 ? entry["programId"].trim() : null,
-    personIds: Array.from(new Set(personIdsRaw.filter((value): value is string => typeof value === "string" && value.trim().length > 0).map((value) => value.trim()))),
+    personIds: Array.from(
+      new Set(
+        personIdsRaw.filter((value): value is string => typeof value === "string" && value.trim().length > 0).map((value) => value.trim())
+      )
+    ),
     document: normalizeDocument(entry["document"]),
     updatedAt: updatedAtRaw,
   }
 }
 
-async function loadProfile(
-  supabase: ReturnType<typeof createSupabaseRouteHandlerClient>,
-  orgId: string,
-) {
+async function loadProfile(supabase: ReturnType<typeof createSupabaseRouteHandlerClient>, orgId: string) {
   const { data: orgRow, error } = await supabase
     .from("organizations")
     .select("profile")
@@ -111,23 +105,8 @@ function readPolicies(profile: Record<string, unknown>): OrgPolicy[] {
   return raw.map((entry) => normalizePolicy(entry)).filter((entry): entry is OrgPolicy => Boolean(entry))
 }
 
-async function savePolicies(
-  supabase: ReturnType<typeof createSupabaseRouteHandlerClient>,
-  orgId: string,
-  profile: Record<string, unknown>,
-  policies: OrgPolicy[],
-) {
-  const nextProfile = { ...profile, policies }
-  const { error } = await supabase
-    .from("organizations")
-    .upsert(
-      {
-        user_id: orgId,
-        profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-      },
-      { onConflict: "user_id" },
-    )
-  if (error) throw new Error(error.message)
+function isPolicyDocumentPath(path: string, orgId: string, policyId: string) {
+  return path.startsWith(`${orgId}/policies/${policyId}/`)
 }
 
 async function requireOrgEditor(request: NextRequest) {
@@ -138,7 +117,9 @@ async function requireOrgEditor(request: NextRequest) {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    return { error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }) }
+    return {
+      error: NextResponse.json({ error: error?.message ?? "Unauthorized" }, { status: 401 }),
+    }
   }
   const { orgId, role } = await resolveActiveOrganization(supabase, user.id)
   if (!canEditOrganization(role)) {
@@ -163,10 +144,7 @@ export async function GET(request: NextRequest) {
     const profile = await loadProfile(supabase, orgId)
     return NextResponse.json({ policies: readPolicies(profile) }, { status: 200 })
   } catch (err: unknown) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unable to load policies" },
-      { status: 500 },
-    )
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Unable to load policies" }, { status: 500 })
   }
 }
 
@@ -181,9 +159,7 @@ export async function POST(request: NextRequest) {
   }
 
   const statusRaw = typeof payload?.status === "string" ? payload.status : "not_started"
-  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus)
-    ? (statusRaw as OrgPolicyStatus)
-    : "not_started"
+  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus) ? (statusRaw as OrgPolicyStatus) : "not_started"
   const categories = normalizeCategories(payload?.categories)
   if (categories.length === 0 && Boolean(payload?.board)) {
     categories.push("Board")
@@ -195,17 +171,14 @@ export async function POST(request: NextRequest) {
     summary: typeof payload?.summary === "string" ? payload.summary.trim() : "",
     status,
     categories,
-    programId:
-      typeof payload?.programId === "string" && payload.programId.trim().length > 0
-        ? payload.programId.trim()
-        : null,
+    programId: typeof payload?.programId === "string" && payload.programId.trim().length > 0 ? payload.programId.trim() : null,
     personIds: Array.isArray(payload?.personIds)
       ? Array.from(
           new Set(
             (payload.personIds as unknown[])
               .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-              .map((value) => value.trim()),
-          ),
+              .map((value) => value.trim())
+          )
         )
       : [],
     document: null,
@@ -213,16 +186,24 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const profile = await loadProfile(auth.supabase, auth.orgId)
-    const policies = readPolicies(profile)
-    const nextPolicies = [nextPolicy, ...policies]
-    await savePolicies(auth.supabase, auth.orgId, profile, nextPolicies)
-    return NextResponse.json({ policy: nextPolicy, policies: nextPolicies }, { status: 200 })
+    const mutation = await mutateOrganizationProfile({
+      supabase: auth.supabase,
+      orgId: auth.orgId,
+      mutate: (profile) => {
+        const nextPolicies = [nextPolicy, ...readPolicies(profile)]
+        return {
+          changed: true,
+          nextProfile: { ...profile, policies: nextPolicies },
+          value: nextPolicies,
+        }
+      },
+    })
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
+    }
+    return NextResponse.json({ policy: nextPolicy, policies: mutation.value }, { status: 200 })
   } catch (err: unknown) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unable to create policy" },
-      { status: 500 },
-    )
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Unable to create policy" }, { status: 500 })
   }
 }
 
@@ -238,50 +219,59 @@ export async function PATCH(request: NextRequest) {
   if (!title) return NextResponse.json({ error: "Policy title is required." }, { status: 400 })
 
   const statusRaw = typeof payload?.status === "string" ? payload.status : "not_started"
-  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus)
-    ? (statusRaw as OrgPolicyStatus)
-    : "not_started"
+  const status = ALLOWED_STATUSES.has(statusRaw as OrgPolicyStatus) ? (statusRaw as OrgPolicyStatus) : "not_started"
   const categories = normalizeCategories(payload?.categories)
   if (categories.length === 0 && Boolean(payload?.board)) {
     categories.push("Board")
   }
 
   try {
-    const profile = await loadProfile(auth.supabase, auth.orgId)
-    const policies = readPolicies(profile)
-    const existing = policies.find((entry) => entry.id === id)
-    if (!existing) return NextResponse.json({ error: "Policy not found." }, { status: 404 })
+    const mutation = await mutateOrganizationProfile({
+      supabase: auth.supabase,
+      orgId: auth.orgId,
+      mutate: (profile) => {
+        const policies = readPolicies(profile)
+        const existing = policies.find((entry) => entry.id === id)
+        if (!existing) return { error: "Policy not found.", status: 404 }
 
-    const nextPolicy: OrgPolicy = {
-      ...existing,
-      title,
-      summary: typeof payload?.summary === "string" ? payload.summary.trim() : "",
-      status,
-      categories,
-      programId:
-        typeof payload?.programId === "string" && payload.programId.trim().length > 0
-          ? payload.programId.trim()
-          : null,
-      personIds: Array.isArray(payload?.personIds)
-        ? Array.from(
-            new Set(
-              (payload.personIds as unknown[])
-                .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-                .map((value) => value.trim()),
-            ),
-          )
-        : [],
-      updatedAt: new Date().toISOString(),
+        const nextPolicy: OrgPolicy = {
+          ...existing,
+          title,
+          summary: typeof payload?.summary === "string" ? payload.summary.trim() : "",
+          status,
+          categories,
+          programId: typeof payload?.programId === "string" && payload.programId.trim().length > 0 ? payload.programId.trim() : null,
+          personIds: Array.isArray(payload?.personIds)
+            ? Array.from(
+                new Set(
+                  (payload.personIds as unknown[])
+                    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+                    .map((value) => value.trim())
+                )
+              )
+            : [],
+          updatedAt: new Date().toISOString(),
+        }
+        const nextPolicies = policies.map((entry) => (entry.id === id ? nextPolicy : entry))
+        return {
+          changed: true,
+          nextProfile: { ...profile, policies: nextPolicies },
+          value: { nextPolicy, nextPolicies },
+        }
+      },
+    })
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
-
-    const nextPolicies = policies.map((entry) => (entry.id === id ? nextPolicy : entry))
-    await savePolicies(auth.supabase, auth.orgId, profile, nextPolicies)
-    return NextResponse.json({ policy: nextPolicy, policies: nextPolicies }, { status: 200 })
-  } catch (err: unknown) {
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unable to update policy" },
-      { status: 500 },
+      {
+        policy: mutation.value.nextPolicy,
+        policies: mutation.value.nextPolicies,
+      },
+      { status: 200 }
     )
+  } catch (err: unknown) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Unable to update policy" }, { status: 500 })
   }
 }
 
@@ -294,19 +284,31 @@ export async function DELETE(request: NextRequest) {
   if (!id) return NextResponse.json({ error: "Policy id is required." }, { status: 400 })
 
   try {
-    const profile = await loadProfile(auth.supabase, auth.orgId)
-    const policies = readPolicies(profile)
-    const policyToDelete = policies.find((entry) => entry.id === id)
-    if (policyToDelete?.document?.path) {
-      await auth.supabase.storage.from(BUCKET).remove([policyToDelete.document.path])
+    const mutation = await mutateOrganizationProfile({
+      supabase: auth.supabase,
+      orgId: auth.orgId,
+      mutate: (profile) => {
+        const policies = readPolicies(profile)
+        const policyToDelete = policies.find((entry) => entry.id === id)
+        const nextPolicies = policies.filter((entry) => entry.id !== id)
+        return {
+          changed: Boolean(policyToDelete),
+          nextProfile: { ...profile, policies: nextPolicies },
+          value: { path: policyToDelete?.document?.path ?? null, nextPolicies },
+        }
+      },
+    })
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
-    const nextPolicies = policies.filter((entry) => entry.id !== id)
-    await savePolicies(auth.supabase, auth.orgId, profile, nextPolicies)
+
+    const { path, nextPolicies } = mutation.value
+    if (path && isPolicyDocumentPath(path, auth.orgId, id)) {
+      const { error: cleanupError } = await auth.supabase.storage.from(BUCKET).remove([path])
+      if (cleanupError) console.warn("Failed to remove deleted policy document")
+    }
     return NextResponse.json({ ok: true, policies: nextPolicies }, { status: 200 })
   } catch (err: unknown) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Unable to delete policy" },
-      { status: 500 },
-    )
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Unable to delete policy" }, { status: 500 })
   }
 }

--- a/src/app/api/account/org-public-documents/route.ts
+++ b/src/app/api/account/org-public-documents/route.ts
@@ -2,9 +2,9 @@ import { NextResponse, type NextRequest } from "next/server"
 import { revalidatePath } from "next/cache"
 
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
-import type { Database } from "@/lib/supabase"
 import { ORG_MEDIA_BUCKET } from "@/lib/storage/org-media"
 import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
+import { mutateOrganizationProfile } from "@/lib/organization/profile-mutation"
 import { createNotification } from "@/lib/notifications"
 
 const MAX_BYTES = 15 * 1024 * 1024
@@ -44,9 +44,7 @@ function validatePdf(file: File): string | null {
 function getKind(searchParams: URLSearchParams): PublicDocumentKind | null {
   const kind = searchParams.get("kind")
   if (!kind) return null
-  return (Object.keys(KIND_KEY_MAP) as PublicDocumentKind[]).includes(kind as PublicDocumentKind)
-    ? (kind as PublicDocumentKind)
-    : null
+  return (Object.keys(KIND_KEY_MAP) as PublicDocumentKind[]).includes(kind as PublicDocumentKind) ? (kind as PublicDocumentKind) : null
 }
 
 function getAttachments(profile: Record<string, unknown>): Record<PublicDocumentKind, PublicDocumentMeta[]> {
@@ -71,25 +69,22 @@ function getAttachments(profile: Record<string, unknown>): Record<PublicDocument
   return output
 }
 
-function updateAttachmentsProfile(
-  profile: Record<string, unknown>,
-  kind: PublicDocumentKind,
-  nextList: PublicDocumentMeta[],
-) {
+function updateAttachmentsProfile(profile: Record<string, unknown>, kind: PublicDocumentKind, nextList: PublicDocumentMeta[]) {
   const current = isRecord(profile["publicAttachments"]) ? { ...(profile["publicAttachments"] as Record<string, unknown>) } : {}
   current[kind] = nextList
   return { ...profile, publicAttachments: current }
 }
 
-async function loadOrgRow(
-  supabase: ReturnType<typeof createSupabaseRouteHandlerClient>,
-  userId: string,
-) {
+async function loadOrgRow(supabase: ReturnType<typeof createSupabaseRouteHandlerClient>, userId: string) {
   const { data: orgRow, error } = await supabase
     .from("organizations")
     .select("profile, public_slug, is_public")
     .eq("user_id", userId)
-    .maybeSingle<{ profile: Record<string, unknown> | null; public_slug: string | null; is_public: boolean | null }>()
+    .maybeSingle<{
+      profile: Record<string, unknown> | null
+      public_slug: string | null
+      is_public: boolean | null
+    }>()
 
   if (error) {
     throw new Error(error.message)
@@ -164,8 +159,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 })
     }
 
-    const { profile, publicSlug } = await loadOrgRow(supabase, orgId)
-    const currentAttachments = getAttachments(profile)[kind]
+    const { publicSlug } = await loadOrgRow(supabase, orgId)
 
     const safeName = sanitizeFilename(file.name)
     const objectName = `${orgId}/public-documents/${kind}/${Date.now()}-${safeName}`
@@ -189,21 +183,23 @@ export async function POST(request: NextRequest) {
       updatedAt: new Date().toISOString(),
     }
 
-    const nextList = [...currentAttachments, doc].slice(-12)
-    const nextProfile = updateAttachmentsProfile(profile, kind, nextList)
-    const { error: upsertError } = await supabase
-      .from("organizations")
-      .upsert(
-        {
-          user_id: orgId,
-          profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-        },
-        { onConflict: "user_id" },
-      )
+    const mutation = await mutateOrganizationProfile({
+      supabase,
+      orgId,
+      mutate: (profile) => {
+        const currentAttachments = getAttachments(profile)[kind]
+        const nextList = [...currentAttachments, doc].slice(-12)
+        return {
+          changed: true,
+          nextProfile: updateAttachmentsProfile(profile, kind, nextList),
+          value: nextList,
+        }
+      },
+    })
 
-    if (upsertError) {
+    if ("error" in mutation) {
       await supabase.storage.from(ORG_MEDIA_BUCKET).remove([objectName])
-      return NextResponse.json({ error: upsertError.message }, { status: 500 })
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
 
     const notifyResult = await createNotification(supabase, {
@@ -221,7 +217,7 @@ export async function POST(request: NextRequest) {
     }
 
     revalidateOrgPaths(publicSlug)
-    return NextResponse.json({ document: doc, attachments: nextList }, { status: 200 })
+    return NextResponse.json({ document: doc, attachments: mutation.value }, { status: 200 })
   } catch (err: unknown) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Upload failed" }, { status: 500 })
   }
@@ -260,32 +256,33 @@ export async function DELETE(request: NextRequest) {
   }
 
   try {
-    const { profile, publicSlug } = await loadOrgRow(supabase, orgId)
-    const currentAttachments = getAttachments(profile)[kind]
-    const nextList = currentAttachments.filter((doc) => doc.path !== path)
-    if (nextList.length === currentAttachments.length) {
-      return NextResponse.json({ error: "File not found" }, { status: 404 })
+    const { publicSlug } = await loadOrgRow(supabase, orgId)
+    const mutation = await mutateOrganizationProfile({
+      supabase,
+      orgId,
+      mutate: (profile) => {
+        const currentAttachments = getAttachments(profile)[kind]
+        const nextList = currentAttachments.filter((doc) => doc.path !== path)
+        if (nextList.length === currentAttachments.length) {
+          return { error: "File not found", status: 404 }
+        }
+        return {
+          changed: true,
+          nextProfile: updateAttachmentsProfile(profile, kind, nextList),
+          value: nextList,
+        }
+      },
+    })
+
+    if ("error" in mutation) {
+      return NextResponse.json({ error: mutation.error }, { status: mutation.status })
     }
 
-    await supabase.storage.from(ORG_MEDIA_BUCKET).remove([path])
-
-    const nextProfile = updateAttachmentsProfile(profile, kind, nextList)
-    const { error: upsertError } = await supabase
-      .from("organizations")
-      .upsert(
-        {
-          user_id: orgId,
-          profile: nextProfile as Database["public"]["Tables"]["organizations"]["Insert"]["profile"],
-        },
-        { onConflict: "user_id" },
-      )
-
-    if (upsertError) {
-      return NextResponse.json({ error: upsertError.message }, { status: 500 })
-    }
+    const { error: cleanupError } = await supabase.storage.from(ORG_MEDIA_BUCKET).remove([path])
+    if (cleanupError) console.warn("Failed to remove deleted public document")
 
     revalidateOrgPaths(publicSlug)
-    return NextResponse.json({ ok: true, attachments: nextList }, { status: 200 })
+    return NextResponse.json({ ok: true, attachments: mutation.value }, { status: 200 })
   } catch (err: unknown) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Delete failed" }, { status: 500 })
   }

--- a/src/lib/organization/profile-mutation.ts
+++ b/src/lib/organization/profile-mutation.ts
@@ -1,0 +1,80 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+const DEFAULT_MAX_ATTEMPTS = 4
+
+export const ORGANIZATION_PROFILE_CONFLICT_ERROR =
+  "Organization data changed while you were saving. Refresh and try again."
+
+type OrganizationProfile = Record<string, unknown>
+
+export type OrganizationProfileMutation<T> =
+  | { changed: false; value: T }
+  | {
+      changed: true
+      nextProfile: OrganizationProfile
+      value: T
+    }
+  | { error: string; status?: number }
+
+export type OrganizationProfileMutationResult<T> =
+  | { ok: true; value: T }
+  | { error: string; status: number }
+
+export async function mutateOrganizationProfile<T>({
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  mutate,
+  orgId,
+  supabase,
+}: {
+  maxAttempts?: number
+  mutate: (profile: OrganizationProfile) => OrganizationProfileMutation<T>
+  orgId: string
+  supabase: SupabaseClient<Database>
+}): Promise<OrganizationProfileMutationResult<T>> {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const { data: organization, error: readError } = await supabase
+      .from("organizations")
+      .select("profile, updated_at")
+      .eq("user_id", orgId)
+      .maybeSingle<{
+        profile: OrganizationProfile | null
+        updated_at: string
+      }>()
+
+    if (readError) {
+      return { error: readError.message, status: 500 }
+    }
+    if (!organization) {
+      return { error: "Organization not found.", status: 404 }
+    }
+
+    const result = mutate(organization.profile ?? {})
+    if ("error" in result) {
+      return { error: result.error, status: result.status ?? 400 }
+    }
+    if (!result.changed) {
+      return { ok: true, value: result.value }
+    }
+
+    const profile =
+      result.nextProfile as Database["public"]["Tables"]["organizations"]["Update"]["profile"]
+    const { data: updated, error: writeError } = await supabase
+      .from("organizations")
+      .update({ profile })
+      .eq("user_id", orgId)
+      .eq("updated_at", organization.updated_at)
+      .select("updated_at")
+      .maybeSingle<{ updated_at: string }>()
+
+    if (writeError) {
+      return { error: writeError.message, status: 500 }
+    }
+    if (updated) {
+      return { ok: true, value: result.value }
+    }
+  }
+
+  return { error: ORGANIZATION_PROFILE_CONFLICT_ERROR, status: 409 }
+}

--- a/tests/acceptance/organization-document-write-safety.test.ts
+++ b/tests/acceptance/organization-document-write-safety.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+
+function readRoute(path: string) {
+  return readFileSync(join(ROOT, path), "utf8")
+}
+
+function handler(source: string, method: "POST" | "DELETE") {
+  const start = source.indexOf(`export async function ${method}`)
+  const nextExport = source.indexOf("\nexport async function ", start + 1)
+  return source.slice(start, nextExport === -1 ? undefined : nextExport)
+}
+
+describe("organization document write safety", () => {
+  const documentRoute = readRoute("src/app/api/account/org-documents/route.ts")
+  const policyRoute = readRoute("src/app/api/account/org-policies/route.ts")
+  const policyDocumentRoute = readRoute(
+    "src/app/api/account/org-policies/document/route.ts"
+  )
+  const publicDocumentRoute = readRoute(
+    "src/app/api/account/org-public-documents/route.ts"
+  )
+
+  it("uses conflict-safe profile mutations instead of whole-profile upserts", () => {
+    for (const source of [
+      documentRoute,
+      policyRoute,
+      policyDocumentRoute,
+      publicDocumentRoute,
+    ]) {
+      expect(source).toContain("mutateOrganizationProfile")
+      expect(source).not.toContain(".upsert(")
+    }
+  })
+
+  it("commits replacement metadata before removing any storage object", () => {
+    for (const source of [
+      documentRoute,
+      policyDocumentRoute,
+      publicDocumentRoute,
+    ]) {
+      const post = handler(source, "POST")
+      const upload = post.indexOf(".upload(")
+      const mutation = post.indexOf("mutateOrganizationProfile")
+      const firstRemoval = post.indexOf(".remove(")
+
+      expect(upload).toBeGreaterThan(-1)
+      expect(mutation).toBeGreaterThan(upload)
+      expect(firstRemoval).toBeGreaterThan(mutation)
+    }
+  })
+
+  it("rolls back staged uploads when the profile mutation fails", () => {
+    expect(handler(documentRoute, "POST")).toContain(".remove([objectName])")
+    expect(handler(policyDocumentRoute, "POST")).toContain(
+      ".remove([objectName])"
+    )
+    expect(handler(publicDocumentRoute, "POST")).toContain(
+      ".remove([objectName])"
+    )
+  })
+
+  it("commits delete metadata before storage cleanup", () => {
+    for (const source of [
+      documentRoute,
+      policyRoute,
+      policyDocumentRoute,
+      publicDocumentRoute,
+    ]) {
+      const remove = handler(source, "DELETE")
+      expect(remove.indexOf("mutateOrganizationProfile")).toBeLessThan(
+        remove.indexOf(".remove(")
+      )
+    }
+  })
+})

--- a/tests/acceptance/organization-profile-mutation.test.ts
+++ b/tests/acceptance/organization-profile-mutation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  mutateOrganizationProfile,
+  ORGANIZATION_PROFILE_CONFLICT_ERROR,
+} from "@/lib/organization/profile-mutation"
+
+function buildSupabaseStub({
+  profiles,
+  writes,
+}: {
+  profiles: Array<{ profile: Record<string, unknown>; updated_at: string }>
+  writes: Array<{ updated_at: string } | null>
+}) {
+  let readIndex = 0
+  let writeIndex = 0
+  const readMaybeSingle = vi.fn(async () => {
+    const data = profiles[readIndex] ?? profiles.at(-1) ?? null
+    readIndex += 1
+    return { data, error: null }
+  })
+  const writeMaybeSingle = vi.fn(async () => {
+    const data = writes[writeIndex] ?? null
+    writeIndex += 1
+    return { data, error: null }
+  })
+  const readEq = vi.fn(() => ({ maybeSingle: readMaybeSingle }))
+  const readSelect = vi.fn(() => ({ eq: readEq }))
+  const writeSelect = vi.fn(() => ({ maybeSingle: writeMaybeSingle }))
+  const writeEq = vi.fn(() => ({ eq: writeEq, select: writeSelect }))
+  const update = vi.fn(() => ({ eq: writeEq }))
+  const from = vi.fn(() => ({ select: readSelect, update }))
+
+  return {
+    supabase: { from } as never,
+    calls: { from, update },
+  }
+}
+
+describe("organization profile mutation", () => {
+  it("retries against the newest profile after a stale revision", async () => {
+    const { calls, supabase } = buildSupabaseStub({
+      profiles: [
+        { profile: { name: "Original" }, updated_at: "revision-1" },
+        {
+          profile: { name: "Concurrent", unrelated: true },
+          updated_at: "revision-2",
+        },
+      ],
+      writes: [null, { updated_at: "revision-3" }],
+    })
+
+    const result = await mutateOrganizationProfile({
+      orgId: "org-1",
+      supabase,
+      mutate: (profile) => ({
+        changed: true,
+        nextProfile: { ...profile, documents: { bylaws: true } },
+        value: null,
+      }),
+    })
+
+    expect(result).toEqual({ ok: true, value: null })
+    expect(calls.update).toHaveBeenCalledTimes(2)
+    expect(calls.update).toHaveBeenLastCalledWith({
+      profile: {
+        name: "Concurrent",
+        unrelated: true,
+        documents: { bylaws: true },
+      },
+    })
+  })
+
+  it("returns a conflict without overwriting after bounded retries", async () => {
+    const { supabase } = buildSupabaseStub({
+      profiles: [
+        { profile: {}, updated_at: "revision-1" },
+        { profile: {}, updated_at: "revision-2" },
+      ],
+      writes: [null, null],
+    })
+
+    const result = await mutateOrganizationProfile({
+      maxAttempts: 2,
+      orgId: "org-1",
+      supabase,
+      mutate: (profile) => ({
+        changed: true,
+        nextProfile: { ...profile, policies: [] },
+        value: null,
+      }),
+    })
+
+    expect(result).toEqual({
+      error: ORGANIZATION_PROFILE_CONFLICT_ERROR,
+      status: 409,
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Added revision-aware organization profile mutations with bounded conflict retries.
- Updated organization documents, policies, policy documents, and public documents to avoid stale whole-profile overwrites.
- Uploads now stage the new object, commit its reference, then clean up the replaced object.
- Deletes now commit metadata removal before best-effort storage cleanup.
- Added concurrency, rollback, and operation-order coverage.
- Updated the Wave 1 PRD evidence and August runlog.

## Root cause

These routes used read-modify-upsert against the entire organization profile. Concurrent changes could be overwritten. Replacement and deletion also removed storage objects before the profile write succeeded, which could leave users with broken document references.

## Impact

Concurrent organization edits are preserved. Failed document writes retain the previous working file. Cleanup failures may leave an unreachable storage object, but cannot disconnect the user-facing document.

## Validation

- `pnpm check:quality` passes.
- 2,036 acceptance tests pass; one intentional skip.
- Fiscal and Finance RLS suites pass; optional generic RLS skipped without separate credentials.
- Production build passes for 108 routes.
- 30/30 visual tests pass against the isolated branch preview.
- Performance budgets pass.
- Authenticated read-only Documents browser smoke passes on the isolated preview.

No production, database, Stripe, billing, Finance, organization, document, or storage data was changed.