### PR TITLE
[STEP S48] Add Find resource detail lookup

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **5/35 complete (14%)**, **4 in progress**, and
-**26 not started**.
+revision. Current progress: **5/35 complete (14%)**, **5 in progress**, and
+**25 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -157,7 +157,7 @@ revision. Current progress: **5/35 complete (14%)**, **4 in progress**, and
 
 - [ ] `wave-3-criterion-1` **In progress:** Serve a compact anonymous resource index without private or detail-only fields — Evidence: branch `feat/find-compact-index-20260811` serves the full 853-record production dataset through a 415,659-byte local index response, down 83.5% from 2,519,680 bytes; production is unchanged.
 - [ ] `wave-3-criterion-2` **In progress:** Add bounded or paginated loading with stable cached refresh behavior — Evidence: stacked branch `feat/find-bounded-loading-20260811` returns all 853 records exactly once across five deterministic 200-item cursor pages; the first page is 97,986 bytes and pages 2–5 reuse one five-minute server snapshot in 25–38 ms locally. The `/find` client remains unchanged.
-- [ ] `wave-3-criterion-3` **Not started:** Load resource details on demand while preserving selected and collected records outside current bounds.
+- [ ] `wave-3-criterion-3` **In progress:** Load resource details on demand while preserving selected and collected records outside current bounds — Evidence: stacked branch `feat/find-detail-on-demand-20260811` returns a 2,783-byte sanitized detail response by exact public item ID, rejects malformed IDs before querying, returns 404 for missing records, and serves repeated requests from cache in 46 ms locally. The `/find` selection and collection cutover remains open.
 - [ ] `wave-3-criterion-4` **Not started:** Verify loading, empty, error, offline, stale, and retry states without losing map context.
 - [ ] `wave-3-criterion-5` **Not started:** Meet payload, first-useful-render, LCP, and interaction budgets in preview and production.
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2715,3 +2715,23 @@
 - Focused acceptance passes 21/21; feature, route, boundary, lint, formatting,
   and invalid-limit checks pass. The existing `/find` client and production are
   unchanged, so Wave 3 criterion 2 remains in progress pending client adoption.
+
+2026-08-11 21:52 EDT - started Find resource detail on demand.
+
+- Marked stacked PR #144 review-ready after hosted quality, step-ID, security,
+  and both Vercel preview checks passed.
+- Added a read-only, versioned `/api/public/resource-map/items/[id]` response.
+  It resolves one exact UUID from the existing anonymous sanitized view, reuses
+  the established public full-item sanitizer, rejects malformed IDs before the
+  database query, returns 404 for missing records, and caches each sanitized
+  detail separately for five minutes.
+- Connected local proof returned the same ID selected from the compact index in
+  a 2,783-byte response with no favicon, raw logo, mission, values, or vision
+  fields. The cold request spent 1.2 seconds in application code; a repeated
+  request completed in 46 ms end to end and 9 ms in application code.
+- An attempted shared raw-dataset cache was rejected during iteration because
+  its 3,061,721-byte value exceeded Next.js's 2 MB per-entry limit. It was never
+  committed; the compact index cache stayed unchanged and per-item sanitized
+  caching replaced it. No migration, database write, UI, or production change
+  occurred. Criterion 3 remains in progress pending client selection and
+  collection adoption.

--- a/src/app/api/public/resource-map/items/[id]/route.ts
+++ b/src/app/api/public/resource-map/items/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+
+import {
+  FIND_RESOURCE_INDEX_CACHE_CONTROL,
+  type FindResourceDetailResponse,
+} from "@/features/find-resource-index"
+import { fetchFindResourceDetailItem } from "../../../../../../features/find-resource-index/server/actions"
+
+export const revalidate = 300
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: rawId } = await params
+  const id = rawId.trim()
+  if (!id || id.length > 256) {
+    return NextResponse.json({ error: "invalid resource ID" }, { status: 400 })
+  }
+
+  const resourceItem = await fetchFindResourceDetailItem(id)
+  if (!resourceItem) {
+    return NextResponse.json({ error: "resource not found" }, { status: 404 })
+  }
+
+  const payload: FindResourceDetailResponse = {
+    version: 1,
+    resourceItem,
+  }
+  return NextResponse.json(payload, {
+    headers: { "Cache-Control": FIND_RESOURCE_INDEX_CACHE_CONTROL },
+  })
+}

