### PR TITLE
[STEP S41] Keep People page reads read-only

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -81,8 +81,9 @@ the relevant wave rather than inferred from merge status:
 | PR #132      | Public Find light-mode contrast repair                       |
 | PR #133      | Parallel organization-detail server reads                   |
 | PR #134      | Revision-safe organization document writes                  |
+| PR #135      | Read-only Workspace and Roadmap rendering                    |
 
-The baseline is `origin/main` commit `e114e45d` on 2026-08-11. A production
+The baseline is `origin/main` commit `76460756` on 2026-08-11. A production
 read of `/api/public/resource-map/items` returned `853` records in a
 `2,519,484`-byte response. That is a live endpoint snapshot, not a performance
 guarantee or proof that all records rendered correctly.
@@ -131,11 +132,14 @@ wave, but unrelated scope does not accumulate in one PR.
 - PR #134 is merged and production-verified for revision-safe organization
   document writes. The authenticated production Documents index rendered its
   existing files after deployment without a mutation.
-- Workspace and Roadmap render-time profile writes are removed on the focused
-  `fix/read-only-profile-cleanup-20260811` branch. Legacy content remains
-  normalized in memory. Focused coverage, the full quality gate, authenticated
-  rendering, and connected unchanged-revision proof pass. Hosted preview,
-  merge, deployment, and production proof remain required.
+- PR #135 is merged and production-verified for read-only Workspace and
+  Roadmap rendering. Legacy content remains normalized in memory, both routes
+  render, and their production reads leave the organization revision unchanged.
+- People-page member synchronization is read-only on the focused
+  `fix/people-page-read-only-20260811` branch. Account-derived display data is
+  still shown, but opening People no longer persists it over organization
+  directory fields. Focused coverage and the full quality gate pass. Hosted
+  preview, merge, deployment, and production proof remain required.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2573,7 +2573,7 @@
   roadmap-section cleanup. Explicit save paths keep their existing sanitation.
 - Added source-contract coverage that prevents insert, update, or upsert calls
   from returning to either rendering loader. Focused tests pass `13/13`.
-- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,038`
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,040`
   acceptance tests with one intentional skip, fiscal and Finance RLS, the
   `108`-route production build, `30/30` visuals against the isolated preview,
   and performance budgets. The optional generic RLS suite skipped without its
@@ -2582,3 +2582,28 @@
   `updated_at` revision unchanged. No organization, document, storage, billing,
   or Finance data was changed. Hosted preview, merge, deployment, and
   production proof remain required.
+
+2026-08-11 11:52 EDT - kept People page loads from rewriting member data.
+
+- Confirmed PR #135 merged, then rebased the next focused Wave 1 repair onto
+  current `origin/main`.
+- Found that loading People synchronized the signed-in member's account name,
+  headline, email, avatar, and membership category into the organization
+  profile. Merely opening the page could overwrite directory fields that an
+  organization had set explicitly.
+- Kept the existing account-derived display synchronization in memory and
+  removed its organization-profile mutation. Explicit People edits, onboarding,
+  invites, and position writes retain their revision-aware persistence.
+- Added read-safety coverage and updated the existing People concurrency
+  contract. Focused tests pass `7/7`.
+- Full `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,038`
+  acceptance tests with one intentional skip, connected fiscal, Finance, and
+  generic RLS, the `108`-route production build, `30/30` visuals, and
+  performance budgets.
+- The authenticated platform People directory rendered `61` organizations and
+  `108` people. The connected organization revision remained unchanged. No
+  organization, People, billing, Finance, or storage data was changed. Hosted
+  preview, merge, deployment, and production proof remain required.
+- Both PR #135 production deployments completed. Authenticated production
+  Workspace and Roadmap renders passed, and the connected organization revision
+  remained unchanged across both reads.

--- a/src/features/member-workspace/server/loaders.ts
+++ b/src/features/member-workspace/server/loaders.ts
@@ -7,7 +7,6 @@ import { loadAdminOrganizationSummaries } from "@/features/member-workspace/serv
 import { resolveOptionalAuthenticatedAppContext } from "@/lib/auth/request-context"
 import { normalizePersonCategory } from "@/lib/people/categories"
 import { resolvePeopleDisplayImages } from "@/lib/people/display-images"
-import { mutateOrganizationPeopleProfile } from "@/lib/people/profile-write"
 import { canEditOrganization } from "@/lib/organization/active-org"
 import type { MemberWorkspacePeoplePageData } from "../types"
 export { loadMemberWorkspaceProjectsPage } from "./project-loaders"
