### PR TITLE
[STEP S44] Add durable Finance PRD progress tracking

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -49,9 +49,13 @@ starts automatically on `main`.
 
 #### Progress contract
 
-Do not report one PRD completion percentage. Prior percentages used different
-denominators: implemented feature scope, merged branches, Prototype Lab nodes,
-and production-readiness gates. They are not interchangeable.
+Report the current PRD completion percentage only from the fixed 35-item
+current-wave completion checklist below: five equally weighted criteria for
+each of seven waves. Percentage is checked criteria divided by 35, rounded to
+the nearest whole percent. In-progress work remains unchecked until its named
+production evidence is complete. Do not calculate progress from the historical
+37-item batch tracker, merged branches, Prototype Lab nodes, or partial preview
+work.
 
 Track each wave as `queued`, `active`, `code complete`, `preview verified`, or
 `production verified`. A wave is complete only after its focused PR is merged,
@@ -84,8 +88,9 @@ the relevant wave rather than inferred from merge status:
 | PR #135      | Read-only Workspace and Roadmap rendering                   |
 | PR #136      | Read-only People page synchronization                       |
 | PR #137      | Revision-safe Workspace board saves                         |
+| PR #138      | Workspace production-deployment evidence                    |
 
-The baseline is `origin/main` commit `872c0f6c` on 2026-08-11. A production
+The baseline is `origin/main` commit `fa25b38d` on 2026-08-11. A production
 read of `/api/public/resource-map/items` returned `853` records in a
 `2,519,484`-byte response. That is a live endpoint snapshot, not a performance
 guarantee or proof that all records rendered correctly.
@@ -118,12 +123,75 @@ wave, but unrelated scope does not accumulate in one PR.
 | Wave                                      | Status on 2026-08-11 | Scope                                                                                                                                                          | Exit evidence                                                                                                                                      | Rollback                                                                                   |
 | ----------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | 1. Live stability and existing work close | Active               | Verify the existing Builder, Workspace, Documents, Finance, organization, role, deep-link, light-mode, mobile, stale-data, and error paths; fix only real gaps | Free/paid/member/coach/admin browser proof; refresh and cross-account isolation; no data loss, console errors, contrast failures, or broken routes | Disable or revert the narrow failed surface; preserve all stored data                      |
-| 2. Signup, recovery, and legal            | Queued               | Direct and contextual signup, verification, login, recovery, Terms, Privacy, required acceptance, and safe return intent                                       | Every signup surface works; consent version/hash/UTC is stored; denial and retry work; legal text is approved                                      | Disable new signup while preserving accounts and consent evidence                          |
+| 2. Signup, recovery, and legal            | Active               | Direct and contextual signup, verification, login, recovery, Terms, Privacy, required acceptance, and safe return intent                                       | Every signup surface works; consent version/hash/UTC is stored; denial and retry work; legal text is approved                                      | Disable new signup while preserving accounts and consent evidence                          |
 | 3. `/find` speed and loading              | Queued               | Compact index, bounded or paginated loading, detail on demand, stable cached refresh, current loading UI, empty/error/retry states, and collected-item lookup  | Fast first useful render; payload/LCP/TTI budgets; complete results; offline/stale/retry proof                                                     | Restore the prior compatible endpoint; retain published records                            |
 | 4. Collect / My Map completion            | Queued, partly built | Reuse the existing saved-organization foundation; rename the experience, collect/uncollect nonprofits and resources, show them in My Map, and persist them     | Visitors can collect locally; signed-in accounts persist across devices; Builders have the same My Map; no lists, notes, tags, ordering, or import | Disable new resource collection writes; preserve existing saved organizations              |
 | 5. Finance reporting completion           | Queued, partly built | Read-only external activity connection, simple graph, activity list, History, source/freshness labels, CSV/PDF export, and board sharing                       | Connected/loading/empty/stale/error states; graph has a text equivalent; reports reconcile; sharing is explicit and revocable                      | Disable sync or reporting entry points; retain read-only records and existing CSV fallback |
 | 6. Qualified resources and varied guides  | Queued               | Promote verified cohorts toward 5,000+ useful records, then publish category- and location-varied guides after `/find` is stable                               | Exact complete/verified/publishable/promoted/public parity; cohort canary; relevant current guides and working links                               | Unpublish a cohort or guide without deleting evidence                                      |
 | 7. Integrated production release          | Queued               | Security review, support runbook, monitoring, rollback rehearsal, production smoke checks, and gradual rollout                                                 | Full quality gate; connected RLS where changed; hosted previews; production browser proof; clean monitoring                                        | Wave-specific flags and forward repair; never use a destructive data rollback              |