--- a/src/app/api/public/resource-map/items/route.ts
+++ b/src/app/api/public/resource-map/items/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server"
 
-import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
-import { isPublicMapTechnicalSourceUrl } from "@/lib/public-map/resource-link-visibility"
+import { serializeFindResourceDetailItem } from "@/features/find-resource-index"
 import { fetchPublicResourceMapItems } from "@/lib/queries/resource-map-public-items"
 
 export const revalidate = 300
@@ -9,93 +8,12 @@ export const revalidate = 300
 const PUBLIC_RESOURCE_MAP_ITEMS_CACHE_CONTROL =
   "public, s-maxage=300, stale-while-revalidate=600"
 
-function serializePublicResourceAvailability(
-  availability: ExternalResourceMapItem["availability"]
-) {
-  if (!availability) return undefined
-  if (availability.status === "unknown" && !availability.notes) {
-    return undefined
-  }
-  if (availability.status === "unknown") {
-    return {
-      notes: availability.notes,
-      status: availability.status,
-      statusLabel: availability.statusLabel,
-    } as ExternalResourceMapItem["availability"]
-  }
-
-  return availability
-}
-
-function serializePublicResourceServices(
-  services: ExternalResourceMapItem["services"],
-  itemDescription: string | null
-) {
-  return (services ?? []).flatMap((service) => {
-    const description =
-      service.description === itemDescription ? null : service.description
-    const hasUsefulDetails = Boolean(
-      description ||
-      service.whoItHelps ||
-      service.eligibility ||
-      service.cost ||
-      service.languages?.length ||
-      service.intakeUrl ||
-      service.appointmentInfo ||
-      service.documentsNeeded?.length ||
-      service.accessibilityNotes ||
-      service.urgentAvailability ||
-      service.ageRange ||
-      service.serviceArea?.length
-    )
-    if (!hasUsefulDetails) return []
-
-    return [{ ...service, description }]
-  })
-}
-
-export function serializePublicResourceMapItem(
-  item: ExternalResourceMapItem
-): ExternalResourceMapItem {
-  const {
-    aliases,
-    availability,
-    deliveryModes,
-    faviconUrl,
-    logoUrl,
-    markerImageUrl,
-    mission,
-    services,
-    sourceUrl,
-    values,
-    vision,
-    ...rest
-  } = item
-  const publicAvailability = serializePublicResourceAvailability(availability)
-  const publicServices = serializePublicResourceServices(
-    services,
-    rest.description
-  )
-  const publicSourceUrl =
-    sourceUrl && isPublicMapTechnicalSourceUrl(sourceUrl) ? null : sourceUrl
-
-  return {
-    ...rest,
-    ...(aliases?.length ? { aliases } : null),
-    ...(publicAvailability ? { availability: publicAvailability } : null),
-    ...(deliveryModes?.length ? { deliveryModes } : null),
-    ...(markerImageUrl ? { markerImageUrl } : null),
-    ...(publicServices.length ? { services: publicServices } : null),
-    sourceUrl: publicSourceUrl,
-  }
-}
-
 export async function GET() {
   const resourceItems = await fetchPublicResourceMapItems()
 
   return NextResponse.json(
     {
-      resourceItems: resourceItems.map(serializePublicResourceMapItem),
+      resourceItems: resourceItems.map(serializeFindResourceDetailItem),
     },
     {
       headers: {

--- a/src/features/find-resource-index/README.md
+++ b/src/features/find-resource-index/README.md
@@ -19,6 +19,12 @@
   cursor instead of numeric offsets so cached refreshes do not skip records.
 - Share one five-minute server snapshot across page URLs so traversal does not
   repeat the complete public resource query for every page.
+- Reuse the existing public full-item sanitizer for detail lookup. Never return
+  the cached raw item directly from an API route.
+- Cache each sanitized detail response separately; the complete raw dataset is
+  larger than Next.js's per-entry data-cache limit.
+- Resolve production details by exact ID from the existing anonymous sanitized
+  view. Never query raw import or curation tables for this route.
 - Keep the existing full-item endpoint unchanged until detail-on-demand is
   available.
 - Keep acceptance coverage in `tests/acceptance/find-resource-index.test.ts`.

--- a/src/features/find-resource-index/index.ts
+++ b/src/features/find-resource-index/index.ts
@@ -5,10 +5,13 @@ export {
   FIND_RESOURCE_INDEX_VERSION,
   paginateFindResourceIndexItems,
   parseFindResourceIndexLimit,
+  resolveFindResourceDetailItem,
+  serializeFindResourceDetailItem,
   serializeFindResourceIndexItem,
 } from "./lib"
 export type {
   FindResourceIndexAvailability,
   FindResourceIndexItem,
   FindResourceIndexResponse,
+  FindResourceDetailResponse,
 } from "./types"

--- a/src/features/find-resource-index/lib/index.ts
+++ b/src/features/find-resource-index/lib/index.ts
@@ -1,4 +1,5 @@
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
+import { isPublicMapTechnicalSourceUrl } from "@/lib/public-map/resource-link-visibility"
 
 import type { FindResourceIndexItem, FindResourceIndexResponse } from "../types"
 
@@ -49,6 +50,96 @@ export function paginateFindResourceIndexItems({
       totalCount: orderedItems.length,
     },
   }
+}
+
+function serializeFindResourceDetailAvailability(
+  availability: ExternalResourceMapItem["availability"]
+) {
+  if (!availability) return undefined
+  if (availability.status === "unknown" && !availability.notes) {
+    return undefined
+  }
+  if (availability.status === "unknown") {
+    return {
+      notes: availability.notes,
+      status: availability.status,
+      statusLabel: availability.statusLabel,
+    } as ExternalResourceMapItem["availability"]
+  }
+
+  return availability
+}
+
+function serializeFindResourceDetailServices(
+  services: ExternalResourceMapItem["services"],
+  itemDescription: string | null
+) {
+  return (services ?? []).flatMap((service) => {
+    const description =
+      service.description === itemDescription ? null : service.description
+    const hasUsefulDetails = Boolean(
+      description ||
+      service.whoItHelps ||
+      service.eligibility ||
+      service.cost ||
+      service.languages?.length ||
+      service.intakeUrl ||
+      service.appointmentInfo ||
+      service.documentsNeeded?.length ||
+      service.accessibilityNotes ||
+      service.urgentAvailability ||
+      service.ageRange ||
+      service.serviceArea?.length
+    )
+    if (!hasUsefulDetails) return []
+
+    return [{ ...service, description }]
+  })
+}
+
+export function serializeFindResourceDetailItem(
+  item: ExternalResourceMapItem
+): ExternalResourceMapItem {
+  const {
+    aliases,
+    availability,
+    deliveryModes,
+    faviconUrl,
+    logoUrl,
+    markerImageUrl,
+    mission,
+    services,
+    sourceUrl,
+    values,
+    vision,
+    ...rest
+  } = item
+  const publicAvailability =
+    serializeFindResourceDetailAvailability(availability)
+  const publicServices = serializeFindResourceDetailServices(
+    services,
+    rest.description
+  )
+  const publicSourceUrl =
+    sourceUrl && isPublicMapTechnicalSourceUrl(sourceUrl) ? null : sourceUrl
+
+  return {
+    ...rest,
+    ...(aliases?.length ? { aliases } : null),
+    ...(publicAvailability ? { availability: publicAvailability } : null),
+    ...(deliveryModes?.length ? { deliveryModes } : null),
+    ...(markerImageUrl ? { markerImageUrl } : null),
+    ...(publicServices.length ? { services: publicServices } : null),
+    sourceUrl: publicSourceUrl,
+  }
+}
+
+export function resolveFindResourceDetailItem(
+  items: ExternalResourceMapItem[],
+  id: string
+) {
+  const matched = items.find((item) => item.id === id)
+  return matched ? serializeFindResourceDetailItem(matched) : null
 }
 
 export function serializeFindResourceIndexItem(

--- a/src/features/find-resource-index/server/actions.ts
+++ b/src/features/find-resource-index/server/actions.ts
@@ -1,8 +1,14 @@
 import { unstable_cache } from "next/cache"
 
-import { fetchPublicResourceMapItems } from "@/lib/queries/resource-map-public-items"
+import {
+  fetchPublicResourceMapItemById,
+  fetchPublicResourceMapItems,
+} from "@/lib/queries/resource-map-public-items"
 
-import { serializeFindResourceIndexItem } from "../lib"
+import {
+  resolveFindResourceDetailItem,
+  serializeFindResourceIndexItem,
+} from "../lib"
 
 const fetchFindResourceIndexItemsCached = unstable_cache(
   async () => {
@@ -13,6 +19,19 @@ const fetchFindResourceIndexItemsCached = unstable_cache(
   { revalidate: 300 }
 )
 
+const fetchFindResourceDetailItemCached = unstable_cache(
+  async (id: string) => {
+    const item = await fetchPublicResourceMapItemById(id)
+    return item ? resolveFindResourceDetailItem([item], id) : null
+  },
+  ["find-resource-detail-v2"],
+  { revalidate: 300 }
+)
+
 export async function fetchFindResourceIndexItems() {
   return fetchFindResourceIndexItemsCached()
+}
+
+export async function fetchFindResourceDetailItem(id: string) {
+  return fetchFindResourceDetailItemCached(id)
 }

--- a/src/features/find-resource-index/types.ts
+++ b/src/features/find-resource-index/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ExternalResourceMapItem,
   PublicMapItemVisibility,
   PublicMapVerificationStatus,
 } from "@/lib/public-map/resource-map-items"
@@ -38,4 +39,9 @@ export type FindResourceIndexResponse = {
     nextCursor: string | null
     totalCount: number
   }
+}
+
+export type FindResourceDetailResponse = {
+  version: 1
+  resourceItem: ExternalResourceMapItem
 }

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -135,8 +135,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Add bounded or paginated loading with stable cached refresh behavior",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Stacked branch feat/find-detail-on-demand-20260811 returns a 2,783-byte sanitized detail by exact public ID, rejects malformed IDs, returns 404 for missing records, and repeats from cache in 46 ms locally; client selection and collection adoption remain open",
+        ],
+        state: "in_progress",
         title:
           "Load resource details on demand while preserving selected and collected records outside current bounds",
       },

--- a/src/lib/queries/resource-map-public-items.ts
+++ b/src/lib/queries/resource-map-public-items.ts
@@ -23,6 +23,8 @@ export type FetchPublicResourceMapItemsOptions = {
 export const DEFAULT_RESOURCE_MAP_LOCAL_PREVIEW_LIMIT = 10000
 export const DEFAULT_RESOURCE_MAP_PUBLIC_DB_LIMIT = 5000
 export const RESOURCE_MAP_PUBLIC_DB_PAGE_SIZE = 500
+const RESOURCE_MAP_PUBLIC_ITEM_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export function isResourceMapPublicDbEnabled(
   value = env.RESOURCE_MAP_PUBLIC_DB_ENABLED
@@ -262,4 +264,54 @@ export async function fetchPublicResourceMapItems(
   return fetchPublicResourceMapItemsUncached({
     limit: options.limit,
   })
+}
+
+export async function fetchPublicResourceMapItemById(
+  id: string,
+  options: FetchPublicResourceMapItemsOptions = {}
+): Promise<ExternalResourceMapItem | null> {
+  const normalizedId = id.trim()
+  if (!normalizedId) return null
+
+  const localPreviewFile = normalizeLocalPreviewFile(
+    options.localPreviewFile ?? env.RESOURCE_MAP_LOCAL_PREVIEW_FILE
+  )
+  const localEnginePreviewFile = normalizeLocalPreviewFile(
+    options.localEnginePreviewFile
+  )
+  if (
+    localPreviewFile ||
+    (localEnginePreviewFile && existsSync(localEnginePreviewFile))
+  ) {
+    const items = await fetchPublicResourceMapItems(options)
+    return items.find((item) => item.id === normalizedId) ?? null
+  }
+
+  const enabled = options.enabled ?? isResourceMapPublicDbEnabled()
+  if (!enabled || !normalizedId.startsWith("resource_map:")) return null
+  const itemId = normalizedId.slice("resource_map:".length)
+  if (!RESOURCE_MAP_PUBLIC_ITEM_UUID_PATTERN.test(itemId)) return null
+
+  const supabase = createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    { auth: { persistSession: false } }
+  )
+  const { data, error } = await supabase
+    .from("resource_map_public_items")
+    .select("*")
+    .eq("item_id", itemId)
+    .maybeSingle()
+  if (error || !data) {
+    if (error) {
+      console.warn("[resource-map] public item lookup unavailable", {
+        code: error.code,
+        message: error.message,
+      })
+    }
+    return null
+  }
+
+  const item = buildExternalResourceMapItemFromPublicRow(data)
+  return item && shouldShowPublicMapResourceItem(item) ? item : null
 }

--- a/tests/acceptance/find-resource-index.test.ts
+++ b/tests/acceptance/find-resource-index.test.ts
@@ -6,6 +6,7 @@ import {
   FIND_RESOURCE_INDEX_VERSION,
   paginateFindResourceIndexItems,
   parseFindResourceIndexLimit,
+  resolveFindResourceDetailItem,
   serializeFindResourceIndexItem,
 } from "@/features/find-resource-index"
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
@@ -222,5 +223,22 @@ describe("find resource index feature contract", () => {
       "resource:c",
       "resource:d",
     ])
+  })
+
+  it("returns one sanitized detail item by exact public ID", () => {
+    const item = buildResourceItem()
+    item.faviconUrl = "https://resource.example.org/favicon.ico"
+    item.logoUrl = "https://resource.example.org/logo.svg"
+
+    expect(resolveFindResourceDetailItem([item], item.id)).toMatchObject({
+      id: item.id,
+      title: item.title,
+    })
+    expect(resolveFindResourceDetailItem([item], item.id)).not.toHaveProperty(
+      "faviconUrl"
+    )
+    expect(
+      resolveFindResourceDetailItem([item], "resource_map:missing")
+    ).toBeNull()
   })
 })

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1183,8 +1183,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 5,
-      inProgress: 4,
-      notStarted: 26,
+      inProgress: 5,
+      notStarted: 25,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(14)

