### PR TITLE
[STEP S54] Enforce Find release performance budgets

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2846,3 +2846,19 @@
   Browser checks displayed `/home` and `/legacy-home` with Fraunces, Sora, and
   Inter loaded in their intended roles. No signup, data, migration, or
   production change occurred; Wave 3 criterion 5 remains next.
+
+2026-08-12 03:32 EDT - started Wave 3 Find performance budgets.
+
+- Replaced the anonymous Find route's generic home preview with a dedicated
+  shell that preserves the visible header, navigation, map frame, and rails
+  without preloading hidden home, pricing, and authentication panels.
+- Reduced compact index pages from 200 to the established 50-item maximum and
+  batches intermediate client updates every 200 records while publishing the
+  first page immediately. The account sheet now loads only when opened.
+- Reduced `/find` first-load JavaScript from 2,085.6KB to 1,852.6KB, an 8.6%
+  improvement, and added a 1,900KB route budget to `check:perf`. The production
+  build, focused 28-test suite, targeted lint, and all route budgets pass.
+- Displayed the local production build in the browser without opening signup.
+  Its shell and search controls render correctly; this isolated worktree lacks
+  the public Mapbox token, so connected map, LCP, and interaction proof remain
+  for the hosted preview and production before criterion 5 can be completed.

--- a/scripts/check-route-entry-contract.mjs
+++ b/scripts/check-route-entry-contract.mjs
@@ -17,9 +17,9 @@ const ROUTE_IMPORT_CONTRACTS = new Map([
   [
     "src/app/(public)/find/page.tsx",
     {
-      requireImports: ["@/components/public/home-canvas-preview"],
+      requireImports: ["@/components/public/home-canvas-find-shell"],
       forbidImports: ["@/components/public/public-header"],
-      requireSourcePatterns: [/<HomeCanvasPreview\b/u],
+      requireSourcePatterns: [/<HomeCanvasFindShell\b/u],
     },
   ],
 ])

