### PR TITLE
[STEP S42] Protect Workspace board saves from concurrent overwrites

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -78,12 +78,13 @@ the relevant wave rather than inferred from merge status:
 | PR #128      | Production-readiness waves and release gates                |
 | PR #130      | Self-hosted Inter build dependency                          |
 | PR #131      | Find and Build product and rollout clarification            |
-| PR #132      | Public Find light-mode contrast repair                       |
+| PR #132      | Public Find light-mode contrast repair                      |
 | PR #133      | Parallel organization-detail server reads                   |
 | PR #134      | Revision-safe organization document writes                  |
-| PR #135      | Read-only Workspace and Roadmap rendering                    |
+| PR #135      | Read-only Workspace and Roadmap rendering                   |
+| PR #136      | Read-only People page synchronization                       |
 
-The baseline is `origin/main` commit `76460756` on 2026-08-11. A production
+The baseline is `origin/main` commit `b43da278` on 2026-08-11. A production
 read of `/api/public/resource-map/items` returned `853` records in a
 `2,519,484`-byte response. That is a live endpoint snapshot, not a performance
 guarantee or proof that all records rendered correctly.
@@ -135,11 +136,15 @@ wave, but unrelated scope does not accumulate in one PR.
 - PR #135 is merged and production-verified for read-only Workspace and
   Roadmap rendering. Legacy content remains normalized in memory, both routes
   render, and their production reads leave the organization revision unchanged.
-- People-page member synchronization is read-only on the focused
-  `fix/people-page-read-only-20260811` branch. Account-derived display data is
-  still shown, but opening People no longer persists it over organization
-  directory fields. Focused coverage and the full quality gate pass. Hosted
-  preview, merge, deployment, and production proof remain required.
+- PR #136 is merged and production-deployed for read-only People-page member
+  synchronization. Account-derived display data is still shown, but opening
+  People no longer persists it over organization directory fields. Explicit
+  People add, edit, invite, remove, and position actions remain available.
+- Workspace board and node-position saves are revision-aware on the focused
+  `fix/workspace-board-concurrency-20260811` branch. Concurrent saves retry
+  against the latest board state instead of silently replacing it. Focused
+  concurrency coverage and the full quality gate pass. Hosted preview, merge,
+  deployment, and production proof remain required.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2607,3 +2607,25 @@
 - Both PR #135 production deployments completed. Authenticated production
   Workspace and Roadmap renders passed, and the connected organization revision
   remained unchanged across both reads.
+
+2026-08-11 12:59 EDT - protected Workspace board saves from concurrent overwrites.
+
+- Confirmed PR #136 is merged and deployed through both production projects.
+  People page loading no longer persists account-derived fields over the
+  organization directory; explicit People editing remains available.
+- Found that whole-board and node-position saves read the current board and then
+  upserted the complete row without checking its revision. Two users saving at
+  once could silently replace the earlier save.
+- Added bounded compare-and-swap retries using the board row's `updated_at`
+  revision. Each retry rebuilds from the latest state; first-row insert races
+  retry after the unique conflict. Personal organization setup now ignores an
+  existing row instead of touching its revision during a board save.
+- Focused concurrency and persistence coverage passes `16/16`. Full
+  `pnpm check:quality` passes: lint and all guardrails, snapshots, `2,043`
+  acceptance tests with one intentional skip, connected fiscal, Finance, and
+  generic RLS, the `108`-route production build, `30/30` visuals against the
+  isolated preview, and performance budgets.
+- The signed-in isolated Workspace request returned `200` and loaded the Coach
+  House page at the expected route. No Workspace, organization, People,
+  billing, Finance, or storage data was changed. Hosted preview, merge,
+  deployment, and production proof remain required.

--- a/src/app/(dashboard)/my-organization/_lib/workspace-actions.ts
+++ b/src/app/(dashboard)/my-organization/_lib/workspace-actions.ts
@@ -4,7 +4,6 @@ import { randomUUID } from "node:crypto"
 import { revalidatePath } from "next/cache"
 
 import { canEditOrganization } from "@/lib/organization/active-org"
-import type { Json } from "@/lib/supabase"
 import { createSupabaseAdminClient } from "@/lib/supabase/admin"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 
@@ -18,6 +17,7 @@ import {
   buildWorkspaceBoardStateWithPersistedNodePosition,
   mergeNewerPersistedWorkspaceNodeState,
 } from "./workspace-board-state-persistence"