--- a/tests/acceptance/resource-map-public-items-query.test.ts
+++ b/tests/acceptance/resource-map-public-items-query.test.ts
@@ -14,9 +14,10 @@ vi.mock("@supabase/supabase-js", () => ({
 }))
 
 import { buildExternalResourceMapItemFromPublicRow } from "@/lib/public-map/resource-map-public-item-adapter"
-import { serializePublicResourceMapItem } from "@/app/api/public/resource-map/items/route"
+import { serializeFindResourceDetailItem } from "@/features/find-resource-index"
 import { resolveResourceAvailability } from "@/lib/public-map/resource-availability"
 import {
+  fetchPublicResourceMapItemById,
   fetchPublicResourceMapItems,
   isResourceMapPublicDbEnabled,
 } from "@/lib/queries/resource-map-public-items"
@@ -237,7 +238,7 @@ describe("resource map public item adapter", () => {
     )
     expect(item).not.toBeNull()
 
-    const serialized = serializePublicResourceMapItem({
+    const serialized = serializeFindResourceDetailItem({
       ...item!,
       aliases: [],
       availability: {
@@ -260,19 +261,19 @@ describe("resource map public item adapter", () => {
 
     expect(serialized.sourceUrl).toBeNull()
     expect(
-      serializePublicResourceMapItem({
+      serializeFindResourceDetailItem({
         ...item!,
         sourceUrl: overpassSourceUrl,
       }).sourceUrl
     ).toBeNull()
     expect(
-      serializePublicResourceMapItem({
+      serializeFindResourceDetailItem({
         ...item!,
         sourceUrl: socrataSourceUrl,
       }).sourceUrl
     ).toBeNull()
     expect(
-      serializePublicResourceMapItem({
+      serializeFindResourceDetailItem({
         ...item!,
         sourceUrl: wikidataSourceUrl,
       }).sourceUrl
@@ -425,6 +426,48 @@ describe("fetchPublicResourceMapItems", () => {
       expect.stringContaining("resource_map_import_records"),
       expect.anything()
     )
+  })
+
+  it("loads one detail item from the sanitized public view", async () => {
+    const itemId = "0072e21f-c0ce-4544-9bd4-40a75be58794"
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: buildPublicResourceRow({ item_id: itemId }),
+      error: null,
+    })
+    const eq = vi.fn().mockReturnValue({ maybeSingle })
+    const select = vi.fn().mockReturnValue({ eq })
+    const from = vi.fn().mockReturnValue({ select })
+    createClientMock.mockReturnValue({ from })
+
+    const item = await fetchPublicResourceMapItemById(
+      `resource_map:${itemId}`,
+      {
+        enabled: true,
+        localEnginePreviewFile: null,
+        localPreviewFile: null,
+      }
+    )
+
+    expect(item).toMatchObject({
+      id: `resource_map:${itemId}`,
+      title: "Community Food Pantry",
+    })
+    expect(from).toHaveBeenCalledWith("resource_map_public_items")
+    expect(select).toHaveBeenCalledWith("*")
+    expect(eq).toHaveBeenCalledWith("item_id", itemId)
+    expect(maybeSingle).toHaveBeenCalledOnce()
+  })
+
+  it("rejects malformed production item IDs without querying the view", async () => {
+    await expect(
+      fetchPublicResourceMapItemById("resource_map:missing", {
+        enabled: true,
+        localEnginePreviewFile: null,
+        localPreviewFile: null,
+      })
+    ).resolves.toBeNull()
+
+    expect(createClientMock).not.toHaveBeenCalled()
   })
 
   it("loads more than 1,000 approved resources without truncation", async () => {


### PR DESCRIPTION
## Summary

- add a versioned public detail endpoint at `/api/public/resource-map/items/[id]`
- resolve one exact UUID from the existing anonymous sanitized view
- move the established full-item sanitizer into the Find feature and reuse it in both endpoints
- cache each sanitized detail for five minutes
- keep the `/find` client unchanged

## Connected evidence

- exact selected ID returned with status 200
- response size: 2,783 bytes
- cold application lookup: 1.2 seconds locally
- repeated request: 46 ms end to end, 9 ms application code
- malformed IDs avoid the database query
- missing IDs return 404
- no favicon, raw logo, mission, values, or vision fields

## Verification

- focused acceptance: 61/61
- production build: 109 routes
- required pre-push: 398 files and 2,053 tests passed; one file/test skipped

## Stack

Base is PR #144, which is green and review-ready. Merge #143, then #144, then retarget this PR to `main`. Review only the two S48 commits.

## Boundaries

- no migration, database write, UI, collection, or production change
- criterion 3 remains in progress until the client preserves selected and collected resources outside loaded pages

## Iteration note

A full raw-dataset cache exceeded Next.js's 2 MB entry limit during connected testing. It was never committed; per-item sanitized caching replaced it.

## Rollback

Revert the two S48 commits. Existing full and compact endpoints remain available.