### PR TITLE
[STEP S57] Render Find consent with initial shell

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2891,3 +2891,14 @@
 - Started a final narrow follow-up that reserves one second for the initial
   shell and consent state before Mapbox startup. Map behavior and permission
   behavior are unchanged; criterion 5 remains active pending hosted reruns.
+
+2026-08-12 04:42 EDT - moved intended Find consent into the initial render.
+
+- PR #153 passed 2,067 pre-push tests, hosted quality, both previews, and both
+  production deployments. Its mobile WebGL Lighthouse rerun measured FCP at
+  1.51 s and LCP at 13.77 s; the existing location consent card remained the
+  late LCP candidate.
+- Preserved the existing automatic consent-card contract while moving its open
+  state into the initial render. Browser geolocation still requires the same
+  explicit action and no location, account, or production data was changed.
+- Wave 3 criterion 5 remains active pending the hosted numeric rerun.

--- a/src/components/public/public-map-index/use-public-map-user-location.ts
+++ b/src/components/public/public-map-index/use-public-map-user-location.ts
@@ -127,7 +127,9 @@ export function usePublicMapUserLocation({
   const [coordinates, setCoordinates] =
     useState<PublicMapUserCoordinates | null>(null)
   const [hasGrantedLocation, setHasGrantedLocation] = useState(false)
-  const [controlOpen, setControlOpen] = useState(false)
+  const [controlOpen, setControlOpen] = useState(
+    !suppressAutomaticEntrance && !welcomeOpen
+  )
   const entranceStartedRef = useRef(false)
   const requestSequenceRef = useRef(0)
   const userMovedMapRef = useRef(false)

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -57,6 +57,14 @@ describe("public Find performance contract", () => {
     expect(source).toContain("window.clearTimeout(initializeTimeoutId)")
   })
 
+  it("renders the intended location consent state in the initial shell", () => {
+    const source = readSource(
+      "src/components/public/public-map-index/use-public-map-user-location.ts"
+    )
+
+    expect(source).toContain("!suppressAutomaticEntrance && !welcomeOpen")
+  })
+
   it("enforces a dedicated first-load JavaScript budget for Find", () => {
     const source = readSource("scripts/performance-route-budgets.mjs")
 

--- a/tests/acceptance/public-map-user-location.test.ts
+++ b/tests/acceptance/public-map-user-location.test.ts
@@ -111,7 +111,9 @@ describe("public map user location", () => {
     )
 
     expect(FALLBACK_ZOOM).toBe(1.5)
-    expect(hookSource).toContain("useState(false)")
+    expect(hookSource).toContain(
+      "!suppressAutomaticEntrance && !welcomeOpen"
+    )
     expect(hookSource).toContain("setControlOpen(!storedGrant)")
     expect(hookSource).toContain(
       "PUBLIC_MAP_GLOBE_SECONDS_PER_REVOLUTION = 180"


### PR DESCRIPTION
## Summary
- preserve the existing automatic location-consent card
- render its intended open state with the initial shell instead of after hydration
- retain explicit browser permission, session grant, and map behavior

## Evidence
- production FCP: 1.51s
- production LCP before this change: 13.77s
- measured LCP element: existing location consent card
- focused checks: 33 tests passed
- pre-push: 400 files passed, 2068 tests passed, 1 intentional skip

## Hosted gate
Both preview deployment and the production mobile WebGL Lighthouse rerun remain required.