### PR TITLE
[STEP S40] Keep profile reads read-only

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -80,8 +80,9 @@ the relevant wave rather than inferred from merge status:
 | PR #131      | Find and Build product and rollout clarification            |
 | PR #132      | Public Find light-mode contrast repair                       |
 | PR #133      | Parallel organization-detail server reads                   |
+| PR #134      | Revision-safe organization document writes                  |
 
-The baseline is `origin/main` commit `46ab9301` on 2026-08-11. A production
+The baseline is `origin/main` commit `e114e45d` on 2026-08-11. A production
 read of `/api/public/resource-map/items` returned `853` records in a
 `2,519,484`-byte response. That is a live endpoint snapshot, not a performance
 guarantee or proof that all records rendered correctly.
@@ -127,13 +128,14 @@ wave, but unrelated scope does not accumulate in one PR.
   surfaces on desktop and mobile.
 - PR #133 is merged and production-verified for organization-detail rendering
   and recoverable missing Stripe-subscription links.
-- The organization document-safety repair is code complete on the focused
-  `fix/document-upload-atomicity-20260811` branch. It replaces stale
-  whole-profile upserts with revision-aware retries and commits document
-  references before removing replaced or deleted storage objects. Focused
-  concurrency and ordering tests, the full quality gate, and an authenticated
-  isolated Documents render pass. Hosted preview, merge, deployment, and
-  production proof remain required.
+- PR #134 is merged and production-verified for revision-safe organization
+  document writes. The authenticated production Documents index rendered its
+  existing files after deployment without a mutation.
+- Workspace and Roadmap render-time profile writes are removed on the focused
+  `fix/read-only-profile-cleanup-20260811` branch. Legacy content remains
+  normalized in memory. Focused coverage, the full quality gate, authenticated
+  rendering, and connected unchanged-revision proof pass. Hosted preview,
+  merge, deployment, and production proof remain required.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2561,3 +2561,24 @@
   existing organization files on the isolated preview. No organization,
   document, storage, billing, or Finance data was changed. Hosted preview,
   merge, deployment, and production proof remain required.