+
+#### Current-wave completion checklist
+
+Only checked criteria count toward the percentage. Criterion IDs and the
+35-item denominator are stable; changing either requires an explicit PRD
+revision. Current progress: **4/35 complete (11%)**, **3 in progress**, and
+**28 not started**.
+
+**Wave 1 — Live stability and existing work close**
+
+- [x] `wave-1-criterion-1` **Complete:** Verify authenticated Find in light and dark mode on desktop and mobile with no contrast regression — Evidence: PR #132 merged and production-verified.
+- [x] `wave-1-criterion-2` **Complete:** Verify organization detail rendering and recoverable missing Stripe-subscription links in production — Evidence: PR #133 merged and production-verified.
+- [x] `wave-1-criterion-3` **Complete:** Verify revision-safe organization document writes and storage rollback behavior — Evidence: PR #134 merged and production-verified.
+- [x] `wave-1-criterion-4` **Complete:** Verify Workspace, Roadmap, and People reads preserve stored organization data — Evidence: PRs #135 and #136 merged with authenticated production read-safety proof.
+- [ ] `wave-1-criterion-5` **In progress:** Complete revision-aware Workspace save smoke and the paid, free, member, coach, and admin journey matrix — Evidence: PRs #137 and #138 merged; authenticated production Workspace smoke remains.
+
+**Wave 2 — Signup, recovery, and legal**
+
+- [ ] `wave-2-criterion-1` **In progress:** Provide canonical Terms and Privacy pages with required acceptance on every signup surface — Evidence: PR #139 preview checks pass; legal review remains.
+- [ ] `wave-2-criterion-2` **In progress:** Persist immutable consent version, content hashes, user, and UTC acceptance time under RLS — Evidence: PR #139 Supabase Preview passes; production is unchanged.
+- [ ] `wave-2-criterion-3` **Not started:** Verify direct and contextual signup, email verification, safe return, denial, retry, and recovery.
+- [ ] `wave-2-criterion-4` **Not started:** Obtain qualified legal approval for Terms and Privacy copy.
+- [ ] `wave-2-criterion-5` **Not started:** Merge, deploy, production-smoke, monitor, and retain a tested signup rollback.
+
+**Wave 3 — `/find` speed and loading**
+
+- [ ] `wave-3-criterion-1` **Not started:** Serve a compact anonymous resource index without private or detail-only fields.
+- [ ] `wave-3-criterion-2` **Not started:** Add bounded or paginated loading with stable cached refresh behavior.
+- [ ] `wave-3-criterion-3` **Not started:** Load resource details on demand while preserving selected and collected records outside current bounds.
+- [ ] `wave-3-criterion-4` **Not started:** Verify loading, empty, error, offline, stale, and retry states without losing map context.
+- [ ] `wave-3-criterion-5` **Not started:** Meet payload, first-useful-render, LCP, and interaction budgets in preview and production.
+
+**Wave 4 — Collect and My Map completion**
+
+- [ ] `wave-4-criterion-1` **Not started:** Let visitors collect and remove nonprofits and resources locally.
+- [ ] `wave-4-criterion-2` **Not started:** Persist signed-in collections across devices with safe idempotent replay.
+- [ ] `wave-4-criterion-3` **Not started:** Build My Map on the existing saved-organization foundation without separate Finder onboarding.
+- [ ] `wave-4-criterion-4` **Not started:** Keep collected records resolvable through loading, empty, stale, and error states.
+- [ ] `wave-4-criterion-5` **Not started:** Verify guest, account, and Builder journeys with RLS, production monitoring, and rollback proof.
+
+**Wave 5 — Finance reporting completion**
+
+- [ ] `wave-5-criterion-1` **Not started:** Connect read-only external activity with explicit source and freshness labels.
+- [ ] `wave-5-criterion-2` **Not started:** Provide a simple accessible graph, text equivalent, Activity list, and History.
+- [ ] `wave-5-criterion-3` **Not started:** Reconcile visible reporting to authorized external records and correction history.
+- [ ] `wave-5-criterion-4` **Not started:** Verify accurate CSV and PDF exports.
+- [ ] `wave-5-criterion-5` **Not started:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback.
+
+**Wave 6 — Qualified resources and varied guides**
+
+- [ ] `wave-6-criterion-1` **Not started:** Report exact candidate, complete, verified, publishable, promoted, and public counts.
+- [ ] `wave-6-criterion-2` **Not started:** Close provider, eligibility, summary, access, contact, and comparison evidence gaps by cohort.
+- [ ] `wave-6-criterion-3` **Not started:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records.
+- [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
+- [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
+
+**Wave 7 — Integrated production release**
+
+- [ ] `wave-7-criterion-1` **Not started:** Pass the full quality gate, connected RLS where changed, and migration parity.
+- [ ] `wave-7-criterion-2` **Not started:** Complete security review, support runbook, ownership, and monitoring setup.
+- [ ] `wave-7-criterion-3` **Not started:** Verify hosted paid, free, member, coach, and admin journeys in light, dark, desktop, and mobile.
+- [ ] `wave-7-criterion-4` **Not started:** Rehearse rollback and complete controlled paid and free canaries with gradual rollout.
+- [ ] `wave-7-criterion-5` **Not started:** Verify production deployment, smoke checks, clean monitoring, and no unresolved P0 risk.
 
 #### Wave 1 current evidence
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2630,3 +2630,29 @@
   billing, Finance, or storage data was changed. PR #137 merged, hosted CI and
   both Vercel previews passed, and both production deployments completed.
   Authenticated production smoke remains required.
+
+2026-08-11 19:12 EDT - restored durable current PRD completion tracking.
+
+- Replaced the production-stability override's prohibition on one percentage
+  with a fixed 35-criterion denominator: five source-controlled completion
+  criteria for each of seven current waves. Only production-verified checked
+  items count; current progress is `4/35` (`11%`), with `3` in progress and
+  `28` not started.
+- Added stable criterion IDs, evidence, explicit wave states, automatic counts,
+  and exact PRD-to-source parity tests. The prior 37-item batch tracker remains
+  available as labeled historical evidence and no longer drives the current
+  percentage.
+- Made Current waves the default Prototype Lab progress view, surfaced the
+  computed percentage and next criterion, retained the historical readiness
+  views, and followed the existing Geist/shadcn layout and accessible
+  text-plus-icon status contract from `docs/design.md`.
+- Focused finance-plan proof passes `37/37`; focused ESLint, thresholds,
+  boundaries, React Grab, workspace-surface, raw-button, and diff checks pass.
+  The full quality components pass: lint and all guardrails, snapshots,
+  `2,044` acceptance tests with one intentional skip, connected fiscal,
+  Finance, and generic RLS, the `108`-route production build, all `30` visual
+  cases, and performance budgets. The canonical command's visual step first
+  reused an unrelated hung port-3000 dev server; isolated development proof
+  passed `29/30`, and the sole cold-compile `/find` timeout passed on its warmed
+  focused rerun.
+- No database, Stripe, or production mutation occurred during this work.

--- a/src/features/prototype-lab/components/finance/finance-plan-current-focus.tsx
+++ b/src/features/prototype-lab/components/finance/finance-plan-current-focus.tsx
@@ -1,40 +1,24 @@
 import TargetIcon from "lucide-react/dist/esm/icons/target"
 import type { HTMLAttributes } from "react"
 
-import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 import {
-  FINANCE_PLAN_BATCH_PROGRESS,
-  FINANCE_PLAN_BATCH_WORK_COUNTS,
-} from "./finance-plan-batch-progress"
-import { FINANCE_RELEASE_PLAN_BATCHES } from "./finance-release-plan-batches"
-
-const activeBatch =
-  FINANCE_PLAN_BATCH_PROGRESS.find(
-    (batch) =>
-      batch.executionState === "in_progress" &&
-      batch.workItemCounts.complete < batch.workItemCounts.total
-  ) ??
-  FINANCE_PLAN_BATCH_PROGRESS.find((batch) => batch.executionState !== "merged")
-const activeBatchDefinition = FINANCE_RELEASE_PLAN_BATCHES.find(
-  (batch) => batch.id === activeBatch?.batchId
-)
-const nextWorkItem = activeBatch?.items.find(
-  (item) => item.state !== "complete"
-)
+  FINANCE_PLAN_COMPLETION_PERCENTAGE,
+  FINANCE_PLAN_CURRENT_WAVE,
+  FINANCE_PLAN_NEXT_CRITERION,
+  FINANCE_PLAN_WAVE_COUNTS,
+} from "./finance-plan-wave-progress"
 
 export const FINANCE_PLAN_CURRENT_FOCUS = {
-  batchId: activeBatch?.batchId ?? FINANCE_RELEASE_PLAN_BATCHES[0].id,
-  batchLabel: activeBatchDefinition
-    ? `Batch ${activeBatchDefinition.sequence}: ${activeBatchDefinition.title}`
-    : "Release roadmap",
-  complete: FINANCE_PLAN_BATCH_WORK_COUNTS.complete,
-  nextStep: nextWorkItem?.title ?? "Review the next proof gate",
-  remaining:
-    FINANCE_PLAN_BATCH_WORK_COUNTS.total -
-    FINANCE_PLAN_BATCH_WORK_COUNTS.complete,
-  total: FINANCE_PLAN_BATCH_WORK_COUNTS.total,
+  complete: FINANCE_PLAN_WAVE_COUNTS.complete,
+  nextStep:
+    FINANCE_PLAN_NEXT_CRITERION?.title ?? "Review the next production wave",
+  percentage: FINANCE_PLAN_COMPLETION_PERCENTAGE,
+  remaining: FINANCE_PLAN_WAVE_COUNTS.total - FINANCE_PLAN_WAVE_COUNTS.complete,
+  total: FINANCE_PLAN_WAVE_COUNTS.total,
+  waveId: FINANCE_PLAN_CURRENT_WAVE.id,
+  waveLabel: `Wave ${FINANCE_PLAN_CURRENT_WAVE.sequence}: ${FINANCE_PLAN_CURRENT_WAVE.title}`,
 } as const
 
 const STATUS_LEGEND = [
@@ -67,26 +51,20 @@ export function FinancePlanStatusLegend({
   )
 }
 
-export function FinancePlanCurrentFocusPill({
-  onOpenBatch,
-}: {
-  onOpenBatch: (batchId: string) => void
-}) {
+export function FinancePlanCurrentFocusPill() {
   return (
-    <Button
-      className="bg-card pointer-events-auto h-11 max-w-80 shrink-0 justify-start rounded-full px-3 shadow-sm"
-      onClick={() => onOpenBatch(FINANCE_PLAN_CURRENT_FOCUS.batchId)}
+    <div
+      aria-label={`${FINANCE_PLAN_CURRENT_FOCUS.percentage}% complete. ${FINANCE_PLAN_CURRENT_FOCUS.waveLabel}`}
+      className="border-border bg-card pointer-events-auto flex h-11 max-w-80 shrink-0 items-center gap-2 rounded-full border px-3 shadow-sm"
       title={`Next: ${FINANCE_PLAN_CURRENT_FOCUS.nextStep}`}
-      type="button"
-      variant="outline"
     >
       <TargetIcon aria-hidden="true" className="size-4 shrink-0" />
       <span className="min-w-0 truncate text-xs">
-        {FINANCE_PLAN_CURRENT_FOCUS.batchLabel}
+        {FINANCE_PLAN_CURRENT_FOCUS.waveLabel}
       </span>
       <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-        {FINANCE_PLAN_CURRENT_FOCUS.complete}/{FINANCE_PLAN_CURRENT_FOCUS.total}
+        {FINANCE_PLAN_CURRENT_FOCUS.percentage}%
       </span>
-    </Button>
+    </div>
   )
 }

--- a/src/features/prototype-lab/components/finance/finance-plan-readiness-category-nav.tsx
+++ b/src/features/prototype-lab/components/finance/finance-plan-readiness-category-nav.tsx
@@ -25,6 +25,7 @@ import {
 } from "./finance-plan-readiness"
 import { FINANCE_PLAN_SECURITY_CONTROL_COUNTS } from "./finance-plan-security-controls"
 import { FINANCE_PLAN_TEST_MATRIX_COUNTS } from "./finance-plan-test-matrix"
+import { FINANCE_PLAN_WAVE_STATUS_COUNTS } from "./finance-plan-wave-progress"
 
 export type FinancePlanReadinessMode =
   | "batches"
@@ -35,8 +36,15 @@ export type FinancePlanReadinessMode =
   | "inputs"
   | "security"
   | "tests"
+  | "waves"
 
 const FINANCE_PLAN_READINESS_CATEGORIES = [
+  {
+    count: FINANCE_PLAN_WAVE_STATUS_COUNTS.total,
+    icon: FlagIcon,
+    label: "Current waves",
+    mode: "waves",
+  },
   {
     count: FINANCE_PLAN_OPEN_INPUT_COUNTS.total,
     icon: ListTodoIcon,
@@ -46,7 +54,7 @@ const FINANCE_PLAN_READINESS_CATEGORIES = [
   {
     count: FINANCE_PLAN_BATCH_READINESS_COUNTS.total,
     icon: GitMergeIcon,
-    label: "Batches",
+    label: "Historical batches",
     mode: "batches",
   },
   {

--- a/src/features/prototype-lab/components/finance/finance-plan-readiness-navigator.tsx
+++ b/src/features/prototype-lab/components/finance/finance-plan-readiness-navigator.tsx
@@ -13,7 +13,6 @@ import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 import type { FinancePlanningViewId } from "./finance-plan-diagram-data"
-import { FINANCE_PLAN_BATCH_WORK_COUNTS } from "./finance-plan-batch-progress"
 import { FINANCE_PLAN_DECISION_ITEM_COUNTS } from "./finance-plan-decision-progress"
 import {
   FINANCE_PLAN_COMPLETION,
@@ -75,6 +74,13 @@ import {
   FINANCE_PLAN_TEST_MATRIX_COUNTS,
   type FinancePlanTestArea,
 } from "./finance-plan-test-matrix"
+import { FinancePlanWaveProgressList } from "./finance-plan-wave-progress-list"
+import {
+  FINANCE_PLAN_COMPLETION_PERCENTAGE,
+  FINANCE_PLAN_WAVE_COUNTS,
+  FINANCE_PLAN_WAVES,
+  FINANCE_PLAN_WAVE_STATUS_COUNTS,
+} from "./finance-plan-wave-progress"
 
 type FinancePlanNodeTarget = {
   nodeId: string
@@ -126,6 +132,10 @@ function getDecisionStateIcon(state: FinancePlanDecisionItemState) {
 }
 
 function getModeDescription(mode: FinancePlanReadinessMode) {
+  if (mode === "waves") {
+    return `${FINANCE_PLAN_WAVE_COUNTS.complete} of ${FINANCE_PLAN_WAVE_COUNTS.total} fixed current-wave criteria are production-verified. In-progress work stays unchecked until its named release evidence is complete.`
+  }
+
   if (mode === "inputs") {
     return `${FINANCE_PLAN_OPEN_INPUT_COUNTS.decisions} decisions and ${FINANCE_PLAN_OPEN_INPUT_COUNTS.research} research tracks remain open; ${FINANCE_PLAN_DECISION_ITEM_COUNTS.approved} of ${FINANCE_PLAN_DECISION_ITEM_COUNTS.total} approval criteria approved and ${FINANCE_PLAN_RESEARCH_ITEM_COUNTS.verified} of ${FINANCE_PLAN_RESEARCH_ITEM_COUNTS.total} research items verified.`
   }
@@ -154,7 +164,7 @@ function getModeDescription(mode: FinancePlanReadinessMode) {
     return `${FINANCE_PLAN_FAILURE_STATE_COUNTS.verified} of ${FINANCE_PLAN_FAILURE_STATE_COUNTS.total} failure and empty states verified; ${FINANCE_PLAN_FAILURE_STATE_COUNTS.collecting} collecting proof and ${FINANCE_PLAN_FAILURE_STATE_COUNTS.notStarted} not started.`
   }
 
-  return `${FINANCE_PLAN_BATCH_READINESS_COUNTS.ready} batches ready, ${FINANCE_PLAN_BATCH_READINESS_COUNTS.blocked} blocked, ${FINANCE_PLAN_BATCH_READINESS_COUNTS.inProgress} in progress, and ${FINANCE_PLAN_BATCH_READINESS_COUNTS.merged} merged.`
+  return `Historical seven-batch implementation record: ${FINANCE_PLAN_BATCH_READINESS_COUNTS.ready} ready, ${FINANCE_PLAN_BATCH_READINESS_COUNTS.blocked} blocked, ${FINANCE_PLAN_BATCH_READINESS_COUNTS.inProgress} in progress, and ${FINANCE_PLAN_BATCH_READINESS_COUNTS.merged} merged. It does not determine the current percentage.`
 }
 
 function FinancePlanOpenInputGroup({
@@ -341,10 +351,7 @@ export function FinancePlanReadinessPanel({
   onSelectResponseTarget: (targetId: string) => void
   responseTargetId: string | null
 }) {
-  const [mode, setMode] = useState<FinancePlanReadinessMode>("batches")
-  const remainingSteps =
-    FINANCE_PLAN_BATCH_WORK_COUNTS.total -
-    FINANCE_PLAN_BATCH_WORK_COUNTS.complete
+  const [mode, setMode] = useState<FinancePlanReadinessMode>("waves")
 
   const handleInputSelect = (input: FinancePlanOpenInput) => {
     onSelect({ nodeId: input.nodeId, viewId: "roadmap" })
@@ -390,21 +397,20 @@ export function FinancePlanReadinessPanel({
       <header className="border-border/70 shrink-0 border-b p-4">
         <div className="flex items-start justify-between gap-3">
           <h2 className="min-w-0 text-sm font-semibold text-balance">
-            Release implementation plan
+            Current release progress
           </h2>
           <Badge
             className="shrink-0 rounded-full tabular-nums"
             variant="outline"
           >
-            {remainingSteps} steps left
+            {FINANCE_PLAN_COMPLETION_PERCENTAGE}% complete
           </Badge>
         </div>
 
         <p className="text-muted-foreground mt-1.5 text-xs leading-5 text-pretty">
-          {FINANCE_PLAN_BATCH_WORK_COUNTS.complete}/
-          {FINANCE_PLAN_BATCH_WORK_COUNTS.total} complete ·{" "}
-          {FINANCE_PLAN_OPEN_INPUT_COUNTS.decisions} decisions for you ·{" "}
-          {FINANCE_PLAN_OPEN_INPUT_COUNTS.research} research tracks for me
+          {FINANCE_PLAN_WAVE_COUNTS.complete}/{FINANCE_PLAN_WAVE_COUNTS.total}{" "}
+          verified · {FINANCE_PLAN_WAVE_COUNTS.inProgress} in progress ·{" "}
+          {FINANCE_PLAN_WAVE_STATUS_COUNTS.active} active waves
         </p>
 
         <FinancePlanReadinessCategoryNav mode={mode} onModeChange={setMode} />
@@ -417,7 +423,9 @@ export function FinancePlanReadinessPanel({
         <p className="border-border/70 text-muted-foreground border-b px-4 py-3 text-xs leading-5 text-pretty">
           {getModeDescription(mode)}
         </p>
-        {mode === "failures" ? (
+        {mode === "waves" ? (
+          <FinancePlanWaveProgressList waves={FINANCE_PLAN_WAVES} />
+        ) : mode === "failures" ? (
           <FinancePlanReadinessFailureList
             failureStates={FINANCE_PLAN_FAILURE_STATES}
             onSelect={handleFailureSelect}
@@ -460,9 +468,7 @@ export function FinancePlanReadinessPanel({
               description="Product, release, fiscal, and visual choices that cannot be assumed during implementation."
               inputs={FINANCE_PLAN_OPEN_DECISIONS}
               onSelect={handleInputSelect}
-              onSelectResponseTarget={(item) =>
-                onSelectResponseTarget(item.id)
-              }
+              onSelectResponseTarget={(item) => onSelectResponseTarget(item.id)}
               responseTargetId={responseTargetId}
               title="Need from you"
             />
@@ -470,9 +476,7 @@ export function FinancePlanReadinessPanel({
               description="Evidence and external verification that must be completed before coding each batch."
               inputs={FINANCE_PLAN_OPEN_RESEARCH}
               onSelect={handleInputSelect}
-              onSelectResponseTarget={(item) =>
-                onSelectResponseTarget(item.id)
-              }
+              onSelectResponseTarget={(item) => onSelectResponseTarget(item.id)}
               responseTargetId={responseTargetId}
               title="Research before coding"
             />
@@ -488,11 +492,11 @@ export function FinancePlanReadinessPanel({
             </p>
             <Button
               className="mt-4 min-h-11 rounded-full"
-              onClick={() => setMode("batches")}
+              onClick={() => setMode("waves")}
               type="button"
               variant="outline"
             >
-              Review batches
+              Review current waves
             </Button>
           </div>
         )}

--- a/src/features/prototype-lab/components/finance/finance-plan-toolbar.tsx
+++ b/src/features/prototype-lab/components/finance/finance-plan-toolbar.tsx
@@ -93,11 +93,7 @@ export function FinancePlanToolbar({
         </SelectContent>
       </Select>
 
-      <FinancePlanCurrentFocusPill
-        onOpenBatch={(batchId) =>
-          onSelectPlanNode({ nodeId: batchId, viewId: "roadmap" })
-        }
-      />
+      <FinancePlanCurrentFocusPill />
 
       <Popover>
         <PopoverTrigger asChild>

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress-list.tsx
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress-list.tsx
@@ -1,0 +1,163 @@
+import CircleCheckBigIcon from "lucide-react/dist/esm/icons/circle-check-big"
+import CircleIcon from "lucide-react/dist/esm/icons/circle"
+import Clock3Icon from "lucide-react/dist/esm/icons/clock-3"
+
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+import type { FinancePlanWorkState } from "./finance-release-plan-data"
+import type {
+  FinancePlanWave,
+  FinancePlanWaveStatus,
+} from "./finance-plan-wave-progress"
+
+function getWaveStatusLabel(status: FinancePlanWaveStatus) {
+  switch (status) {
+    case "active":
+      return "Active"
+    case "code_complete":
+      return "Code complete"
+    case "preview_verified":
+      return "Preview verified"
+    case "production_verified":
+      return "Production verified"
+    default:
+      return "Queued"
+  }
+}
+
+function getWaveStatusClassName(status: FinancePlanWaveStatus) {
+  switch (status) {
+    case "production_verified":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+    case "active":
+    case "code_complete":
+    case "preview_verified":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+    default:
+      return "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+  }
+}
+
+function getCriterionStateLabel(state: FinancePlanWorkState) {
+  switch (state) {
+    case "complete":
+      return "Complete"
+    case "in_progress":
+      return "In progress"
+    default:
+      return "Not started"
+  }
+}
+
+function getCriterionStateIcon(state: FinancePlanWorkState) {
+  switch (state) {
+    case "complete":
+      return CircleCheckBigIcon
+    case "in_progress":
+      return Clock3Icon
+    default:
+      return CircleIcon
+  }
+}
+
+function getCriterionStateClassName(state: FinancePlanWorkState) {
+  switch (state) {
+    case "complete":
+      return "text-emerald-700 dark:text-emerald-300"
+    case "in_progress":
+      return "text-amber-700 dark:text-amber-300"
+    default:
+      return "text-blue-700 dark:text-blue-300"
+  }
+}
+
+export function FinancePlanWaveProgressList({
+  waves,
+}: {
+  waves: readonly FinancePlanWave[]
+}) {
+  return (
+    <ol className="space-y-2 p-2 sm:p-3">
+      {waves.map((wave) => {
+        const complete = wave.criteria.filter(
+          (criterion) => criterion.state === "complete"
+        ).length
+
+        return (
+          <li key={wave.id}>
+            <section
+              aria-labelledby={`${wave.id}-title`}
+              className="border-border/60 rounded-xl border"
+              data-finance-wave={wave.id}
+              data-finance-wave-status={wave.status}
+            >
+              <header className="px-3 pt-3">
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  Wave {wave.sequence}
+                </span>
+                <h3
+                  className="mt-0.5 text-sm font-medium text-balance"
+                  id={`${wave.id}-title`}
+                >
+                  {wave.title}
+                </h3>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <Badge
+                    className={cn(
+                      "rounded-full",
+                      getWaveStatusClassName(wave.status)
+                    )}
+                    variant="outline"
+                  >
+                    {getWaveStatusLabel(wave.status)}
+                  </Badge>
+                  <Badge
+                    className="rounded-full tabular-nums"
+                    variant="outline"
+                  >
+                    {complete}/{wave.criteria.length} verified
+                  </Badge>
+                </div>
+              </header>
+
+              <ul className="border-border/70 mx-3 mt-3 mb-3 space-y-2 border-t pt-3">
+                {wave.criteria.map((criterion) => {
+                  const StateIcon = getCriterionStateIcon(criterion.state)
+
+                  return (
+                    <li
+                      className="text-muted-foreground flex gap-2 text-xs leading-5 text-pretty"
+                      data-finance-wave-criterion={criterion.id}
+                      data-finance-wave-criterion-state={criterion.state}
+                      key={criterion.id}
+                    >
+                      <StateIcon
+                        aria-hidden="true"
+                        className={cn(
+                          "mt-0.5 size-4 shrink-0",
+                          getCriterionStateClassName(criterion.state)
+                        )}
+                      />
+                      <span className="min-w-0 flex-1 break-words">
+                        <span className="sr-only">
+                          {getCriterionStateLabel(criterion.state)}.{" "}
+                        </span>
+                        <span>{criterion.title}</span>
+                        {criterion.evidence.length ? (
+                          <span className="mt-1 block text-[11px] leading-4">
+                            Evidence: {criterion.evidence.join("; ")}
+                          </span>
+                        ) : null}
+                      </span>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -1,0 +1,350 @@
+import type { FinancePlanWorkState } from "./finance-release-plan-data"
+
+export type FinancePlanWaveStatus =
+  | "active"
+  | "code_complete"
+  | "preview_verified"
+  | "production_verified"
+  | "queued"
+
+export type FinancePlanWaveCriterion = {
+  evidence: readonly string[]
+  id: string
+  state: FinancePlanWorkState
+  title: string
+}
+
+export type FinancePlanWave = {
+  criteria: readonly FinancePlanWaveCriterion[]
+  id: string
+  sequence: number
+  status: FinancePlanWaveStatus
+  title: string
+}
+
+function defineCriteria(
+  waveSequence: number,
+  criteria: readonly Omit<FinancePlanWaveCriterion, "id">[]
+): FinancePlanWaveCriterion[] {
+  return criteria.map((criterion, index) => ({
+    ...criterion,
+    id: `wave-${waveSequence}-criterion-${index + 1}`,
+  }))
+}
+
+export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
+  {
+    id: "wave-1-live-stability",
+    sequence: 1,
+    status: "active",
+    title: "Live stability and existing work close",
+    criteria: defineCriteria(1, [
+      {
+        evidence: ["PR #132 merged and production-verified"],
+        state: "complete",
+        title:
+          "Verify authenticated Find in light and dark mode on desktop and mobile with no contrast regression",
+      },
+      {
+        evidence: ["PR #133 merged and production-verified"],
+        state: "complete",
+        title:
+          "Verify organization detail rendering and recoverable missing Stripe-subscription links in production",
+      },
+      {
+        evidence: ["PR #134 merged and production-verified"],
+        state: "complete",
+        title:
+          "Verify revision-safe organization document writes and storage rollback behavior",
+      },
+      {
+        evidence: [
+          "PRs #135 and #136 merged with authenticated production read-safety proof",
+        ],
+        state: "complete",
+        title:
+          "Verify Workspace, Roadmap, and People reads preserve stored organization data",
+      },
+      {
+        evidence: [
+          "PRs #137 and #138 merged; authenticated production Workspace smoke remains",
+        ],
+        state: "in_progress",
+        title:
+          "Complete revision-aware Workspace save smoke and the paid, free, member, coach, and admin journey matrix",
+      },
+    ]),
+  },
+  {
+    id: "wave-2-signup-legal",
+    sequence: 2,
+    status: "active",
+    title: "Signup, recovery, and legal",
+    criteria: defineCriteria(2, [
+      {
+        evidence: ["PR #139 preview checks pass; legal review remains"],
+        state: "in_progress",
+        title:
+          "Provide canonical Terms and Privacy pages with required acceptance on every signup surface",
+      },
+      {
+        evidence: ["PR #139 Supabase Preview passes; production is unchanged"],
+        state: "in_progress",
+        title:
+          "Persist immutable consent version, content hashes, user, and UTC acceptance time under RLS",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify direct and contextual signup, email verification, safe return, denial, retry, and recovery",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title: "Obtain qualified legal approval for Terms and Privacy copy",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Merge, deploy, production-smoke, monitor, and retain a tested signup rollback",
+      },
+    ]),
+  },
+  {
+    id: "wave-3-find-performance",
+    sequence: 3,
+    status: "queued",
+    title: "/find speed and loading",
+    criteria: defineCriteria(3, [
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Serve a compact anonymous resource index without private or detail-only fields",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Add bounded or paginated loading with stable cached refresh behavior",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Load resource details on demand while preserving selected and collected records outside current bounds",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify loading, empty, error, offline, stale, and retry states without losing map context",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Meet payload, first-useful-render, LCP, and interaction budgets in preview and production",
+      },
+    ]),
+  },
+  {
+    id: "wave-4-my-map",
+    sequence: 4,
+    status: "queued",
+    title: "Collect and My Map completion",
+    criteria: defineCriteria(4, [
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Let visitors collect and remove nonprofits and resources locally",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Persist signed-in collections across devices with safe idempotent replay",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Build My Map on the existing saved-organization foundation without separate Finder onboarding",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Keep collected records resolvable through loading, empty, stale, and error states",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify guest, account, and Builder journeys with RLS, production monitoring, and rollback proof",
+      },
+    ]),
+  },
+  {
+    id: "wave-5-finance-reporting",
+    sequence: 5,
+    status: "queued",
+    title: "Finance reporting completion",
+    criteria: defineCriteria(5, [
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Connect read-only external activity with explicit source and freshness labels",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Provide a simple accessible graph, text equivalent, Activity list, and History",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Reconcile visible reporting to authorized external records and correction history",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title: "Verify accurate CSV and PDF exports",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify explicit revocable board sharing, role isolation, failure states, and production rollback",
+      },
+    ]),
+  },
+  {
+    id: "wave-6-resources-guides",
+    sequence: 6,
+    status: "queued",
+    title: "Qualified resources and varied guides",
+    criteria: defineCriteria(6, [
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Report exact candidate, complete, verified, publishable, promoted, and public counts",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Close provider, eligibility, summary, access, contact, and comparison evidence gaps by cohort",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Publish current location-connected guides across multiple service categories",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof",
+      },
+    ]),
+  },
+  {
+    id: "wave-7-integrated-release",
+    sequence: 7,
+    status: "queued",
+    title: "Integrated production release",
+    criteria: defineCriteria(7, [
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Pass the full quality gate, connected RLS where changed, and migration parity",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Complete security review, support runbook, ownership, and monitoring setup",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify hosted paid, free, member, coach, and admin journeys in light, dark, desktop, and mobile",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Rehearse rollback and complete controlled paid and free canaries with gradual rollout",
+      },
+      {
+        evidence: [],
+        state: "not_started",
+        title:
+          "Verify production deployment, smoke checks, clean monitoring, and no unresolved P0 risk",
+      },
+    ]),
+  },
+]
+
+const allCriteria = FINANCE_PLAN_WAVES.flatMap((wave) => wave.criteria)
+
+export const FINANCE_PLAN_WAVE_COUNTS = {
+  complete: allCriteria.filter((criterion) => criterion.state === "complete")
+    .length,
+  inProgress: allCriteria.filter(
+    (criterion) => criterion.state === "in_progress"
+  ).length,
+  notStarted: allCriteria.filter(
+    (criterion) => criterion.state === "not_started"
+  ).length,
+  total: allCriteria.length,
+} as const
+
+export const FINANCE_PLAN_COMPLETION_PERCENTAGE = Math.round(
+  (FINANCE_PLAN_WAVE_COUNTS.complete / FINANCE_PLAN_WAVE_COUNTS.total) * 100
+)
+
+export const FINANCE_PLAN_WAVE_STATUS_COUNTS = {
+  active: FINANCE_PLAN_WAVES.filter((wave) => wave.status === "active").length,
+  codeComplete: FINANCE_PLAN_WAVES.filter(
+    (wave) => wave.status === "code_complete"
+  ).length,
+  previewVerified: FINANCE_PLAN_WAVES.filter(
+    (wave) => wave.status === "preview_verified"
+  ).length,
+  productionVerified: FINANCE_PLAN_WAVES.filter(
+    (wave) => wave.status === "production_verified"
+  ).length,
+  queued: FINANCE_PLAN_WAVES.filter((wave) => wave.status === "queued").length,
+  total: FINANCE_PLAN_WAVES.length,
+} as const
+
+export const FINANCE_PLAN_CURRENT_WAVE =
+  FINANCE_PLAN_WAVES.find((wave) => wave.status === "active") ??
+  FINANCE_PLAN_WAVES.find((wave) => wave.status !== "production_verified") ??
+  FINANCE_PLAN_WAVES.at(-1)!
+
+export const FINANCE_PLAN_NEXT_CRITERION =
+  FINANCE_PLAN_CURRENT_WAVE.criteria.find(
+    (criterion) => criterion.state === "in_progress"
+  ) ??
+  FINANCE_PLAN_CURRENT_WAVE.criteria.find(
+    (criterion) => criterion.state === "not_started"
+  )

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -123,6 +123,14 @@ import {
   FINANCE_PLAN_OBJECTIVE_TRACEABILITY,
   FINANCE_PLAN_OBJECTIVE_TRACEABILITY_COUNT,
 } from "@/features/prototype-lab/components/finance/finance-plan-objective-traceability"
+import {
+  FINANCE_PLAN_COMPLETION_PERCENTAGE,
+  FINANCE_PLAN_CURRENT_WAVE,
+  FINANCE_PLAN_NEXT_CRITERION,
+  FINANCE_PLAN_WAVE_COUNTS,
+  FINANCE_PLAN_WAVES,
+  FINANCE_PLAN_WAVE_STATUS_COUNTS,
+} from "@/features/prototype-lab/components/finance/finance-plan-wave-progress"
 
 const FINANCE_COMPONENT_ROOT = "src/features/prototype-lab/components/finance"
 const FINANCE_PRD_PATH =
@@ -171,6 +179,29 @@ function readPrdBatchScopeItems() {
       .split(/\n- /gu)
       .map((item) => normalizeGateRequirement(item))
   )
+}
+
+function readPrdCurrentWaveCriteria() {
+  const prd = readFileSync(FINANCE_PRD_PATH, "utf8")
+  const section = prd.match(
+    /^#### Current-wave completion checklist\n\n[\s\S]*?\n\n([\s\S]*?)\n\n#### Wave 1 current evidence/m
+  )?.[1]
+  const stateByLabel = {
+    Complete: "complete",
+    "In progress": "in_progress",
+    "Not started": "not_started",
+  } as const
+
+  return [
+    ...(section ?? "").matchAll(
+      /^- \[([ x])\] `([^`]+)` \*\*(Complete|In progress|Not started):\*\* (.*?)(?: — Evidence: .*)?$/gm
+    ),
+  ].map((match) => ({
+    checked: match[1] === "x",
+    id: match[2],
+    state: stateByLabel[match[3] as keyof typeof stateByLabel],
+    title: normalizeGateRequirement(match[4]),
+  }))
 }
 
 function readFinancePrdGateRequirements() {
@@ -1126,7 +1157,56 @@ describe("finance release planning graph", () => {
     ])
   })
 
-  it("derives all seven batches from 37 stateful PRD scope items", () => {
+  it("derives one durable percentage from 35 current-wave criteria", () => {
+    const sourceCriteria = readPrdCurrentWaveCriteria()
+    const trackedCriteria = FINANCE_PLAN_WAVES.flatMap((wave) => wave.criteria)
+
+    expect(FINANCE_PLAN_WAVES.map((wave) => wave.sequence)).toEqual([
+      1, 2, 3, 4, 5, 6, 7,
+    ])
+    expect(FINANCE_PLAN_WAVES.map((wave) => wave.criteria.length)).toEqual(
+      Array(7).fill(5)
+    )
+    expect(FINANCE_PLAN_WAVES.map((wave) => wave.status)).toEqual([
+      "active",
+      "active",
+      ...Array(5).fill("queued"),
+    ])
+    expect(FINANCE_PLAN_WAVE_STATUS_COUNTS).toEqual({
+      active: 2,
+      codeComplete: 0,
+      previewVerified: 0,
+      productionVerified: 0,
+      queued: 5,
+      total: 7,
+    })
+    expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
+      complete: 4,
+      inProgress: 3,
+      notStarted: 28,
+      total: 35,
+    })
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(11)
+    expect(sourceCriteria).toHaveLength(35)
+    expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
+      trackedCriteria.map((criterion) => criterion.id)
+    )
+    expect(sourceCriteria.map((criterion) => criterion.state)).toEqual(
+      trackedCriteria.map((criterion) => criterion.state)
+    )
+    expect(sourceCriteria.map((criterion) => criterion.title)).toEqual(
+      trackedCriteria.map((criterion) =>
+        normalizeGateRequirement(criterion.title)
+      )
+    )
+    expect(sourceCriteria.map((criterion) => criterion.checked)).toEqual(
+      trackedCriteria.map((criterion) => criterion.state === "complete")
+    )
+    expect(FINANCE_PLAN_CURRENT_WAVE.id).toBe("wave-1-live-stability")
+    expect(FINANCE_PLAN_NEXT_CRITERION?.id).toBe("wave-1-criterion-5")
+  })
+
+  it("preserves all seven historical batches and 37 scope items", () => {
     const prdBatchScopeItems = readPrdBatchScopeItems()
     const workItems = FINANCE_PLAN_BATCH_PROGRESS.flatMap(
       (batch) => batch.items
@@ -1195,14 +1275,15 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      batchId: FINANCE_RELEASE_PLAN_NODE_IDS.batch3,
-      batchLabel: "Batch 3: Fiscal sponsorship and project operations",
-      complete: 13,
-      remaining: 24,
-      total: 37,
+      complete: 4,
+      percentage: 11,
+      remaining: 31,
+      total: 35,
+      waveId: "wave-1-live-stability",
+      waveLabel: "Wave 1: Live stability and existing work close",
     })
     expect(FINANCE_PLAN_CURRENT_FOCUS.nextStep).toContain(
-      "Obtain non-author review and merge PR #120"
+      "Complete revision-aware Workspace save smoke"
     )
     expect(
       getFinancePlanNodeStatusTone(
@@ -2108,14 +2189,18 @@ describe("finance release planning graph", () => {
     const readinessFailureSource = readFinanceSource(
       "finance-plan-readiness-failure-list.tsx"
     )
+    const waveProgressSource = readFinanceSource(
+      "finance-plan-wave-progress-list.tsx"
+    )
     expect(readinessNavigatorSource).not.toContain("<Dialog")
     expect(readinessNavigatorSource).toContain("<aside")
     expect(readinessNavigatorSource).toContain("<ScrollArea")
-    expect(readinessNavigatorSource).toContain("Release implementation plan")
-    expect(readinessNavigatorSource).toContain("steps left")
+    expect(readinessNavigatorSource).toContain("Current release progress")
+    expect(readinessNavigatorSource).toContain("% complete")
     expect(readinessNavigatorSource).toContain("Need from you")
     expect(readinessNavigatorSource).toContain("Research before coding")
-    expect(readinessCategorySource).toContain("Batches")
+    expect(readinessCategorySource).toContain("Current waves")
+    expect(readinessCategorySource).toContain("Historical batches")
     expect(readinessCategorySource).toContain("Gates")
     expect(readinessCategorySource).toContain("Tests")
     expect(readinessCategorySource).toContain("Security")
@@ -2144,7 +2229,7 @@ describe("finance release planning graph", () => {
     )
     expect(readinessNavigatorSource).toContain("data-finance-readiness-panel")
     expect(readinessNavigatorSource).toContain(
-      'useState<FinancePlanReadinessMode>("batches")'
+      'useState<FinancePlanReadinessMode>("waves")'
     )
     expect(readinessCategorySource).toContain('from "@/components/ui/select"')
     expect(readinessCategorySource).toContain("<SelectTrigger")
@@ -2152,6 +2237,10 @@ describe("finance release planning graph", () => {
       'from "@/components/ui/button"'
     )
     expect(readinessNavigatorSource).toContain("data-finance-readiness-mode")
+    expect(waveProgressSource).toContain("data-finance-wave")
+    expect(waveProgressSource).toContain("data-finance-wave-status")
+    expect(waveProgressSource).toContain("data-finance-wave-criterion")
+    expect(waveProgressSource).toContain("data-finance-wave-criterion-state")
     expect(readinessGateSource).toContain("data-finance-readiness-gate-state")
     expect(readinessGateSource).toContain(
       "data-finance-readiness-evidence-list"


### PR DESCRIPTION
## What changed

- define a stable 35-criterion completion contract in the authoritative Finance release PRD
- make current waves the default Prototype Lab progress view
- show computed completion, criterion states, evidence, and the next required proof
- retain the 37-item batch tracker as explicitly historical
- enforce exact PRD-to-source parity in acceptance tests

## Why

The PRD prohibited one completion percentage because earlier reports mixed incompatible denominators. That made progress impossible to track durably between sessions.

This replaces the ambiguity with one version-controlled denominator: five criteria across each of seven release waves. Only checked, production-evidenced criteria count.

Current progress is 4/35, or 11%.

## Impact

Future sessions can read the PRD and source tracker, report the same percentage, and update stable criterion IDs as evidence becomes complete.

No database, Stripe, or production mutation is included.

## Validation

- focused Finance release-plan tests: 37/37 passed
- pre-push checks: structural guards, snapshots, and 2,044 acceptance tests passed
- RLS suites and 108-route production build passed
- visual cases: 30/30 passed across the initial run and warmed focused rerun
- performance budgets passed
