### PR TITLE
[STEP S56] Reserve Find initial paint window

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2880,3 +2880,14 @@
 - Started a narrow follow-up that lets the initial shell and location consent
   state paint before Mapbox initialization. Wave 3 criterion 5 remains active
   until the preview and production LCP reruns pass.
+
+2026-08-12 04:24 EDT - tightened the Find initial-paint boundary.
+
+- PR #152 passed 2,067 pre-push tests, hosted quality, both previews, and both
+  production deployments before its mobile WebGL Lighthouse rerun.
+- Yielding one paint reduced production LCP from 37.26 s to 13.52 s, while FCP
+  remained 1.52 s. The existing location consent card remained the LCP element,
+  proving Mapbox startup still began before React received a reliable paint.
+- Started a final narrow follow-up that reserves one second for the initial
+  shell and consent state before Mapbox startup. Map behavior and permission
+  behavior are unchanged; criterion 5 remains active pending hosted reruns.

--- a/src/components/public/public-map-index/public-map-index-runtime.ts
+++ b/src/components/public/public-map-index/public-map-index-runtime.ts
@@ -27,6 +27,8 @@ import {
 export type PublicMapMapboxApi = (typeof import("mapbox-gl"))["default"]
 export { isRecoverablePublicMapTileError } from "./public-map-runtime-errors"
 
+const PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 1_000
+
 function applyPublicMapGlobePresentation(map: mapboxgl.Map) {
   map.setProjection("globe")
   applyPublicMapSpaceFog(map)
@@ -336,7 +338,7 @@ export function useInitializePublicMap({
     const initializeFrameId = window.requestAnimationFrame(() => {
       initializeTimeoutId = window.setTimeout(() => {
         void initializeMap()
-      }, 0)
+      }, PUBLIC_MAP_INITIAL_PAINT_DELAY_MS)
     })
 
     return () => {

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -51,6 +51,7 @@ describe("public Find performance contract", () => {
     expect(source).toContain(
       "const initializeFrameId = window.requestAnimationFrame"
     )
+    expect(source).toContain("PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 1_000")
     expect(source).toContain("initializeTimeoutId = window.setTimeout")
     expect(source).toContain("window.cancelAnimationFrame(initializeFrameId)")
     expect(source).toContain("window.clearTimeout(initializeTimeoutId)")


### PR DESCRIPTION
## Summary
- reserve one second for the Find shell and existing consent state to paint
- start Mapbox immediately after that bounded window
- preserve map and geolocation behavior

## Evidence
- production LCP improved from 37.26s to 13.52s after S55 but remained blocked by Mapbox startup
- focused checks: 22 tests passed
- pre-push: 400 files passed, 2067 tests passed, 1 intentional skip

## Hosted gate
Rerun the same mobile WebGL Lighthouse profile in preview before merge.