+
+2026-08-11 11:14 EDT - removed organization writes from Workspace and Roadmap reads.
+
+- Confirmed PR #134 is merged, both production deployments completed, and the
+  authenticated production Documents index renders its existing files.
+- Found that loading Workspace or Roadmap normalized legacy organization
+  profile content and silently upserted the whole profile during rendering.
+  A concurrent organization edit could be overwritten by a read.
+- Removed both render-time upserts while preserving the same in-memory HTML and
+  roadmap-section cleanup. Explicit save paths keep their existing sanitation.
+- Added source-contract coverage that prevents insert, update, or upsert calls
+  from returning to either rendering loader. Focused tests pass `13/13`.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,038`
+  acceptance tests with one intentional skip, fiscal and Finance RLS, the
+  `108`-route production build, `30/30` visuals against the isolated preview,
+  and performance budgets. The optional generic RLS suite skipped without its
+  separate credentials.
+- Authenticated Roadmap and Workspace reads left the connected organization's
+  `updated_at` revision unchanged. No organization, document, storage, billing,
+  or Finance data was changed. Hosted preview, merge, deployment, and
+  production proof remain required.

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-profile.ts
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-profile.ts
@@ -1,6 +1,5 @@
 import { cleanupOrgProfileHtml } from "@/lib/organization/profile-cleanup"
 import { resolveRoadmapSections } from "@/lib/roadmap"
-import type { Json } from "@/lib/supabase"
 import { resolveOptionalAuthenticatedAppContext } from "@/lib/auth/request-context"
 
 import { buildInitialOrganizationProfile } from "./helpers"
@@ -27,22 +26,7 @@ export async function loadMyOrganizationProfileContext({
       is_public: boolean | null
     }>()
 
-  let profile = (orgRow?.profile ?? {}) as Record<string, unknown>
-
-  if (orgRow?.profile) {
-    const { nextProfile, changed } = cleanupOrgProfileHtml(profile)
-    if (changed) {
-      const { error: cleanupError } = await supabase
-        .from("organizations")
-        .upsert(
-          { user_id: orgId, profile: nextProfile as Json },
-          { onConflict: "user_id" }
-        )
-      if (!cleanupError) {
-        profile = nextProfile
-      }
-    }
-  }
+  const profile = cleanupOrgProfileHtml(orgRow?.profile ?? {}).nextProfile
 
   const initialProfile = buildInitialOrganizationProfile({
     profile,

--- a/src/components/roadmap/strategic-roadmap-editor-page.tsx
+++ b/src/components/roadmap/strategic-roadmap-editor-page.tsx
@@ -6,7 +6,7 @@ import { cleanupRoadmapTestSections, resolveRoadmapHeroUrl, resolveRoadmapSectio
 import { resolveRoadmapHomework } from "@/lib/roadmap/homework"
 import { cleanupOrgProfileHtml } from "@/lib/organization/profile-cleanup"
 import { canEditOrganization, resolveActiveOrganization } from "@/lib/organization/active-org"
-import { createSupabaseServerClient, type Json } from "@/lib/supabase"
+import { createSupabaseServerClient } from "@/lib/supabase"
 import { isSupabaseAuthSessionMissingError } from "@/lib/supabase/auth-errors"
 import { supabaseErrorToError } from "@/lib/supabase/errors"
 
@@ -42,33 +42,8 @@ export async function StrategicRoadmapEditorPage({
       public_slug: string | null
     }>()
 
-  let profile = (orgRow?.profile ?? {}) as Record<string, unknown>
-
-  if (orgRow?.profile) {
-    let nextProfile = profile
-    let changed = false
-
-    const htmlCleanup = cleanupOrgProfileHtml(nextProfile)
-    if (htmlCleanup.changed) {
-      nextProfile = htmlCleanup.nextProfile
-      changed = true
-    }
-
-    const roadmapCleanup = cleanupRoadmapTestSections(nextProfile)
-    if (roadmapCleanup.changed) {
-      nextProfile = roadmapCleanup.nextProfile
-      changed = true
-    }
-
-    if (changed) {
-      const { error: cleanupError } = await supabase
-        .from("organizations")
-        .upsert({ user_id: orgId, profile: nextProfile as Json }, { onConflict: "user_id" })
-      if (!cleanupError) {
-        profile = nextProfile
-      }
-    }
-  }
+  const htmlCleanup = cleanupOrgProfileHtml(orgRow?.profile ?? {})
+  const profile = cleanupRoadmapTestSections(htmlCleanup.nextProfile).nextProfile
 
   const roadmapHomework = await resolveRoadmapHomework(orgId, supabase)
   const roadmapSections = resolveRoadmapSections(profile).map((section) => {

--- a/tests/acceptance/organization-profile-read-safety.test.ts
+++ b/tests/acceptance/organization-profile-read-safety.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+
+function readSource(path: string) {
+  return readFileSync(join(ROOT, path), "utf8")
+}
+
+describe("organization profile read safety", () => {
+  const workspaceProfileLoader = readSource(
+    "src/app/(dashboard)/my-organization/_lib/my-organization-page-profile.ts",
+  )
+  const roadmapPage = readSource(
+    "src/components/roadmap/strategic-roadmap-editor-page.tsx",
+  )
+
+  it("never writes the organization profile while rendering a page", () => {
+    for (const source of [workspaceProfileLoader, roadmapPage]) {
+      expect(source).not.toContain('.upsert(')
+      expect(source).not.toContain('.update(')
+      expect(source).not.toContain('.insert(')
+    }
+  })
+
+  it("still normalizes legacy profile content in memory", () => {
+    expect(workspaceProfileLoader).toContain(
+      "cleanupOrgProfileHtml(orgRow?.profile ?? {}).nextProfile",
+    )
+    expect(roadmapPage).toContain(
+      "cleanupOrgProfileHtml(orgRow?.profile ?? {})",
+    )
+    expect(roadmapPage).toContain(
+      "cleanupRoadmapTestSections(htmlCleanup.nextProfile).nextProfile",
+    )
+  })
+})


### PR DESCRIPTION
## What changed

- Removed organization profile upserts from Workspace and Roadmap rendering.
- Kept legacy HTML and roadmap-section cleanup in memory.
- Added regression coverage that prevents database writes from returning to either read path.
- Updated the Wave 1 PRD and runlog evidence.

## Why

Opening Workspace or Roadmap could silently upsert the whole organization profile. A concurrent edit could therefore be overwritten by a page read.

## Impact

Workspace and Roadmap reads are now read-only. Explicit save paths retain their existing sanitation behavior.

## Validation

- Focused tests: 13/13 passed.
- Full `pnpm check:quality` passed: lint, guardrails, snapshots, 2,038 acceptance tests with one skip, fiscal and Finance RLS, 108-route build, 30/30 visuals, and performance budgets.
- Pre-push gate passed.
- Authenticated Workspace and Roadmap reads left the connected organization's `updated_at` unchanged.
- No organization, document, storage, billing, or Finance data changed.
