### PR TITLE
[STEP S51] Preserve Find context through loading failures

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2807,3 +2807,14 @@
   available. No signup, account, database, or resource data was changed.
 - Marked Wave 3 criteria 1-3 complete at 8/35 durable criteria. Criterion 4,
   state recovery without losing map context, is next.
+
+2026-08-12 00:29 EDT - started Wave 3 Find state recovery.
+
+- Kept criterion 4 limited to the existing Find loading-state contract. Initial
+  loading now describes progressive resources instead of a monolithic full
+  directory, while existing search and category empty states remain intact.
+- Added explicit offline detection, preserved loaded resource items as visibly
+  labeled stale results, retained the map and directory shell, and automatically
+  revalidates after the browser reconnects. Manual retry remains available.
+- Focused client, sidebar, and route acceptance checks pass 51/51. No map,
+  resource, database, authentication, or collection behavior changed.

--- a/src/components/public/public-map-index/organization-list.tsx
+++ b/src/components/public/public-map-index/organization-list.tsx
@@ -22,7 +22,10 @@ import {
 } from "./organization-list-pagination"
 import { PUBLIC_MAP_SIDEBAR_CARD_CLASSNAME } from "./sidebar-theme"
 import type { PublicMapGroupFilterKey } from "./category-filter"
-import type { PublicMapResourceItemsLoadStatus } from "./use-resource-map-items"
+import {
+  PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR,
+  type PublicMapResourceItemsLoadStatus,
+} from "./use-resource-map-items"
 
 function buildPublicMapListItems({
   items,
@@ -42,9 +45,7 @@ function PublicMapOrganizationListSkeleton() {
       role="status"
       aria-live="polite"
     >
-      <p className="text-muted-foreground px-1 text-xs">
-        Loading the full resource directory…
-      </p>
+      <p className="text-muted-foreground px-1 text-xs">Loading resources…</p>
       <div className="grid w-full min-w-0 grid-cols-[repeat(auto-fill,minmax(min(100%,22rem),1fr))] gap-3">
         {Array.from({ length: 4 }, (_, index) => (
           <div
@@ -134,20 +135,25 @@ function PublicMapOrganizationListComponent({
     const hasSearchQuery = normalizedQuery.length > 0
     const hasCategoryFilter = activeGroup !== "all"
     const loadFailed = loadStatus === "error"
-    const title = loadFailed
-      ? "Resource directory unavailable"
-      : hasSearchQuery
-        ? `No matches for “${normalizedQuery}”`
-        : hasCategoryFilter
-          ? "No resources in this category"
-          : "No resources available"
-    const description = loadFailed
-      ? (loadError ?? "The full resource directory could not load.")
-      : hasSearchQuery
-        ? "Try a shorter term or clear the search to browse every resource."
-        : hasCategoryFilter
-          ? "Show all categories or choose another category."
-          : "Try loading the directory again."
+    const loadOffline = loadError === PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR
+    const title = loadOffline
+      ? "You’re offline"
+      : loadFailed
+        ? "Resource directory unavailable"
+        : hasSearchQuery
+          ? `No matches for “${normalizedQuery}”`
+          : hasCategoryFilter
+            ? "No resources in this category"
+            : "No resources available"
+    const description = loadOffline
+      ? "Connect to the internet, then try loading the directory again."
+      : loadFailed
+        ? (loadError ?? "The resource directory could not load.")
+        : hasSearchQuery
+          ? "Try a shorter term or clear the search to browse every resource."
+          : hasCategoryFilter
+            ? "Show all categories or choose another category."
+            : "Try loading the directory again."
     const action = loadFailed
       ? onRetryLoad
         ? { label: "Try again", onClick: onRetryLoad }

--- a/src/components/public/public-map-index/sidebar-panels.tsx
+++ b/src/components/public/public-map-index/sidebar-panels.tsx
@@ -15,7 +15,10 @@ import { PublicMapOrganizationList } from "./organization-list"
 import { PublicMapSearchCard } from "./search-card"
 import { PUBLIC_MAP_SIDEBAR_CARD_CLASSNAME } from "./sidebar-theme"
 import type { PublicMapListItem } from "./map-items-state"
-import type { PublicMapResourceItemsLoadStatus } from "./use-resource-map-items"
+import {
+  PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR,
+  type PublicMapResourceItemsLoadStatus,
+} from "./use-resource-map-items"
 
 export {
   PublicMapDrawerDetailPanel,
@@ -134,10 +137,12 @@ function PublicMapOrganizationsStack({
 }
 
 function PublicMapSearchResultsStatus({
+  hasStaleResourceItems,
   resourceItemsLoadStatus,
   resultCount,
   searchPending,
 }: {
+  hasStaleResourceItems: boolean
   resourceItemsLoadStatus: PublicMapResourceItemsLoadStatus
   resultCount: number
   searchPending: boolean
@@ -148,9 +153,11 @@ function PublicMapSearchResultsStatus({
     ? `${resultLabel} · Updating map…`
     : resourceItemsLoadStatus === "loading"
       ? resultCount > 0
-        ? `${formattedCount} available · Loading full directory…`
-        : "Loading full directory…"
-      : resultLabel
+        ? `${formattedCount} available · Loading more…`
+        : "Loading resources…"
+      : resourceItemsLoadStatus === "error" && hasStaleResourceItems
+        ? `${resultLabel} · Last loaded results`
+        : resultLabel
 
   return (
     <div
@@ -172,17 +179,24 @@ function PublicMapSearchResultsStatus({
 
 function PublicMapResourceItemsErrorNotice({
   error,
+  hasStaleResourceItems,
   onRetry,
 }: {
   error: string | null
+  hasStaleResourceItems: boolean
   onRetry: () => void
 }) {
   if (!error) return null
+  const message = hasStaleResourceItems
+    ? error === PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR
+      ? "You’re offline. Showing last loaded results."
+      : "Latest results are unavailable. Showing last loaded results."
+    : error
 
   return (
     <Alert className="border-destructive/30 bg-background/45 py-2.5">
       <AlertDescription className="col-start-1 flex w-full flex-row items-center justify-between gap-3">
-        <span className="text-pretty">{error}</span>
+        <span className="text-pretty">{message}</span>
         <Button
           type="button"
           variant="ghost"
@@ -266,6 +280,9 @@ export function PublicMapRailSearchPanel({
           className="shrink-0 pb-1.5"
         >
           <PublicMapSearchResultsStatus
+            hasStaleResourceItems={items.some(
+              (item) => item.itemType === "external_resource"
+            )}
             resourceItemsLoadStatus={resourceItemsLoadStatus}
             resultCount={items.length}
             searchPending={searchPending}
@@ -280,6 +297,9 @@ export function PublicMapRailSearchPanel({
           <div className="shrink-0 pb-2">
             <PublicMapResourceItemsErrorNotice
               error={resourceItemsLoadError}
+              hasStaleResourceItems={items.some(
+                (item) => item.itemType === "external_resource"
+              )}
               onRetry={onRetryResourceItems}
             />
           </div>
@@ -368,6 +388,9 @@ export function PublicMapDrawerSearchPanel({
       </div>
       <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden px-2")}>
         <PublicMapSearchResultsStatus
+          hasStaleResourceItems={items.some(
+            (item) => item.itemType === "external_resource"
+          )}
           resourceItemsLoadStatus={resourceItemsLoadStatus}
           resultCount={items.length}
           searchPending={searchPending}
@@ -381,6 +404,9 @@ export function PublicMapDrawerSearchPanel({
           <div className="shrink-0 pb-2">
             <PublicMapResourceItemsErrorNotice
               error={resourceItemsLoadError}
+              hasStaleResourceItems={items.some(
+                (item) => item.itemType === "external_resource"
+              )}
               onRetry={onRetryResourceItems}
             />
           </div>

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -8,6 +8,10 @@ import { warmPublicMapListItemSearchCache } from "./map-items-state"
 
 export const EMPTY_PUBLIC_MAP_RESOURCE_ITEMS: ExternalResourceMapItem[] = []
 export const PUBLIC_MAP_RESOURCE_ITEMS_REFRESH_INTERVAL_MS = 5 * 60 * 1000
+export const PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR =
+  "You’re offline. Connect to the internet and try again."
+export const PUBLIC_MAP_RESOURCE_ITEMS_UNAVAILABLE_ERROR =
+  "The resource directory could not load."
 export type PublicMapResourceItemsLoadStatus = "loading" | "ready" | "error"
 
 type ResourceItemsLoad = {
@@ -207,7 +211,11 @@ export function usePublicMapResourceItems({
       } catch (error) {
         if (cancelled) return
         setStatus("error")
-        setError("The full resource directory could not load.")
+        setError(
+          navigator.onLine === false
+            ? PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR
+            : PUBLIC_MAP_RESOURCE_ITEMS_UNAVAILABLE_ERROR
+        )
         console.warn("[public-map] resource items unavailable", {
           message: error instanceof Error ? error.message : String(error),
         })
@@ -217,19 +225,36 @@ export function usePublicMapResourceItems({
     void loadResourceItems()
     const refreshVisibleResourceItems = () => {
       if (document.visibilityState === "hidden") return
+      if (navigator.onLine === false) {
+        setStatus("error")
+        setError(PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR)
+        return
+      }
       void loadResourceItems()
+    }
+    const markResourceItemsOffline = () => {
+      setStatus("error")
+      setError(PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR)
+    }
+    const refreshResourceItemsOnline = () => {
+      clearPublicMapResourceItemsCache(endpoint)
+      setLoadRequestId((current) => current + 1)
     }
     const refreshInterval = window.setInterval(
       refreshVisibleResourceItems,
       PUBLIC_MAP_RESOURCE_ITEMS_REFRESH_INTERVAL_MS
     )
     window.addEventListener("focus", refreshVisibleResourceItems)
+    window.addEventListener("offline", markResourceItemsOffline)
+    window.addEventListener("online", refreshResourceItemsOnline)
     document.addEventListener("visibilitychange", refreshVisibleResourceItems)
 
     return () => {
       cancelled = true
       window.clearInterval(refreshInterval)
       window.removeEventListener("focus", refreshVisibleResourceItems)
+      window.removeEventListener("offline", markResourceItemsOffline)
+      window.removeEventListener("online", refreshResourceItemsOnline)
       document.removeEventListener(
         "visibilitychange",
         refreshVisibleResourceItems

--- a/tests/acceptance/public-find-route.test.ts
+++ b/tests/acceptance/public-find-route.test.ts
@@ -532,7 +532,7 @@ describe("public find routes", () => {
     expect(sidebarPanelsSource).toContain(
       'data-public-map-search-results-status="true"'
     )
-    expect(sidebarPanelsSource).toContain("Loading full directory…")
+    expect(sidebarPanelsSource).toContain("Loading resources…")
     expect(organizationListSource).toContain(
       'data-public-map-search-loading="true"'
     )

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -167,6 +167,8 @@ describe("public map resource items client", () => {
     )
 
     expect(source).toContain('window.addEventListener("focus"')
+    expect(source).toContain('window.addEventListener("offline"')
+    expect(source).toContain('window.addEventListener("online"')
     expect(source).toContain('document.addEventListener("visibilitychange"')
     expect(source).toContain("PUBLIC_MAP_RESOURCE_ITEMS_REFRESH_INTERVAL_MS")
     expect(source).not.toContain('cache: "force-cache"')

--- a/tests/acceptance/public-map-sidebar-layout.test.ts
+++ b/tests/acceptance/public-map-sidebar-layout.test.ts
@@ -16,6 +16,7 @@ import {
   PublicMapResourceDrawerDetailPanel,
 } from "@/components/public/public-map-index/sidebar-panels"
 import { resolvePublicMapResourceCategoryIcon } from "@/components/public/public-map-index/resource-category-icon"
+import { PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR } from "@/components/public/public-map-index/use-resource-map-items"
 import { resolveResourceIdentityTitle } from "@/components/public/public-map-index/resource-detail-primary-sections"
 import {
   filterPublicMapSavedOrganizations,
@@ -1726,15 +1727,52 @@ describe("public map sidebar layout", () => {
         loadError: "The full resource directory could not load.",
       })
     )
+    const offlineMarkup = renderToStaticMarkup(
+      React.createElement(PublicMapOrganizationList, {
+        ...baseProps,
+        query: "",
+        loadStatus: "error",
+        loadError: PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR,
+      })
+    )
 
     expect(loadingMarkup).toContain('data-public-map-search-loading="true"')
-    expect(loadingMarkup).toContain("Loading the full resource directory")
+    expect(loadingMarkup).toContain("Loading resources")
     expect(loadingMarkup.match(/data-slot="skeleton"/g)).toHaveLength(16)
     expect(emptyMarkup).toContain('data-public-map-search-empty="true"')
     expect(emptyMarkup).toContain("No matches for")
     expect(emptyMarkup).toContain("Clear search")
     expect(errorMarkup).toContain("Resource directory unavailable")
     expect(errorMarkup).toContain("Try again")
+    expect(offlineMarkup).toContain("You’re offline")
+    expect(offlineMarkup).toContain("Connect to the internet")
+  })
+
+  it("keeps stale results visible through offline recovery", () => {
+    const resource = buildResourceItem()
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicMapDrawerSearchPanel, {
+        query: "",
+        items: [resource],
+        organizations: [],
+        selectedItemId: null,
+        selectedOrgId: null,
+        activeGroup: "all",
+        groupCounts: buildPublicMapGroupFilterCounts([resource]),
+        resourceItemsLoadStatus: "error",
+        resourceItemsLoadError: PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR,
+        onQueryChange: () => {},
+        onActiveGroupChange: () => {},
+        onSelectItem: () => {},
+        onOpenDetails: () => {},
+        onRetryResourceItems: () => {},
+      })
+    )
+
+    expect(markup).toContain("Last loaded results")
+    expect(markup).toContain("Showing last loaded results")
+    expect(markup).toContain(resource.title)
+    expect(markup).toContain("Try again")
   })
 
   it("hides raw data API endpoints from public resource detail links", () => {


### PR DESCRIPTION
## Summary
- distinguish progressive loading, empty, unavailable, offline, and stale states
- preserve loaded results and map context through failures
- automatically revalidate on reconnect while retaining manual retry

## Verification
- focused Find acceptance: 51/51
- pre-push: 2,059 passed, 1 skipped

PRD scope: `wave-3-criterion-4` only.