--- a/scripts/performance-route-budgets.mjs
+++ b/scripts/performance-route-budgets.mjs
@@ -6,6 +6,12 @@ export const performanceRouteBudgets = [
     maxFirstLoadKB: 1600,
   },
   {
+    routeKey: "/(public)/find/page",
+    urlLabel: "/find",
+    shell: "public find",
+    maxFirstLoadKB: 1900,
+  },
+  {
     routeKey: "/(community)/community/page",
     urlLabel: "/community",
     shell: "community",

--- a/src/app/(public)/find/[slug]/page.tsx
+++ b/src/app/(public)/find/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
-import { HomeCanvasPreview } from "@/components/public/home-canvas-preview"
-import { PricingSurface } from "@/components/public/pricing-surface"
+import { HomeCanvasFindShell } from "@/components/public/home-canvas-find-shell"
 import { PublicMapIndex } from "@/components/public/public-map-index"
 import { readAppSidebarDefaultOpen } from "@/components/app-shell/sidebar-state-server"
 import {
@@ -16,7 +15,7 @@ import { resolveDashboardLayoutState } from "@/app/(dashboard)/_lib/dashboard-la
 import { completeMemberMapOnboardingAction } from "@/app/(dashboard)/onboarding/actions"
 
 const PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT =
-  "/api/public/resource-map/index?limit=200"
+  "/api/public/resource-map/index?limit=50"
 
 export const revalidate = 300
 
@@ -205,20 +204,16 @@ export default async function PublicFindOrganizationPage({
   }
 
   return (
-    <HomeCanvasPreview
-      initialSection="find"
-      pricingPanel={<PricingSurface embedded />}
-      findPanel={
-        <div className="relative h-full">
-          <PublicMapIndex
-            organizations={organizations}
-            resourceItemsEndpoint={PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT}
-            mapboxToken={publicToken}
-            initialPublicSlug={matched.publicSlug}
-            viewer={viewerState.viewer}
-          />
-        </div>
-      }
-    />
+    <HomeCanvasFindShell>
+      <div className="relative h-full">
+        <PublicMapIndex
+          organizations={organizations}
+          resourceItemsEndpoint={PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT}
+          mapboxToken={publicToken}
+          initialPublicSlug={matched.publicSlug}
+          viewer={viewerState.viewer}
+        />
+      </div>
+    </HomeCanvasFindShell>
   )
 }

--- a/src/app/(public)/find/loading.tsx
+++ b/src/app/(public)/find/loading.tsx
@@ -1,6 +1,6 @@
 import LoaderCircleIcon from "lucide-react/dist/esm/icons/loader-circle"
 
-import { HomeCanvasPreview } from "@/components/public/home-canvas-preview"
+import { HomeCanvasFindShell } from "@/components/public/home-canvas-find-shell"
 import { Skeleton } from "@/components/ui/skeleton"
 
 function FindRouteLoadingPanel() {
@@ -50,5 +50,9 @@ function FindRouteLoadingPanel() {
 }
 
 export default function PublicFindLoading() {
-  return <HomeCanvasPreview initialSection="find" findPanel={<FindRouteLoadingPanel />} />
+  return (
+    <HomeCanvasFindShell>
+      <FindRouteLoadingPanel />
+    </HomeCanvasFindShell>
+  )
 }

--- a/src/app/(public)/find/page.tsx
+++ b/src/app/(public)/find/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 
-import { HomeCanvasPreview } from "@/components/public/home-canvas-preview"
-import { PricingSurface } from "@/components/public/pricing-surface"
+import { HomeCanvasFindShell } from "@/components/public/home-canvas-find-shell"
 import { PublicMapIndex } from "@/components/public/public-map-index"
 import { readAppSidebarDefaultOpen } from "@/components/app-shell/sidebar-state-server"
 import {
@@ -15,7 +14,7 @@ import { resolveDashboardLayoutState } from "@/app/(dashboard)/_lib/dashboard-la
 import { completeMemberMapOnboardingAction } from "@/app/(dashboard)/onboarding/actions"
 
 const PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT =
-  "/api/public/resource-map/index?limit=200"
+  "/api/public/resource-map/index?limit=50"
 
 export const metadata: Metadata = {
   title: "Find organizations",
@@ -102,19 +101,15 @@ export default async function PublicFindPage() {
   }
 
   return (
-    <HomeCanvasPreview
-      initialSection="find"
-      pricingPanel={<PricingSurface embedded />}
-      findPanel={
-        <div className="relative h-full">
-          <PublicMapIndex
-            organizations={organizations}
-            resourceItemsEndpoint={PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT}
-            mapboxToken={publicToken}
-            viewer={viewerState.viewer}
-          />
-        </div>
-      }
-    />
+    <HomeCanvasFindShell>
+      <div className="relative h-full">
+        <PublicMapIndex
+          organizations={organizations}
+          resourceItemsEndpoint={PUBLIC_RESOURCE_MAP_ITEMS_ENDPOINT}
+          mapboxToken={publicToken}
+          viewer={viewerState.viewer}
+        />
+      </div>
+    </HomeCanvasFindShell>
   )
 }

--- a/src/components/public/home-canvas-find-shell.tsx
+++ b/src/components/public/home-canvas-find-shell.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { type CSSProperties, type ReactNode } from "react"
+
+import { ShellRightRail } from "@/components/app-shell/components/shell-right-rail"
+import {
+  RightRailProvider,
+  useRightRailPresence,
+} from "@/components/app-shell/right-rail"
+import { useAppShellRightRailState } from "@/components/app-shell/use-app-shell-right-rail-state"
+import { HomeCanvasPreviewHeader } from "@/components/public/home-canvas-preview-shell"
+import { HomeCanvasPreviewSidebar } from "@/components/public/home-canvas-preview-sidebar"
+import {
+  HomeCanvasSidebarSlotProvider,
+  useHomeCanvasSidebarContent,
+  useHomeCanvasSidebarPresence,
+} from "@/components/public/home-canvas-sidebar-slot"
+import type { CanvasSectionId } from "@/components/public/home-canvas-preview-config"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+export function HomeCanvasFindShell({ children }: { children: ReactNode }) {
+  return (
+    <RightRailProvider>
+      <HomeCanvasSidebarSlotProvider>
+        <HomeCanvasFindShellContent>{children}</HomeCanvasFindShellContent>
+      </HomeCanvasSidebarSlotProvider>
+    </RightRailProvider>
+  )
+}
+
+function HomeCanvasFindShellContent({ children }: { children: ReactNode }) {
+  const router = useRouter()
+  const hasRightRail = useRightRailPresence()
+  const hasSidebarSlot = useHomeCanvasSidebarPresence()
+  const sidebarSlotContent = useHomeCanvasSidebarContent()
+  const isMobile = useIsMobile()
+  const { rightOpen, handleRightOpenChangeUser, handleRightOpenChangeAuto } =
+    useAppShellRightRailState({ hasRightRail, isMobile })
+
+  function navigateToSection(section: CanvasSectionId) {
+    router.push(`/?section=${section}`)
+  }
+
+  return (
+    <SidebarProvider
+      defaultOpen
+      data-shell-root
+      style={
+        {
+          "--sidebar-width": "23rem",
+        } as CSSProperties
+      }
+      className="text-foreground h-svh min-h-0 overflow-hidden bg-[var(--shell-bg)] [--shell-bg:var(--background)] [--shell-border:var(--border)] [--shell-rail:var(--background)] [--sidebar-border:var(--border)] [--sidebar-foreground:var(--foreground)] [--sidebar:var(--background)] [--shell-content-pad:1rem] [--shell-rail-gap:1rem] [--shell-rail-item-gap:0.5rem] [--shell-rail-item-padding:0.5rem] [--shell-rail-padding:0.75rem] [--shell-right-rail-width:20rem] sm:[--shell-content-pad:1.25rem]"
+    >
+      <div className="flex min-h-0 flex-1">
+        {hasSidebarSlot ? (
+          <HomeCanvasPreviewSidebar
+            showFindSidebarShell
+            sidebarSlotContent={sidebarSlotContent}
+          />
+        ) : null}
+
+        <div className="flex min-h-0 flex-1">
+          <SidebarInset className="h-full min-h-0 overflow-hidden bg-[var(--shell-bg)]">
+            <HomeCanvasPreviewHeader
+              activeSection="find"
+              changeSection={navigateToSection}
+              onRightOpenChange={handleRightOpenChangeUser}
+              railToggleClassName="text-muted-foreground size-10 rounded-md border border-[color:var(--shell-border)] hover:bg-foreground/5 hover:text-foreground md:size-8"
+              rightOpen={rightOpen}
+              showShellSidebar={hasSidebarSlot}
+              showRightRailToggle={hasRightRail}
+            />
+
+            <div className="flex min-h-0 flex-1 p-[var(--shell-content-pad)] md:pt-0 md:pr-[var(--shell-content-pad)] md:pb-[var(--shell-content-pad)] md:pl-0">
+              <div className="relative flex min-h-0 w-full flex-1 overflow-hidden rounded-[28px] border border-[color:var(--shell-border)] bg-[var(--shell-bg)]">
+                <div className="absolute inset-0 overflow-hidden overscroll-contain">
+                  {children}
+                </div>
+              </div>
+            </div>
+          </SidebarInset>
+          <ShellRightRail
+            open={rightOpen}
+            onOpenChange={handleRightOpenChangeUser}
+            onAutoClose={handleRightOpenChangeAuto}
+          />
+        </div>
+      </div>
+    </SidebarProvider>
+  )
+}

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import dynamic from "next/dynamic"
 import {
   useEffect,
   useLayoutEffect,
@@ -14,7 +15,6 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { cn } from "@/lib/utils"
 
 import type { SidebarMode } from "./constants"
-import { PublicMapAuthSheet } from "./auth-sheet"
 import { resolvePublicMapSurfacePanelState } from "./map-surface-helpers"
 import {
   PublicMapLocationControl,
@@ -35,6 +35,10 @@ import type {
 } from "./category-filter"
 import { PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME } from "./sidebar-theme"
 import type { PublicMapResourceItemsLoadStatus } from "./use-resource-map-items"
+
+const PublicMapAuthSheet = dynamic(() =>
+  import("./auth-sheet").then((module) => module.PublicMapAuthSheet)
+)
 
 type PublicMapSurfaceProps = {
   containerRef: RefObject<HTMLDivElement | null>
@@ -293,11 +297,13 @@ export function PublicMapSurface({
         </div>
       ) : null}
 
-      <PublicMapAuthSheet
-        open={authSheetOpen}
-        onOpenChange={onAuthSheetOpenChange}
-        redirectTo={authRedirectTo}
-      />
+      {authSheetOpen ? (
+        <PublicMapAuthSheet
+          open
+          onOpenChange={onAuthSheetOpenChange}
+          redirectTo={authRedirectTo}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -20,6 +20,7 @@ type ResourceItemsLoad = {
 }
 
 const resourceItemsLoadByEndpoint = new Map<string, ResourceItemsLoad>()
+const RESOURCE_ITEMS_PROGRESS_BATCH_SIZE = 200
 
 type FindResourceIndexPage = {
   hasMore?: unknown
@@ -138,7 +139,6 @@ export function loadPublicMapResourceItems(
         resourceItems.push(
           ...payload.resourceItems.map(normalizeLoadedResourceItem)
         )
-        for (const listener of listeners) listener([...resourceItems])
       }
 
       const nextCursor = payload.page?.nextCursor
@@ -149,6 +149,14 @@ export function loadPublicMapResourceItems(
       pageCount += 1
       if (pageCount > 100) {
         throw new Error("Resource map items exceeded the page limit")
+      }
+
+      const shouldPublishProgress =
+        pageCount === 1 ||
+        pageEndpoint === null ||
+        resourceItems.length % RESOURCE_ITEMS_PROGRESS_BATCH_SIZE === 0
+      if (shouldPublishProgress) {
+        for (const listener of listeners) listener([...resourceItems])
       }
     }
 

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8")
+}
+
+describe("public Find performance contract", () => {
+  it("uses 50-item compact pages without pre-rendering the pricing surface", () => {
+    for (const route of [
+      "src/app/(public)/find/page.tsx",
+      "src/app/(public)/find/[slug]/page.tsx",
+    ]) {
+      const source = readSource(route)
+
+      expect(source).toContain("/api/public/resource-map/index?limit=50")
+      expect(source).not.toContain("PricingSurface")
+      expect(source).not.toContain("pricingPanel=")
+    }
+  })
+
+  it("uses a dedicated shell that excludes hidden home and authentication panels", () => {
+    const source = readSource("src/components/public/home-canvas-find-shell.tsx")
+
+    expect(source).toContain("HomeCanvasPreviewHeader")
+    expect(source).toContain("HomeCanvasPreviewSidebar")
+    expect(source).not.toContain("CanvasAuthPanel")
+    expect(source).not.toContain("HomeSectionPanel")
+    expect(source).not.toContain("PricingSurface")
+  })
+
+  it("loads the account sheet only after the user opens it", () => {
+    const source = readSource(
+      "src/components/public/public-map-index/map-surface.tsx"
+    )
+
+    expect(source).toContain('dynamic(() =>\n  import("./auth-sheet")')
+    expect(source).toContain("{authSheetOpen ? (")
+    expect(source).not.toContain(
+      'import { PublicMapAuthSheet } from "./auth-sheet"'
+    )
+  })
+
+  it("enforces a dedicated first-load JavaScript budget for Find", () => {
+    const source = readSource("scripts/performance-route-budgets.mjs")
+
+    expect(source).toContain('routeKey: "/(public)/find/page"')
+    expect(source).toContain('urlLabel: "/find"')
+    expect(source).toContain('shell: "public find"')
+  })
+})

--- a/tests/acceptance/public-find-route.test.ts
+++ b/tests/acceptance/public-find-route.test.ts
@@ -191,7 +191,7 @@ describe("public find routes", () => {
   it("preserves selected organization detail wiring on slug routes", () => {
     const source = readRoute("src/app/(public)/find/[slug]/page.tsx")
     const authenticatedBranchIndex = source.indexOf("<AuthenticatedFindShell")
-    const publicBranchIndex = source.indexOf("<HomeCanvasPreview")
+    const publicBranchIndex = source.indexOf("<HomeCanvasFindShell")
     const firstInitialSlugIndex = source.indexOf(
       "initialPublicSlug={matched.publicSlug}"
     )

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
+  clearPublicMapResourceItemsCache,
   loadPublicMapResourceItems,
   mergeProgressiveResourceItems,
 } from "@/components/public/public-map-index/use-resource-map-items"
@@ -23,6 +24,7 @@ function buildResourceItemsResponse(resourceItems: unknown[]) {
 
 describe("public map resource items client", () => {
   afterEach(() => {
+    clearPublicMapResourceItemsCache()
     vi.restoreAllMocks()
   })
 
@@ -97,7 +99,7 @@ describe("public map resource items client", () => {
 
     const progressCounts: number[] = []
     const items = await loadPublicMapResourceItems(
-      "/api/public/resource-map/index?limit=200",
+      "/api/public/resource-map/index?limit=50",
       (loadedItems) => progressCounts.push(loadedItems.length)
     )
 
@@ -112,12 +114,36 @@ describe("public map resource items client", () => {
     })
     expect(fetchSpy).toHaveBeenNthCalledWith(
       2,
-      `/api/public/resource-map/index?limit=200&cursor=${encodeURIComponent(compactItem.id)}`,
+      `/api/public/resource-map/index?limit=50&cursor=${encodeURIComponent(compactItem.id)}`,
       {
         cache: "no-store",
         headers: { Accept: "application/json" },
       }
     )
+  })
+
+  it("publishes the first compact page immediately and batches later progress", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+    for (let index = 1; index <= 5; index += 1) {
+      fetchSpy.mockResolvedValueOnce(
+        buildJsonResponse({
+          resourceItems: [{ id: `resource_map:${index}` }],
+          page: {
+            hasMore: index < 5,
+            nextCursor: index < 5 ? `resource_map:${index}` : null,
+          },
+        })
+      )
+    }
+
+    const progressCounts: number[] = []
+    const items = await loadPublicMapResourceItems(
+      "/api/public/resource-map/index?limit=50&test=batched-progress",
+      (loadedItems) => progressCounts.push(loadedItems.length)
+    )
+
+    expect(items).toHaveLength(5)
+    expect(progressCounts).toEqual([1, 5])
   })
 
   it("deduplicates selected resource detail loads", async () => {


### PR DESCRIPTION
## Summary
- replace the anonymous Find route generic preview with a dedicated shell
- load compact index pages at 50 items and batch intermediate updates
- defer the account sheet until requested
- reduce first-load JavaScript from 2085.6KB to 1852.6KB and enforce a 1900KB route budget

## Verification
- pnpm build
- pnpm check:perf
- 35 focused acceptance tests
- pre-push: 400 files passed, 2066 tests passed, 1 intentional skip
- local browser production-build check

## Hosted gate
Preview Mapbox/data, LCP, first-useful render, and interaction measurements remain required before merge.