### PR TITLE
[STEP S47] Add bounded Find index loading

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **5/35 complete (14%)**, **3 in progress**, and
-**27 not started**.
+revision. Current progress: **5/35 complete (14%)**, **4 in progress**, and
+**26 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -156,7 +156,7 @@ revision. Current progress: **5/35 complete (14%)**, **3 in progress**, and
 **Wave 3 — `/find` speed and loading**
 
 - [ ] `wave-3-criterion-1` **In progress:** Serve a compact anonymous resource index without private or detail-only fields — Evidence: branch `feat/find-compact-index-20260811` serves the full 853-record production dataset through a 415,659-byte local index response, down 83.5% from 2,519,680 bytes; production is unchanged.
-- [ ] `wave-3-criterion-2` **Not started:** Add bounded or paginated loading with stable cached refresh behavior.
+- [ ] `wave-3-criterion-2` **In progress:** Add bounded or paginated loading with stable cached refresh behavior — Evidence: stacked branch `feat/find-bounded-loading-20260811` returns all 853 records exactly once across five deterministic 200-item cursor pages; the first page is 97,986 bytes and pages 2–5 reuse one five-minute server snapshot in 25–38 ms locally. The `/find` client remains unchanged.
 - [ ] `wave-3-criterion-3` **Not started:** Load resource details on demand while preserving selected and collected records outside current bounds.
 - [ ] `wave-3-criterion-4` **Not started:** Verify loading, empty, error, offline, stale, and retry states without losing map context.
 - [ ] `wave-3-criterion-5` **Not started:** Meet payload, first-useful-render, LCP, and interaction budgets in preview and production.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2698,3 +2698,20 @@
   was unavailable; direct HTTP verified the live local response and exact field
   boundary. Production remains unchanged. Continue with bounded detail lookup,
   then switch `/find` to the compact index without losing selected records.
+
+2026-08-11 21:30 EDT - started bounded Find index loading.
+
+- Marked PR #143 review-ready after quality, step-ID, security, and both Vercel
+  preview checks passed. The hosted endpoint is protected by Vercel SSO and the
+  connected browser blocked it client-side, so no hosted payload claim was made.
+- Added deterministic cursor pagination to the compact index on stacked branch
+  `feat/find-bounded-loading-20260811`: 200 records by default, 500 maximum,
+  explicit invalid-limit responses, stable public-ID ordering, and cursor
+  recovery when a previously returned item disappears.
+- Added a shared five-minute server snapshot. Connected local traversal returned
+  all 853 production records exactly once across five pages; the first page was
+  97,986 bytes and the cached remaining pages completed in 25-38 ms. The cache
+  response remains `s-maxage=300, stale-while-revalidate=600`.
+- Focused acceptance passes 21/21; feature, route, boundary, lint, formatting,
+  and invalid-limit checks pass. The existing `/find` client and production are
+  unchanged, so Wave 3 criterion 2 remains in progress pending client adoption.

--- a/src/app/api/public/resource-map/index/route.ts
+++ b/src/app/api/public/resource-map/index/route.ts
@@ -2,19 +2,30 @@ import { NextResponse } from "next/server"
 
 import {
   FIND_RESOURCE_INDEX_CACHE_CONTROL,
-  FIND_RESOURCE_INDEX_VERSION,
-  type FindResourceIndexResponse,
+  paginateFindResourceIndexItems,
+  parseFindResourceIndexLimit,
 } from "@/features/find-resource-index"
 import { fetchFindResourceIndexItems } from "../../../../../features/find-resource-index/server/actions"
 
 export const revalidate = 300
 
