### PR TITLE
[STEP S58] Start Find map after initial content paint

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -2902,3 +2902,14 @@
   state into the initial render. Browser geolocation still requires the same
   explicit action and no location, account, or production data was changed.
 - Wave 3 criterion 5 remains active pending the hosted numeric rerun.
+
+2026-08-12 05:12 EDT - isolated the final Find render blocker.
+
+- PR #154 passed 2,068 pre-push tests, hosted quality, both previews, and both
+  production deployments. Rendering consent with the initial shell reduced
+  production mobile WebGL LCP from 13.77 s to 4.76 s.
+- The trace measured FCP at 1.53 s and 2.44 s of LCP element render delay.
+  Mapbox still began at 1 s, before first paint, and then occupied the throttled
+  main thread. Increased the bounded map-start delay to 2.5 s so the usable
+  search shell and consent card paint before Mapbox startup.
+- Criterion 5 remains active pending the final hosted rerun.

--- a/src/components/public/public-map-index/public-map-index-runtime.ts
+++ b/src/components/public/public-map-index/public-map-index-runtime.ts
@@ -27,7 +27,7 @@ import {
 export type PublicMapMapboxApi = (typeof import("mapbox-gl"))["default"]
 export { isRecoverablePublicMapTileError } from "./public-map-runtime-errors"
 
-const PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 1_000
+const PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 2_500
 
 function applyPublicMapGlobePresentation(map: mapboxgl.Map) {
   map.setProjection("globe")

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -51,7 +51,7 @@ describe("public Find performance contract", () => {
     expect(source).toContain(
       "const initializeFrameId = window.requestAnimationFrame"
     )
-    expect(source).toContain("PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 1_000")
+    expect(source).toContain("PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 2_500")
     expect(source).toContain("initializeTimeoutId = window.setTimeout")
     expect(source).toContain("window.cancelAnimationFrame(initializeFrameId)")
     expect(source).toContain("window.clearTimeout(initializeTimeoutId)")


### PR DESCRIPTION
## Summary
- move bounded Mapbox startup from 1.0s to 2.5s
- preserve immediate search shell and location consent render
- keep map and permission behavior unchanged

## Evidence
- production FCP: 1.53s
- production LCP before this change: 4.76s
- measured LCP render delay: 2.44s because Mapbox began before FCP
- focused checks: 23 tests passed
- pre-push: 400 files passed, 2068 tests passed, 1 intentional skip

## Hosted gate
Preview deployment and final production mobile WebGL Lighthouse rerun remain required.