### PR TITLE
[STEP S55] Paint Find consent before Mapbox startup

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2862,3 +2862,21 @@
   Its shell and search controls render correctly; this isolated worktree lacks
   the public Mapbox token, so connected map, LCP, and interaction proof remain
   for the hosted preview and production before criterion 5 can be completed.
+
+2026-08-12 04:08 EDT - deployed Find budgets and isolated the LCP blocker.
+
+- Reviewed and sole-maintainer merged PR #151 after 2,066 pre-push tests,
+  hosted quality, and both Vercel previews passed. Main CI and both production
+  deployments for commit `77862637` passed.
+- Production `/find` HTML measured 137,592 bytes raw and 37,171 bytes
+  compressed. Its 50-item index page measured 24,964 bytes raw and about 3,970
+  bytes compressed; four warm samples completed in 185-249 ms.
+- Browser production proof displayed the loaded Mapbox surface with all 871
+  combined results. No signup, location permission, account, or data mutation
+  occurred.
+- A representative mobile Lighthouse run with software WebGL measured FCP at
+  1.46 s but LCP at 37.26 s. The LCP element is the existing location consent
+  card, which currently loses its first paint to synchronous Mapbox startup.
+- Started a narrow follow-up that lets the initial shell and location consent
+  state paint before Mapbox initialization. Wave 3 criterion 5 remains active
+  until the preview and production LCP reruns pass.

--- a/src/components/public/public-map-index/public-map-index-runtime.ts
+++ b/src/components/public/public-map-index/public-map-index-runtime.ts
@@ -332,10 +332,19 @@ export function useInitializePublicMap({
       }
     }
 
-    void initializeMap()
+    let initializeTimeoutId: number | null = null
+    const initializeFrameId = window.requestAnimationFrame(() => {
+      initializeTimeoutId = window.setTimeout(() => {
+        void initializeMap()
+      }, 0)
+    })
 
     return () => {
       cancelled = true
+      window.cancelAnimationFrame(initializeFrameId)
+      if (initializeTimeoutId !== null) {
+        window.clearTimeout(initializeTimeoutId)
+      }
       if (mapRef.current) {
         mapRef.current.remove()
         mapRef.current = null

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -43,6 +43,19 @@ describe("public Find performance contract", () => {
     )
   })
 
+  it("lets the initial shell paint before starting Mapbox", () => {
+    const source = readSource(
+      "src/components/public/public-map-index/public-map-index-runtime.ts"
+    )
+
+    expect(source).toContain(
+      "const initializeFrameId = window.requestAnimationFrame"
+    )
+    expect(source).toContain("initializeTimeoutId = window.setTimeout")
+    expect(source).toContain("window.cancelAnimationFrame(initializeFrameId)")
+    expect(source).toContain("window.clearTimeout(initializeTimeoutId)")
+  })
+
   it("enforces a dedicated first-load JavaScript budget for Find", () => {
     const source = readSource("scripts/performance-route-budgets.mjs")
 


### PR DESCRIPTION
## Summary
- yield one browser paint before Mapbox initialization
- let the existing location consent state render with the initial shell
- preserve map behavior and cancel scheduled startup on unmount

## Evidence
- production FCP: 1.46s
- production LCP before this change: 37.26s
- measured LCP element: existing location consent card
- focused checks: 22 tests passed
- pre-push: 400 files passed, 2067 tests passed, 1 intentional skip

## Hosted gate
Rerun the same mobile Lighthouse WebGL profile in preview before merge.