-export async function GET() {
-  const resourceItems = await fetchFindResourceIndexItems()
-  const payload: FindResourceIndexResponse = {
-    version: FIND_RESOURCE_INDEX_VERSION,
-    resourceItems,
+export async function GET(request: Request) {
+  const searchParams = new URL(request.url).searchParams
+  const limit = parseFindResourceIndexLimit(searchParams.get("limit"))
+  if (limit === null) {
+    return NextResponse.json(
+      { error: "limit must be an integer between 1 and 500" },
+      { status: 400 }
+    )
   }
+
+  const cursor = searchParams.get("cursor")?.trim() || null
+  const resourceItems = await fetchFindResourceIndexItems()
+  const payload = paginateFindResourceIndexItems({
+    cursor,
+    items: resourceItems,
+    limit,
+  })
 
   return NextResponse.json(payload, {
     headers: {

--- a/src/features/find-resource-index/README.md
+++ b/src/features/find-resource-index/README.md
@@ -14,6 +14,11 @@
 - Keep `server/**` free of UI/component imports.
 - Keep the index transport compact and public-safe. Detail-only fields belong to
   the separate resource detail contract.
+- Bump the response version whenever paging semantics change.
+- Keep pages deterministically ordered by public item ID. Use the returned
+  cursor instead of numeric offsets so cached refreshes do not skip records.
+- Share one five-minute server snapshot across page URLs so traversal does not
+  repeat the complete public resource query for every page.
 - Keep the existing full-item endpoint unchanged until detail-on-demand is
   available.
 - Keep acceptance coverage in `tests/acceptance/find-resource-index.test.ts`.

--- a/src/features/find-resource-index/index.ts
+++ b/src/features/find-resource-index/index.ts
@@ -1,6 +1,10 @@
 export {
   FIND_RESOURCE_INDEX_CACHE_CONTROL,
+  FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT,
+  FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT,
   FIND_RESOURCE_INDEX_VERSION,
+  paginateFindResourceIndexItems,
+  parseFindResourceIndexLimit,
   serializeFindResourceIndexItem,
 } from "./lib"
 export type {

--- a/src/features/find-resource-index/lib/index.ts
+++ b/src/features/find-resource-index/lib/index.ts
@@ -1,10 +1,55 @@
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
 
-import type { FindResourceIndexItem } from "../types"
+import type { FindResourceIndexItem, FindResourceIndexResponse } from "../types"
 
-export const FIND_RESOURCE_INDEX_VERSION = 1 as const
+export const FIND_RESOURCE_INDEX_VERSION = 2 as const
+export const FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT = 200
+export const FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT = 500
 export const FIND_RESOURCE_INDEX_CACHE_CONTROL =
   "public, s-maxage=300, stale-while-revalidate=600"
+
+export function parseFindResourceIndexLimit(value: string | null) {
+  if (value === null) return FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT
+  if (!/^\d+$/.test(value)) return null
+
+  const limit = Number(value)
+  if (limit < 1 || limit > FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT) return null
+  return limit
+}
+
+export function paginateFindResourceIndexItems({
+  cursor,
+  items,
+  limit,
+}: {
+  cursor: string | null
+  items: FindResourceIndexItem[]
+  limit: number
+}): FindResourceIndexResponse {
+  const orderedItems = [...items].sort((left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0
+  )
+  const startIndex = cursor
+    ? orderedItems.findIndex((item) => item.id > cursor)
+    : 0
+  const remainingItems =
+    startIndex === -1
+      ? []
+      : orderedItems.slice(startIndex, startIndex + limit + 1)
+  const hasMore = remainingItems.length > limit
+  const resourceItems = remainingItems.slice(0, limit)
+
+  return {
+    version: FIND_RESOURCE_INDEX_VERSION,
+    resourceItems,
+    page: {
+      hasMore,
+      limit,
+      nextCursor: hasMore ? (resourceItems.at(-1)?.id ?? null) : null,
+      totalCount: orderedItems.length,
+    },
+  }
+}
 
 export function serializeFindResourceIndexItem(
   item: ExternalResourceMapItem

--- a/src/features/find-resource-index/server/actions.ts
+++ b/src/features/find-resource-index/server/actions.ts
@@ -1,8 +1,18 @@
+import { unstable_cache } from "next/cache"
+
 import { fetchPublicResourceMapItems } from "@/lib/queries/resource-map-public-items"
 
 import { serializeFindResourceIndexItem } from "../lib"
 
+const fetchFindResourceIndexItemsCached = unstable_cache(
+  async () => {
+    const items = await fetchPublicResourceMapItems()
+    return items.map(serializeFindResourceIndexItem)
+  },
+  ["find-resource-index-v2"],
+  { revalidate: 300 }
+)
+
 export async function fetchFindResourceIndexItems() {
-  const items = await fetchPublicResourceMapItems()
-  return items.map(serializeFindResourceIndexItem)
+  return fetchFindResourceIndexItemsCached()
 }

--- a/src/features/find-resource-index/types.ts
+++ b/src/features/find-resource-index/types.ts
@@ -30,6 +30,12 @@ export type FindResourceIndexItem = {
 }
 
 export type FindResourceIndexResponse = {
-  version: 1
+  version: 2
   resourceItems: FindResourceIndexItem[]
+  page: {
+    hasMore: boolean
+    limit: number
+    nextCursor: string | null
+    totalCount: number
+  }
 }

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -127,8 +127,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Serve a compact anonymous resource index without private or detail-only fields",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Stacked branch feat/find-bounded-loading-20260811 returns all 853 records once across five stable cursor pages; page one is 97,986 bytes and cached pages 2-5 complete in 25-38 ms locally; the client is unchanged",
+        ],
+        state: "in_progress",
         title:
           "Add bounded or paginated loading with stable cached refresh behavior",
       },

--- a/tests/acceptance/find-resource-index.test.ts
+++ b/tests/acceptance/find-resource-index.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT,
+  FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT,
   FIND_RESOURCE_INDEX_VERSION,
+  paginateFindResourceIndexItems,
+  parseFindResourceIndexLimit,
   serializeFindResourceIndexItem,
 } from "@/features/find-resource-index"
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
@@ -79,7 +83,7 @@ describe("find resource index feature contract", () => {
   it("serializes only fields needed to place, filter, and identify resources", () => {
     const serialized = serializeFindResourceIndexItem(buildResourceItem())
 
-    expect(FIND_RESOURCE_INDEX_VERSION).toBe(1)
+    expect(FIND_RESOURCE_INDEX_VERSION).toBe(2)
     expect(serialized).toEqual({
       id: "resource_map:service-food-1",
       itemType: "external_resource",
@@ -150,5 +154,73 @@ describe("find resource index feature contract", () => {
     expect(serializeFindResourceIndexItem(item)).not.toHaveProperty(
       "availability"
     )
+  })
+
+  it("validates bounded page limits", () => {
+    expect(parseFindResourceIndexLimit(null)).toBe(
+      FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT
+    )
+    expect(parseFindResourceIndexLimit("1")).toBe(1)
+    expect(parseFindResourceIndexLimit("500")).toBe(
+      FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT
+    )
+    expect(parseFindResourceIndexLimit("0")).toBeNull()
+    expect(parseFindResourceIndexLimit("501")).toBeNull()
+    expect(parseFindResourceIndexLimit("2.5")).toBeNull()
+  })
+
+  it("returns deterministic cursor pages without duplicates", () => {
+    const item = serializeFindResourceIndexItem(buildResourceItem())
+    const items = ["resource:c", "resource:a", "resource:b"].map((id) => ({
+      ...item,
+      id,
+    }))
+
+    const firstPage = paginateFindResourceIndexItems({
+      cursor: null,
+      items,
+      limit: 2,
+    })
+    const secondPage = paginateFindResourceIndexItems({
+      cursor: firstPage.page.nextCursor,
+      items,
+      limit: 2,
+    })
+
+    expect(firstPage).toMatchObject({
+      version: 2,
+      resourceItems: [{ id: "resource:a" }, { id: "resource:b" }],
+      page: {
+        hasMore: true,
+        limit: 2,
+        nextCursor: "resource:b",
+        totalCount: 3,
+      },
+    })
+    expect(secondPage).toMatchObject({
+      resourceItems: [{ id: "resource:c" }],
+      page: {
+        hasMore: false,
+        nextCursor: null,
+        totalCount: 3,
+      },
+    })
+  })
+
+  it("resumes after a cursor that disappeared during refresh", () => {
+    const item = serializeFindResourceIndexItem(buildResourceItem())
+    const page = paginateFindResourceIndexItems({
+      cursor: "resource:b",
+      items: ["resource:a", "resource:c", "resource:d"].map((id) => ({
+        ...item,
+        id,
+      })),
+      limit: 2,
+    })
+
+    expect(page.resourceItems.map(({ id }) => id)).toEqual([
+      "resource:c",
+      "resource:d",
+    ])
   })
 })

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1183,8 +1183,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 5,
-      inProgress: 3,
-      notStarted: 27,
+      inProgress: 4,
+      notStarted: 26,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(14)


### PR DESCRIPTION
## Summary

- add version 2 deterministic cursor pages to the compact Find index
- return 200 records by default, with a validated 500-record maximum
- reuse one five-minute server snapshot across page URLs
- keep the existing `/find` client unchanged

## Connected evidence

- all 853 public production records returned exactly once across five pages
- first page: 97,986 bytes
- cold first page: 3.3 seconds locally
- cached pages 2-5: 25-38 ms each
- invalid limits return 400
- cache header remains `s-maxage=300, stale-while-revalidate=600`

## Verification

- focused acceptance: 58/58
- production build: 109 routes
- required pre-push: 398 files and 2,050 tests passed; one file/test skipped

## Stack

Base is PR #143. Review only the two S47 commits. Merge #143 first, then retarget this PR to `main`.

## Boundaries

- no database, migration, browser UI, or production mutation
- criterion 2 remains in progress until `/find` adopts paged loading

## Rollback

Revert the two S47 commits; version 1 full-index behavior remains in PR #143.