+import { persistWorkspaceBoardState } from "./workspace-board-state-write"
 import type {
   WorkspaceBoardActionResult,
   WorkspaceCollaborationActionResult,
@@ -29,7 +29,6 @@ import {
   buildWorkspaceInviteExpiry,
   canInviteWorkspaceCollaborators,
   filterActiveWorkspaceInvites,
-  readWorkspaceBoardStateValue,
 } from "./workspace-state"
 import { WORKSPACE_COLLABORATION_INVITE_NOTIFICATION_TYPE } from "./workspace-collaboration-invite-helpers"
 import {
@@ -90,25 +89,6 @@ export async function saveWorkspaceBoardStateAction(
     // Local/dev environments may omit service-role credentials.
   }
 
-  const incomingBoardState = normalizeWorkspaceBoardState(input)
-  const currentBoardResult = await persistenceClient
-    .from("organization_workspace_boards")
-    .select("state")
-    .eq("org_id", activeOrg.orgId)
-    .maybeSingle<{ state: unknown }>()
-  const persistedBoardStateBeforeSave =
-    currentBoardResult.error || !currentBoardResult.data?.state
-      ? null
-      : readWorkspaceBoardStateValue(currentBoardResult.data.state)
-  const boardState = mergeNewerPersistedWorkspaceNodeState({
-    incoming: incomingBoardState,
-    persisted: persistedBoardStateBeforeSave,
-  })
-  const persistedBoardState: WorkspaceBoardState = {
-    ...boardState,
-    updatedAt: new Date().toISOString(),
-  }
-
   if (activeOrg.orgId === user.id) {
     const { error: organizationUpsertError } = await persistenceClient
       .from("organizations")
@@ -116,7 +96,7 @@ export async function saveWorkspaceBoardStateAction(
         {
           user_id: activeOrg.orgId,
         },
-        { onConflict: "user_id" }
+        { ignoreDuplicates: true, onConflict: "user_id" }
       )
 
     if (organizationUpsertError) {
@@ -124,36 +104,22 @@ export async function saveWorkspaceBoardStateAction(
     }
   }
 
-  const boardUpsertPayload = {
-    org_id: activeOrg.orgId,
-    state: persistedBoardState as Json,
-    updated_by: user.id,
-  }
-
-  let { error } = await persistenceClient
-    .from("organization_workspace_boards")
-    .upsert(boardUpsertPayload, { onConflict: "org_id" })
-
-  if (error?.code === "23503") {
-    const retryResult = await persistenceClient
-      .from("organization_workspace_boards")
-      .upsert(
-        {
-          ...boardUpsertPayload,
-          updated_by: null,
-        },
-        { onConflict: "org_id" }
-      )
-    error = retryResult.error
-  }
-
-  if (error) {
-    return { error: "Unable to save workspace layout." }
-  }
+  const incomingBoardState = normalizeWorkspaceBoardState(input)
+  const result = await persistWorkspaceBoardState({
+    buildState: (persisted) =>
+      mergeNewerPersistedWorkspaceNodeState({
+        incoming: incomingBoardState,
+        persisted,
+      }),
+    orgId: activeOrg.orgId,
+    supabase: persistenceClient,
+    userId: user.id,
+  })
+  if ("error" in result) return result
 
   revalidateWorkspaceBoardRoutes()
 
-  return { ok: true, boardState: persistedBoardState }
+  return result
 }
 
 export async function saveWorkspaceNodePositionAction(
@@ -179,29 +145,6 @@ export async function saveWorkspaceNodePositionAction(
     // Local/dev environments may omit service-role credentials.
   }
 
-  const currentBoardResult = await persistenceClient
-    .from("organization_workspace_boards")
-    .select("state")
-    .eq("org_id", activeOrg.orgId)
-    .maybeSingle<{ state: unknown }>()
-  if (currentBoardResult.error) {
-    return { error: "Unable to save workspace layout." }
-  }
-
-  const currentBoardState = currentBoardResult.data?.state
-    ? readWorkspaceBoardStateValue(currentBoardResult.data.state)
-    : normalizeWorkspaceBoardState(input.boardState)
-  const boardState = buildWorkspaceBoardStateWithPersistedNodePosition({
-    boardState: currentBoardState,
-    cardId: input.cardId,
-    x: Math.round(input.x),
-    y: Math.round(input.y),
-  })
-  const persistedBoardState: WorkspaceBoardState = {
-    ...boardState,
-    updatedAt: new Date().toISOString(),
-  }
-
   if (activeOrg.orgId === user.id) {
     const { error: organizationUpsertError } = await persistenceClient
       .from("organizations")
@@ -209,7 +152,7 @@ export async function saveWorkspaceNodePositionAction(
         {
           user_id: activeOrg.orgId,
         },
-        { onConflict: "user_id" }
+        { ignoreDuplicates: true, onConflict: "user_id" }
       )
 
     if (organizationUpsertError) {
@@ -217,36 +160,23 @@ export async function saveWorkspaceNodePositionAction(
     }
   }
 
-  const boardUpsertPayload = {
-    org_id: activeOrg.orgId,
-    state: persistedBoardState as Json,
-    updated_by: user.id,
-  }
-
-  let { error } = await persistenceClient
-    .from("organization_workspace_boards")
-    .upsert(boardUpsertPayload, { onConflict: "org_id" })
-
-  if (error?.code === "23503") {
-    const retryResult = await persistenceClient
-      .from("organization_workspace_boards")
-      .upsert(
-        {
-          ...boardUpsertPayload,
-          updated_by: null,
-        },
-        { onConflict: "org_id" }
-      )
-    error = retryResult.error
-  }
-
-  if (error) {
-    return { error: "Unable to save workspace layout." }
-  }
+  const result = await persistWorkspaceBoardState({
+    buildState: (persisted) =>
+      buildWorkspaceBoardStateWithPersistedNodePosition({
+        boardState: persisted ?? normalizeWorkspaceBoardState(input.boardState),
+        cardId: input.cardId,
+        x: Math.round(input.x),
+        y: Math.round(input.y),
+      }),
+    orgId: activeOrg.orgId,
+    supabase: persistenceClient,
+    userId: user.id,
+  })
+  if ("error" in result) return result
 
   revalidateWorkspaceBoardRoutes()
 
-  return { ok: true, boardState: persistedBoardState }
+  return result
 }
 
 export async function completeWorkspaceCanvasTutorialAction(): Promise<WorkspaceTutorialActionResult> {

--- a/src/app/(dashboard)/my-organization/_lib/workspace-board-state-write.ts
+++ b/src/app/(dashboard)/my-organization/_lib/workspace-board-state-write.ts
@@ -1,0 +1,150 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database, Json } from "@/lib/supabase"
+
+import type { WorkspaceBoardState } from "../_components/workspace-board/workspace-board-types"
+import { readWorkspaceBoardStateValue } from "./workspace-state"
+
+const MAX_WORKSPACE_BOARD_WRITE_ATTEMPTS = 4
+
+export const WORKSPACE_BOARD_WRITE_CONFLICT_ERROR =
+  "Workspace changed while you were saving. Refresh and try again."
+
+type WorkspaceBoardSnapshot = {
+  exists: boolean
+  revision: string | null
+  state: WorkspaceBoardState | null
+}
+
+type WorkspaceBoardSnapshotReadResult =
+  | { snapshot: WorkspaceBoardSnapshot }
+  | { error: string }
+
+type WorkspaceBoardSnapshotWriteResult =
+  | { status: "written" }
+  | { status: "conflict" }
+  | { status: "error"; error: string }
+
+export async function commitWorkspaceBoardState({
+  buildState,
+  maxAttempts = MAX_WORKSPACE_BOARD_WRITE_ATTEMPTS,
+  readSnapshot,
+  writeSnapshot,
+}: {
+  buildState: (
+    persistedState: WorkspaceBoardState | null
+  ) => WorkspaceBoardState
+  maxAttempts?: number
+  readSnapshot: () => Promise<WorkspaceBoardSnapshotReadResult>
+  writeSnapshot: (
+    snapshot: WorkspaceBoardSnapshot,
+    nextState: WorkspaceBoardState
+  ) => Promise<WorkspaceBoardSnapshotWriteResult>
+}): Promise<{ ok: true; boardState: WorkspaceBoardState } | { error: string }> {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const readResult = await readSnapshot()
+    if ("error" in readResult) return readResult
+
+    const boardState = {
+      ...buildState(readResult.snapshot.state),
+      updatedAt: new Date().toISOString(),
+    }
+    const writeResult = await writeSnapshot(readResult.snapshot, boardState)
+    if (writeResult.status === "written") {
+      return { ok: true, boardState }
+    }
+    if (writeResult.status === "error") {
+      return { error: writeResult.error }
+    }
+  }
+
+  return { error: WORKSPACE_BOARD_WRITE_CONFLICT_ERROR }
+}
+
+function isForeignKeyViolation(error: { code?: string } | null) {
+  return error?.code === "23503"
+}
+
+function isUniqueViolation(error: { code?: string } | null) {
+  return error?.code === "23505"
+}
+
+export async function persistWorkspaceBoardState({
+  buildState,
+  orgId,
+  supabase,
+  userId,
+}: {
+  buildState: (
+    persistedState: WorkspaceBoardState | null
+  ) => WorkspaceBoardState
+  orgId: string
+  supabase: SupabaseClient<Database>
+  userId: string
+}) {
+  return commitWorkspaceBoardState({
+    buildState,
+    readSnapshot: async () => {
+      const { data, error } = await supabase
+        .from("organization_workspace_boards")
+        .select("state, updated_at")
+        .eq("org_id", orgId)
+        .maybeSingle<{ state: unknown; updated_at: string }>()
+
+      if (error) return { error: "Unable to save workspace layout." }
+      return {
+        snapshot: {
+          exists: Boolean(data),
+          revision: data?.updated_at ?? null,
+          state: data?.state ? readWorkspaceBoardStateValue(data.state) : null,
+        },
+      }
+    },
+    writeSnapshot: async (snapshot, nextState) => {
+      const state = nextState as unknown as Json
+
+      if (!snapshot.exists) {
+        const insertWithActor = (updatedBy: string | null) =>
+          supabase
+            .from("organization_workspace_boards")
+            .insert({ org_id: orgId, state, updated_by: updatedBy })
+            .select("updated_at")
+            .maybeSingle<{ updated_at: string }>()
+
+        let { data, error } = await insertWithActor(userId)
+        if (isForeignKeyViolation(error)) {
+          const fallbackResult = await insertWithActor(null)
+          data = fallbackResult.data
+          error = fallbackResult.error
+        }
+        if (isUniqueViolation(error)) return { status: "conflict" }
+        if (error) {
+          return { status: "error", error: "Unable to save workspace layout." }
+        }
+        return data ? { status: "written" } : { status: "conflict" }
+      }
+
+      const revision = snapshot.revision
+      if (!revision) return { status: "conflict" }
+      const updateWithActor = (updatedBy: string | null) =>
+        supabase
+          .from("organization_workspace_boards")
+          .update({ state, updated_by: updatedBy })
+          .eq("org_id", orgId)
+          .eq("updated_at", revision)
+          .select("updated_at")
+          .maybeSingle<{ updated_at: string }>()
+
+      let { data, error } = await updateWithActor(userId)
+      if (isForeignKeyViolation(error)) {
+        const fallbackResult = await updateWithActor(null)
+        data = fallbackResult.data
+        error = fallbackResult.error
+      }
+      if (error) {
+        return { status: "error", error: "Unable to save workspace layout." }
+      }
+      return data ? { status: "written" } : { status: "conflict" }
+    },
+  })
+}

--- a/tests/acceptance/workspace-board-write-concurrency.test.ts
+++ b/tests/acceptance/workspace-board-write-concurrency.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { buildDefaultBoardState } from "@/app/(dashboard)/my-organization/_components/workspace-board/workspace-board-layout"
+import { mergeNewerPersistedWorkspaceNodeState } from "@/app/(dashboard)/my-organization/_lib/workspace-board-state-persistence"
+import {
+  commitWorkspaceBoardState,
+  WORKSPACE_BOARD_WRITE_CONFLICT_ERROR,
+} from "@/app/(dashboard)/my-organization/_lib/workspace-board-state-write"
+
+describe("workspace board write concurrency", () => {
+  it("retries a stale save and preserves the concurrent node position", async () => {
+    const defaults = buildDefaultBoardState()
+    const incoming = {
+      ...defaults,
+      updatedAt: "2026-08-11T15:00:00.000Z",
+    }
+    let persisted = {
+      ...defaults,
+      updatedAt: "2026-08-11T15:00:00.000Z",
+    }
+    let revision = "revision-1"
+    let injectConcurrentSave = true
+    let readCount = 0
+    let writeCount = 0
+
+    const result = await commitWorkspaceBoardState({
+      readSnapshot: async () => {
+        readCount += 1
+        return {
+          snapshot: {
+            exists: true,
+            revision,
+            state: structuredClone(persisted),
+          },
+        }
+      },
+      buildState: (current) =>
+        mergeNewerPersistedWorkspaceNodeState({
+          incoming,
+          persisted: current,
+        }),
+      writeSnapshot: async (snapshot, nextState) => {
+        writeCount += 1
+        if (injectConcurrentSave) {
+          persisted = {
+            ...persisted,
+            updatedAt: "2026-08-11T15:01:00.000Z",
+            nodes: persisted.nodes.map((node) =>
+              node.id === "fiscal-sponsorship"
+                ? {
+                    ...node,
+                    x: 420,
+                    y: 920,
+                    positionMode: "manual" as const,
+                  }
+                : node
+            ),
+          }
+          revision = "revision-2"
+          injectConcurrentSave = false
+        }
+        if (snapshot.revision !== revision) return { status: "conflict" }
+        persisted = nextState
+        revision = "revision-3"
+        return { status: "written" }
+      },
+    })
+
+    expect(result).toMatchObject({ ok: true })
+    expect(readCount).toBe(2)
+    expect(writeCount).toBe(2)
+    expect(
+      "boardState" in result
+        ? result.boardState.nodes.find(
+            (node) => node.id === "fiscal-sponsorship"
+          )
+        : null
+    ).toMatchObject({ x: 420, y: 920, positionMode: "manual" })
+  })
+
+  it("returns a clear error after bounded conflicts", async () => {
+    let readCount = 0
+    let writeCount = 0
+    const result = await commitWorkspaceBoardState({
+      maxAttempts: 3,
+      readSnapshot: async () => {
+        readCount += 1
+        return {
+          snapshot: {
+            exists: true,
+            revision: `revision-${readCount}`,
+            state: buildDefaultBoardState(),
+          },
+        }
+      },
+      buildState: (current) => current ?? buildDefaultBoardState(),
+      writeSnapshot: async () => {
+        writeCount += 1
+        return { status: "conflict" }
+      },
+    })
+
+    expect(result).toEqual({ error: WORKSPACE_BOARD_WRITE_CONFLICT_ERROR })
+    expect(readCount).toBe(3)
+    expect(writeCount).toBe(3)
+  })
+
+  it("guards both Workspace save actions with the row revision", () => {
+    const root = process.cwd()
+    const actionSource = readFileSync(
+      join(
+        root,
+        "src/app/(dashboard)/my-organization/_lib/workspace-actions.ts"
+      ),
+      "utf8"
+    )
+    const writerSource = readFileSync(
+      join(
+        root,
+        "src/app/(dashboard)/my-organization/_lib/workspace-board-state-write.ts"
+      ),
+      "utf8"
+    )
+
+    expect(actionSource.match(/persistWorkspaceBoardState\(\{/g)?.length).toBe(
+      2
+    )
+    expect(actionSource).not.toContain(".upsert(boardUpsertPayload")
+    expect(actionSource).toContain("ignoreDuplicates: true")
+    expect(writerSource).toContain('.eq("updated_at", revision)')
+    expect(writerSource).toContain("MAX_WORKSPACE_BOARD_WRITE_ATTEMPTS = 4")
+    expect(writerSource).toContain("isUniqueViolation(error)")
+  })
+})


### PR DESCRIPTION
## What changed

- protect full Workspace board and node-position saves with row revision checks
- retry conflicts against the latest saved board instead of silently overwriting it
- avoid touching an existing personal organization row during board setup
- add focused concurrency regression coverage and update the Wave 1 PRD/runlog

## Root cause

Workspace saves read the current board and then upserted the complete row without checking whether another save had changed it.

## User impact

Concurrent users can keep editing the Workspace without one save silently replacing another. Existing editing behavior and stored board data remain intact.

## Validation

- `pnpm check:quality`
- 2,043 acceptance tests passed; one intentional skip
- connected fiscal, Finance, and generic RLS passed
- 108-route production build passed
- 30 visual tests and performance budgets passed
- signed-in isolated Workspace request returned 200