@@ -130,32 +129,8 @@ export async function loadMemberWorkspacePeoplePage(): Promise<MemberWorkspacePe
       }
     }
 
-    if (canEdit) {
-      const syncResult = await mutateOrganizationPeopleProfile<
-        OrgPerson,
-        OrgPerson[]
-      >({
-        supabase,
-        orgId,
-        mutate: (people) => {
-          const sync = synchronizeSelf(people)
-          return sync.changed
-            ? {
-                ok: true,
-                changed: true,
-                people: sync.people,
-                value: sync.people,
-              }
-            : { ok: true, changed: false, value: people }
-        },
-      })
-      if (!("error" in syncResult)) {
-        peopleRaw.splice(0, peopleRaw.length, ...syncResult.value)
-      }
-    } else {
-      const sync = synchronizeSelf(peopleRaw)
-      if (sync.changed) peopleRaw.splice(0, peopleRaw.length, ...sync.people)
-    }
+    const sync = synchronizeSelf(peopleRaw)
+    if (sync.changed) peopleRaw.splice(0, peopleRaw.length, ...sync.people)
   }
 
   const normalizedPeople = peopleRaw.map((person) => ({

--- a/tests/acceptance/member-workspace-people-read-safety.test.ts
+++ b/tests/acceptance/member-workspace-people-read-safety.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const source = readFileSync(
+  join(
+    process.cwd(),
+    "src/features/member-workspace/server/loaders.ts",
+  ),
+  "utf8",
+)
+
+describe("member workspace People read safety", () => {
+  it("does not write the organization profile while loading People", () => {
+    expect(source).not.toContain("mutateOrganizationPeopleProfile")
+    expect(source).not.toContain(".upsert(")
+    expect(source).not.toContain(".update(")
+    expect(source).not.toContain(".insert(")
+  })
+
+  it("still synchronizes the signed-in member for display", () => {
+    expect(source).toContain("const sync = synchronizeSelf(peopleRaw)")
+    expect(source).toContain(
+      "peopleRaw.splice(0, peopleRaw.length, ...sync.people)",
+    )
+  })
+})

--- a/tests/acceptance/people-profile-write-concurrency.test.ts
+++ b/tests/acceptance/people-profile-write-concurrency.test.ts
@@ -147,7 +147,7 @@ describe("People profile write concurrency", () => {
     expect(writer).toContain("MAX_PROFILE_WRITE_ATTEMPTS = 4")
   })
 
-  it("guards automatic onboarding and directory synchronization writers", () => {
+  it("guards automatic onboarding writes and keeps directory reads read-only", () => {
     const onboarding = readSource("src/app/(dashboard)/onboarding/actions.ts")
     const onboardingWriter = readSource(
       "src/lib/onboarding/organization-profile-write.ts"
@@ -166,8 +166,9 @@ describe("People profile write concurrency", () => {
       ".upsert(\n        {\n          user_id: targetOrgId"
     )
     expect(invites).toContain("mutateOrganizationPeopleProfile<")
-    expect(memberDirectory).toContain("mutateOrganizationPeopleProfile<")
+    expect(memberDirectory).not.toContain("mutateOrganizationPeopleProfile<")
     expect(memberDirectory).toContain("...selfExisting")
+    expect(memberDirectory).toContain("const sync = synchronizeSelf(peopleRaw)")
     expect(memberDirectory).not.toContain(
       ".upsert({ user_id: orgId, profile: nextProfile }"
     )


### PR DESCRIPTION
## What changed

- Removed organization-profile persistence from the People page loader.
- Kept account-derived member synchronization in memory for the rendered directory.
- Added read-safety coverage and updated the existing People concurrency contract.
- Updated the Wave 1 PRD and runlog evidence.

## Why

Opening People could persist the signed-in member's account name, headline, email, avatar, and membership category over organization directory fields. A page read could therefore overwrite data the organization set explicitly.

## Impact

People page reads are now read-only. Explicit People edits, onboarding, invites, and position writes retain their revision-aware persistence.

## Validation

- Focused tests: 9/9 passed after rebasing onto current main.
- Full `pnpm check:quality` passed: lint, guardrails, snapshots, 2,040 acceptance tests with one skip, fiscal, Finance, and generic RLS, 108-route build, 30/30 visuals, and performance budgets.
- Pre-push gate passed.
- Authenticated People rendered 61 organizations and 108 people.
- No organization, People, billing, Finance, or storage data changed.
- PR #135 is production-verified: Workspace and Roadmap rendered and left the organization revision unchanged.
