### PR TITLE
[STEP S61] feat(find): add guest My Map collections

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -125,7 +125,7 @@ wave, but unrelated scope does not accumulate in one PR.
 | 1. Live stability and existing work close | Production verified  | Verify the existing Builder, Workspace, Documents, Finance, organization, role, deep-link, light-mode, mobile, stale-data, and error paths; fix only real gaps | Free/paid/member/coach/admin browser proof; refresh and cross-account isolation; no data loss, console errors, contrast failures, or broken routes | Disable or revert the narrow failed surface; preserve all stored data                      |
 | 2. Signup, recovery, and legal            | Active               | Direct and contextual signup, verification, login, recovery, Terms, Privacy, required acceptance, and safe return intent                                       | Every signup surface works; consent version/hash/UTC is stored; denial and retry work; legal text is approved                                      | Disable new signup while preserving accounts and consent evidence                          |
 | 3. `/find` speed and loading              | Active               | Compact index, bounded or paginated loading, detail on demand, stable cached refresh, current loading UI, empty/error/retry states, and collected-item lookup  | Fast first useful render; payload/LCP/TTI budgets; complete results; offline/stale/retry proof                                                     | Restore the prior compatible endpoint; retain published records                            |
-| 4. Collect / My Map completion            | Queued, partly built | Reuse the existing saved-organization foundation; rename the experience, collect/uncollect nonprofits and resources, show them in My Map, and persist them     | Visitors can collect locally; signed-in accounts persist across devices; Builders have the same My Map; no lists, notes, tags, ordering, or import | Disable new resource collection writes; preserve existing saved organizations              |
+| 4. Collect / My Map completion            | Active               | Reuse the existing saved-organization foundation; rename the experience, collect/uncollect nonprofits and resources, show them in My Map, and persist them     | Visitors can collect locally; signed-in accounts persist across devices; Builders have the same My Map; no lists, notes, tags, ordering, or import | Disable new resource collection writes; preserve existing saved organizations              |
 | 5. Finance reporting completion           | Queued, partly built | Read-only external activity connection, simple graph, activity list, History, source/freshness labels, CSV/PDF export, and board sharing                       | Connected/loading/empty/stale/error states; graph has a text equivalent; reports reconcile; sharing is explicit and revocable                      | Disable sync or reporting entry points; retain read-only records and existing CSV fallback |
 | 6. Qualified resources and varied guides  | Queued               | Promote verified cohorts toward 5,000+ useful records, then publish category- and location-varied guides after `/find` is stable                               | Exact complete/verified/publishable/promoted/public parity; cohort canary; relevant current guides and working links                               | Unpublish a cohort or guide without deleting evidence                                      |
 | 7. Integrated production release          | Queued               | Security review, support runbook, monitoring, rollback rehearsal, production smoke checks, and gradual rollout                                                 | Full quality gate; connected RLS where changed; hosted previews; production browser proof; clean monitoring                                        | Wave-specific flags and forward repair; never use a destructive data rollback              |
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **11/35 complete (31%)**, **3 in progress**, and
-**21 not started**.
+revision. Current progress: **11/35 complete (31%)**, **4 in progress**, and
+**20 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -163,7 +163,7 @@ revision. Current progress: **11/35 complete (31%)**, **3 in progress**, and
 
 **Wave 4 — Collect and My Map completion**
 
-- [ ] `wave-4-criterion-1` **Not started:** Let visitors collect and remove nonprofits and resources locally.
+- [ ] `wave-4-criterion-1` **In progress:** Let visitors collect and remove nonprofits and resources locally — Evidence: isolated local My Map implementation passes focused lint, 49 focused tests, full acceptance, RLS, build, visual, and performance gates; merge, deployment, and production smoke remain.
 - [ ] `wave-4-criterion-2` **Not started:** Persist signed-in collections across devices with safe idempotent replay.
 - [ ] `wave-4-criterion-3` **Not started:** Build My Map on the existing saved-organization foundation without separate Finder onboarding.
 - [ ] `wave-4-criterion-4` **Not started:** Keep collected records resolvable through loading, empty, stale, and error states.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3014,3 +3014,28 @@
 - Future local checks use one port-3000 server, bounded curl probes, full
   process-tree shutdown, and recoverable cache quarantine only after repeated
   stalls. The focused browser tab displays `http://localhost:3000/find`.
+
+2026-08-12 16:31 EDT - implemented the first local Collect and My Map slice.
+
+- Started isolated branch `feat/my-map-guest-collection-20260812` from current
+  `origin/main`. Visitors can now collect and remove nonprofits without a
+  signup interruption, collect and remove public resources, and retain both
+  collections locally. The existing Saved tab is presented as My Map on the
+  shared desktop rail and mobile drawer without adding Finder onboarding,
+  lists, notes, tags, ordering, or import.
+- Kept the existing signed-in saved-organization sync intact. Resource
+  collection remains local in this slice; cross-device account persistence and
+  replay remain Wave 4 criterion 2 work. Collected-resource resolution during
+  partial and failed loading remains criterion 4 work.
+- Focused lint, all source guardrails, snapshots, 2,074 acceptance tests, all
+  RLS suites, the production build, 30 visual cases, and performance budgets
+  pass. The two Find visual cases initially used the obsolete Saved label and
+  passed after their selectors were changed to My Map. The repository-wide
+  standalone TypeScript command still reports unrelated pre-existing
+  test-fixture errors; the production build's TypeScript validation passed.
+- Replaced the port-3000 proof server with this exact worktree, kept port 3015
+  closed, and opened `http://localhost:3000/find` in Chrome. The first compile
+  completed in 51 seconds and the subsequent browser request returned `200` in
+  5.9 seconds. A partial dependency install was moved to
+  `/private/tmp/coach-house-my-map-partial-node-modules-20260812-1625`; nothing
+  was deleted.

--- a/src/components/public/public-map-index.tsx
+++ b/src/components/public/public-map-index.tsx
@@ -49,6 +49,7 @@ import { usePublicMapFilterUrlState } from "./public-map-index/use-filter-url-st
 import { usePublicMapPreferences } from "./public-map-index/use-public-map-preferences"
 import {
   useFilteredPublicMapItems,
+  usePublicMapCollectedResources,
   usePublicMapSavedOrganizations,
   usePublicMapSelectableItemMap,
 } from "./public-map-index/map-items-state"
@@ -128,7 +129,7 @@ export function PublicMapIndex({
       resolveInitialCameraTarget(initialOrganization)
     )
   const [authSheetOpen, setAuthSheetOpen] = useState(false)
-  const [pendingAuthOrgId, setPendingAuthOrgId] = useState<string | null>(null)
+  const pendingAuthOrgId: string | null = null
   const [sidebarInsetLeft, setSidebarInsetLeft] = useState(0)
   const [initialViewportResolved, setInitialViewportResolved] = useState(false)
   const [mapLoadVersion, setMapLoadVersion] = useState(0)
@@ -159,10 +160,12 @@ export function PublicMapIndex({
   const deferredQuery = useDeferredValue(query)
   const searchPending = deferredQuery !== query
   const {
+    collectedResourceIds,
     favorites,
     preferencesSaveError,
     viewer,
     setFavorites,
+    setCollectedResourceIds,
     setRecentOrganizationIds,
   } = usePublicMapPreferences({ initialViewer })
   const isAuthenticated = Boolean(viewer ?? initialViewer)
@@ -235,6 +238,12 @@ export function PublicMapIndex({
     favorites,
     organizationById,
   })
+  const { savedResources, toggleCollectedResource } =
+    usePublicMapCollectedResources({
+      collectedResourceIds,
+      resourceItems,
+      setCollectedResourceIds,
+    })
   const authAction = searchParams.get("auth_action")
   const authOrganizationId = searchParams.get("auth_org")
   const handleSameLocationSelectionChange = useCallback(
@@ -285,7 +294,6 @@ export function PublicMapIndex({
   const { authRedirectTo, handleSelectOrganization, toggleFavorite } =
     usePublicMapActions({
       organizationById,
-      isAuthenticated,
       searchParams,
       initialPublicSlug,
       selectedOrganization,
@@ -294,8 +302,6 @@ export function PublicMapIndex({
       setSidebarMode,
       setCameraTargetOrgId: handleSetCameraTargetOrgId,
       setRecentOrganizationIds,
-      setPendingAuthOrgId,
-      setAuthSheetOpen,
       setFavorites,
     })
   const {
@@ -404,8 +410,10 @@ export function PublicMapIndex({
       organizationCurationAction={organizationCurationAction}
       resourceMapCurationAction={resourceMapCurationAction}
       favorites={favorites}
+      collectedResourceIds={collectedResourceIds}
       guides={resourceGuides}
       savedOrganizations={savedOrganizations}
+      savedResources={savedResources}
       query={query}
       activeGroup={activeGroup}
       groupCounts={groupCounts}
@@ -423,6 +431,7 @@ export function PublicMapIndex({
       onActiveGroupChange={handleActiveGroupChange}
       onRetryResourceItems={retryResourceItems}
       onToggleFavorite={toggleFavorite}
+      onToggleCollectedResource={toggleCollectedResource}
       onGuideSelect={handleGuideSelect}
       onSelectOrganization={handleRailSelectOrganization}
       onSelectItem={handleSelectListItem}

--- a/src/components/public/public-map-index/constants.ts
+++ b/src/components/public/public-map-index/constants.ts
@@ -24,6 +24,8 @@ export const PUBLIC_MAP_SPACE_FOG = {
   "star-intensity": 0.28,
 } satisfies FogSpecification
 export const FAVORITES_STORAGE_KEY = "public-map:favorites:v1"
+export const COLLECTED_RESOURCES_STORAGE_KEY =
+  "public-map:collected-resources:v1"
 export const SAVED_QUERIES_STORAGE_KEY = "public-map:saved-queries:v1"
 export const RECENT_ORGANIZATIONS_STORAGE_KEY =
   "public-map:recent-organizations:v1"

--- a/src/components/public/public-map-index/map-items-state.ts
+++ b/src/components/public/public-map-index/map-items-state.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useCallback, useMemo, type Dispatch, type SetStateAction } from "react"
 
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import {
@@ -197,4 +197,35 @@ export function usePublicMapSavedOrganizations({
         ),
     [favorites, organizationById]
   )
+}
+
+export function usePublicMapCollectedResources({
+  collectedResourceIds,
+  resourceItems,
+  setCollectedResourceIds,
+}: {
+  collectedResourceIds: string[]
+  resourceItems: ExternalResourceMapItem[]
+  setCollectedResourceIds: Dispatch<SetStateAction<string[]>>
+}) {
+  const savedResources = useMemo(() => {
+    const resourceById = new Map(resourceItems.map((item) => [item.id, item]))
+    return collectedResourceIds.flatMap((resourceId) => {
+      const item = resourceById.get(resourceId)
+      return item ? [item] : []
+    })
+  }, [collectedResourceIds, resourceItems])
+
+  const toggleCollectedResource = useCallback(
+    (resourceId: string) => {
+      setCollectedResourceIds((current) =>
+        current.includes(resourceId)
+          ? current.filter((entry) => entry !== resourceId)
+          : [resourceId, ...current].slice(0, 120)
+      )
+    },
+    [setCollectedResourceIds]
+  )
+
+  return { savedResources, toggleCollectedResource }
 }

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -52,8 +52,10 @@ type PublicMapSurfaceProps = {
   organizationCurationAction?: PublicMapOrganizationCurationAction
   resourceMapCurationAction?: PublicMapResourceCurationAction
   favorites: string[]
+  collectedResourceIds?: string[]
   guides?: PublicMapResourceGuide[]
   savedOrganizations: PublicMapOrganization[]
+  savedResources?: ExternalResourceMapItem[]
   query: string
   activeGroup: PublicMapGroupFilterKey
   groupCounts: PublicMapGroupFilterCounts
@@ -70,6 +72,7 @@ type PublicMapSurfaceProps = {
   onActiveGroupChange: (group: PublicMapGroupFilterKey) => void
   onRetryResourceItems: () => void
   onToggleFavorite: (orgId: string) => void
+  onToggleCollectedResource?: (resourceId: string) => void
   onGuideSelect?: (guideId: string) => void
   onSelectOrganization: (organizationId: string) => void
   onSelectItem: (itemId: string) => void
@@ -102,8 +105,10 @@ export function PublicMapSurface({
   organizationCurationAction,
   resourceMapCurationAction,
   favorites,
+  collectedResourceIds = [],
   guides = [],
   savedOrganizations,
+  savedResources = [],
   query,
   activeGroup,
   groupCounts,
@@ -120,6 +125,7 @@ export function PublicMapSurface({
   onActiveGroupChange,
   onRetryResourceItems,
   onToggleFavorite,
+  onToggleCollectedResource = () => undefined,
   onGuideSelect,
   onSelectOrganization,
   onSelectItem,
@@ -217,8 +223,10 @@ export function PublicMapSurface({
           organizationCurationAction={organizationCurationAction}
           resourceMapCurationAction={resourceMapCurationAction}
           favorites={favorites}
+          collectedResourceIds={collectedResourceIds}
           guides={guides}
           savedOrganizations={savedOrganizations}
+          savedResources={savedResources}
           query={query}
           activeGroup={activeGroup}
           groupCounts={groupCounts}
@@ -230,6 +238,7 @@ export function PublicMapSurface({
           setActiveGroup={onActiveGroupChange}
           retryResourceItems={onRetryResourceItems}
           toggleFavorite={onToggleFavorite}
+          toggleCollectedResource={onToggleCollectedResource}
           onGuideSelect={onGuideSelect}
           onSelectOrganization={onSelectOrganization}
           onSelectItem={onSelectItem}

--- a/src/components/public/public-map-index/member-rail-organization-section.tsx
+++ b/src/components/public/public-map-index/member-rail-organization-section.tsx
@@ -10,27 +10,35 @@ import { Empty } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { formatCompactOrganizationLocation } from "@/lib/location/organization-location"
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
+import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
 import { cn } from "@/lib/utils"
+import { PublicMapResourceListCard } from "./organization-list-resource-card"
 
 export function PublicMapOrganizationsRailSection({
   title,
   icon,
   organizations,
+  resources = [],
   emptyTitle,
   emptyDescription,
   className,
   onSelectOrganization,
   onToggleFavorite,
+  onSelectResource,
+  onToggleCollectedResource,
   removable = false,
 }: {
   title: string
   icon: ReactNode
   organizations: PublicMapOrganization[]
+  resources?: ExternalResourceMapItem[]
   emptyTitle: string
   emptyDescription: string
   className?: string
   onSelectOrganization: (organizationId: string) => void
   onToggleFavorite: (organizationId: string) => void
+  onSelectResource?: (resourceId: string) => void
+  onToggleCollectedResource?: (resourceId: string) => void
   removable?: boolean
 }) {
   return (
@@ -53,7 +61,7 @@ export function PublicMapOrganizationsRailSection({
         viewportClassName="scroll-fade-effect-y overscroll-contain [--mask-height:1.5rem] [--scroll-buffer:1rem] [scrollbar-width:thin]"
         contentClassName="p-4"
       >
-        {organizations.length === 0 ? (
+        {organizations.length === 0 && resources.length === 0 ? (
           <Empty
             className="border-border/70 bg-background/70 min-h-[220px] rounded-xl border"
             title={emptyTitle}
@@ -109,7 +117,7 @@ export function PublicMapOrganizationsRailSection({
                         variant="ghost"
                         size="icon"
                         className="border-border/70 bg-background/85 text-muted-foreground hover:bg-muted hover:text-foreground size-11 shrink-0 rounded-full border"
-                        aria-label={`Remove ${organization.name} from saved organizations`}
+                        aria-label={`Remove ${organization.name} from My Map`}
                         onClick={() => onToggleFavorite(organization.id)}
                       >
                         <MinusIcon className="size-4" aria-hidden />
@@ -119,6 +127,17 @@ export function PublicMapOrganizationsRailSection({
                 </article>
               )
             })}
+            {resources.map((resource) => (
+              <PublicMapResourceListCard
+                key={resource.id}
+                constrainedLayout
+                item={resource}
+                selected={false}
+                collected
+                onSelectItem={onSelectResource}
+                onToggleCollected={onToggleCollectedResource}
+              />
+            ))}
           </div>
         )}
       </ScrollArea>

--- a/src/components/public/public-map-index/member-rail.tsx
+++ b/src/components/public/public-map-index/member-rail.tsx
@@ -13,6 +13,7 @@ import BookmarkIcon from "lucide-react/dist/esm/icons/bookmark"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
+import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
 import { cn } from "@/lib/utils"
 
 import {
@@ -34,6 +35,7 @@ import {
   buildPublicMapSearchIndex,
   filterPublicMapOrganizationIds,
 } from "./search-index"
+import { publicMapListItemMatchesQuery } from "./map-items-state"
 
 const PUBLIC_MAP_MEMBER_TABS_LIST_CLASSNAME =
   "mx-auto h-7 w-fit max-w-full min-w-0 justify-center gap-0 self-center p-0"
@@ -47,10 +49,29 @@ type PublicMapMemberRailProps = {
   directoryMode?: PublicMapDirectoryRailMode | null
   guides?: PublicMapResourceGuide[]
   savedOrganizations: PublicMapOrganization[]
+  savedResources?: ExternalResourceMapItem[]
   onActiveTabChange?: (tab: PublicMapMemberTab) => void
   onGuideSelect?: (guideId: string) => void
   onSelectOrganization: (organizationId: string) => void
+  onSelectResource?: (resourceId: string) => void
   onToggleFavorite: (organizationId: string) => void
+  onToggleCollectedResource?: (resourceId: string) => void
+}
+
+export function filterPublicMapSavedResources({
+  activeGroup,
+  query,
+  savedResources,
+}: {
+  activeGroup: PublicMapGroupFilterKey
+  query: string
+  savedResources: ExternalResourceMapItem[]
+}) {
+  return savedResources.filter(
+    (item) =>
+      publicMapListItemMatchesQuery({ item, query }) &&
+      publicMapItemMatchesGroupFilter({ activeGroup, item })
+  )
 }
 
 export type PublicMapMemberTab = "directory" | "guides" | "saved"
@@ -97,10 +118,13 @@ export function PublicMapMemberRail({
   directoryMode = null,
   guides = [],
   savedOrganizations,
+  savedResources = [],
   onActiveTabChange,
   onGuideSelect,
   onSelectOrganization,
+  onSelectResource,
   onToggleFavorite,
+  onToggleCollectedResource,
 }: PublicMapMemberRailProps) {
   const hasDirectoryRail = Boolean(directoryRail)
   const hasGuides = Boolean(onGuideSelect)
@@ -124,8 +148,11 @@ export function PublicMapMemberRail({
     useState<PublicMapGroupFilterKey>("all")
   const previousHasDirectoryRailRef = useRef(hasDirectoryRail)
   const savedItems = useMemo(
-    () => savedOrganizations.map(buildPlatformOrganizationMapItem),
-    [savedOrganizations]
+    () => [
+      ...savedOrganizations.map(buildPlatformOrganizationMapItem),
+      ...savedResources,
+    ],
+    [savedOrganizations, savedResources]
   )
   const savedGroupCounts = useMemo(
     () => buildPublicMapGroupFilterCounts(savedItems),
@@ -139,6 +166,15 @@ export function PublicMapMemberRail({
         savedOrganizations,
       }),
     [savedActiveGroup, savedOrganizations, savedQuery]
+  )
+  const filteredSavedResources = useMemo(
+    () =>
+      filterPublicMapSavedResources({
+        activeGroup: savedActiveGroup,
+        query: savedQuery,
+        savedResources,
+      }),
+    [savedActiveGroup, savedQuery, savedResources]
   )
   const hasSavedFilters =
     savedQuery.trim().length > 0 || savedActiveGroup !== "all"
@@ -180,6 +216,12 @@ export function PublicMapMemberRail({
       setActiveTab("directory")
     }
   }
+  const handleSelectResource = (resourceId: string) => {
+    onSelectResource?.(resourceId)
+    if (hasDirectoryRail) {
+      setActiveTab("directory")
+    }
+  }
 
   return (
     <div
@@ -216,7 +258,7 @@ export function PublicMapMemberRail({
             value="saved"
             className={PUBLIC_MAP_MEMBER_TAB_TRIGGER_CLASSNAME}
           >
-            <span className="truncate">Saved</span>
+            <span className="truncate">My Map</span>
           </TabsTrigger>
         </TabsList>
 
@@ -264,7 +306,7 @@ export function PublicMapMemberRail({
             </div>
 
             <PublicMapOrganizationsRailSection
-              title="Saved organizations"
+              title="My Map"
               icon={
                 <BookmarkIcon
                   className="text-muted-foreground h-4 w-4"
@@ -272,19 +314,22 @@ export function PublicMapMemberRail({
                 />
               }
               organizations={filteredSavedOrganizations}
+              resources={filteredSavedResources}
               emptyTitle={
                 hasSavedFilters
-                  ? "No saved results"
-                  : "No saved organizations yet"
+                  ? "No collected results"
+                  : "Nothing collected yet"
               }
               emptyDescription={
                 hasSavedFilters
                   ? "Try a different search or category filter."
-                  : "Tap the heart on any organization to keep it here."
+                  : "Collect nonprofits and resources to keep them here."
               }
               className="mx-2 min-h-0 flex-1 bg-transparent"
               onSelectOrganization={handleSelectOrganization}
+              onSelectResource={handleSelectResource}
               onToggleFavorite={onToggleFavorite}
+              onToggleCollectedResource={onToggleCollectedResource}
               removable
             />
           </div>

--- a/src/components/public/public-map-index/organization-detail-shell-sections.tsx
+++ b/src/components/public/public-map-index/organization-detail-shell-sections.tsx
@@ -70,8 +70,8 @@ export function OrganizationDetailPanelChrome({
     : undefined
   const isFavorite = favorites.includes(organization.id)
   const favoriteLabel = isFavorite
-    ? `Remove ${organization.name} from favorites`
-    : `Add ${organization.name} to favorites`
+    ? `Remove ${organization.name} from My Map`
+    : `Collect ${organization.name} in My Map`
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/public/public-map-index/organization-list-resource-card.tsx
+++ b/src/components/public/public-map-index/organization-list-resource-card.tsx
@@ -8,6 +8,8 @@ import {
   PUBLIC_MAP_RESOURCE_CATEGORY_LABELS,
   resolvePublicMapResourceCategoryColor,
 } from "@/lib/public-map/resource-categories"
+import { Button } from "@/components/ui/button"
+import BookmarkIcon from "lucide-react/dist/esm/icons/bookmark"
 import { cn } from "@/lib/utils"
 import {
   buildPublicMapOrganizationListCardOwnerId,
@@ -40,11 +42,15 @@ export function PublicMapResourceListCard({
   item,
   selected,
   onSelectItem,
+  collected = false,
+  onToggleCollected,
 }: {
   constrainedLayout: boolean
   item: ExternalResourceMapItem
   selected: boolean
   onSelectItem?: (id: string) => void
+  collected?: boolean
+  onToggleCollected?: (id: string) => void
 }) {
   const selectableItemId = resolvePublicMapItemSelectableId(item)
   const metadataItems = buildResourceMetadataItems({ item })
@@ -152,11 +158,36 @@ export function PublicMapResourceListCard({
               ownerId={ownerId}
             />
           </div>
-          <PublicMapListViewButton
-            ownerId={ownerId}
-            onClick={openResourceDetails}
-            notes="Explicit right-aligned call-to-action button for opening resource details."
-          />
+          <div className="flex shrink-0 items-center gap-1">
+            {onToggleCollected ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="border-border/70 bg-background/85 text-muted-foreground hover:bg-muted hover:text-foreground size-11 rounded-full border"
+                aria-label={
+                  collected
+                    ? `Remove ${item.title} from My Map`
+                    : `Collect ${item.title} in My Map`
+                }
+                aria-pressed={collected}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onToggleCollected(item.id)
+                }}
+              >
+                <BookmarkIcon
+                  className={cn("size-4", collected && "fill-current")}
+                  aria-hidden
+                />
+              </Button>
+            ) : null}
+            <PublicMapListViewButton
+              ownerId={ownerId}
+              onClick={openResourceDetails}
+              notes="Explicit right-aligned call-to-action button for opening resource details."
+            />
+          </div>
         </div>
         {subtitle ? (
           <p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed text-pretty">

--- a/src/components/public/public-map-index/resource-detail-primary-sections.tsx
+++ b/src/components/public/public-map-index/resource-detail-primary-sections.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ReactNode } from "react"
 import ArrowLeftIcon from "lucide-react/dist/esm/icons/arrow-left"
+import BookmarkIcon from "lucide-react/dist/esm/icons/bookmark"
 import MapPinIcon from "lucide-react/dist/esm/icons/map-pin"
 
 import { Button } from "@/components/ui/button"
@@ -89,13 +90,17 @@ function PublicMapResourceIdentityMedia({
 
 export function PublicMapResourceDetailChrome({
   canManageResourceMap = false,
+  collected = false,
   item,
   onBack,
+  onToggleCollected,
   resourceMapCurationAction,
 }: {
   canManageResourceMap?: boolean
+  collected?: boolean
   item: ExternalResourceMapItem
   onBack: () => void
+  onToggleCollected?: (resourceId: string) => void
   resourceMapCurationAction?: PublicMapResourceCurationAction
 }) {
   return (
@@ -123,6 +128,31 @@ export function PublicMapResourceDetailChrome({
             item={item}
             onComplete={onBack}
           />
+        ) : null}
+        {onToggleCollected ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={cn(
+              PUBLIC_MAP_DETAIL_ICON_BUTTON_CLASSNAME,
+              collected
+                ? "border-sky-400/55 bg-sky-500/12 text-sky-600 hover:bg-sky-500/18 dark:border-sky-400/45 dark:bg-sky-400/14 dark:text-sky-300 dark:hover:bg-sky-400/20"
+                : PUBLIC_MAP_DETAIL_CHROME_BUTTON_SURFACE_CLASSNAME
+            )}
+            onClick={() => onToggleCollected(item.id)}
+            aria-label={
+              collected
+                ? `Remove ${item.title} from My Map`
+                : `Collect ${item.title} in My Map`
+            }
+            aria-pressed={collected}
+          >
+            <BookmarkIcon
+              className={cn("size-4", collected && "fill-current")}
+              aria-hidden
+            />
+          </Button>
         ) : null}
       </div>
     </div>

--- a/src/components/public/public-map-index/resource-detail.tsx
+++ b/src/components/public/public-map-index/resource-detail.tsx
@@ -21,15 +21,19 @@ import {
 
 export function PublicMapResourceDetail({
   canManageResourceMap = false,
+  collected = false,
   item,
   compact = false,
   onBack,
+  onToggleCollected,
   resourceMapCurationAction,
 }: {
   canManageResourceMap?: boolean
+  collected?: boolean
   item: ExternalResourceMapItem
   compact?: boolean
   onBack: () => void
+  onToggleCollected?: (resourceId: string) => void
   resourceMapCurationAction?: PublicMapResourceCurationAction
 }) {
   return (
@@ -42,8 +46,10 @@ export function PublicMapResourceDetail({
     >
       <PublicMapResourceDetailChrome
         canManageResourceMap={canManageResourceMap}
+        collected={collected}
         item={item}
         onBack={onBack}
+        onToggleCollected={onToggleCollected}
         resourceMapCurationAction={resourceMapCurationAction}
       />
       <PublicMapResourceIdentitySection item={item} />

--- a/src/components/public/public-map-index/sidebar-contract.ts
+++ b/src/components/public/public-map-index/sidebar-contract.ts
@@ -34,8 +34,10 @@ export type PublicMapSidebarProps = {
   organizationCurationAction?: PublicMapOrganizationCurationAction
   resourceMapCurationAction?: PublicMapResourceCurationAction
   favorites: string[]
+  collectedResourceIds?: string[]
   guides?: PublicMapResourceGuide[]
-  savedOrganizations: PublicMapOrganization[]
+  savedOrganizations?: PublicMapOrganization[]
+  savedResources?: ExternalResourceMapItem[]
   query: string
   activeGroup: PublicMapGroupFilterKey
   groupCounts: PublicMapGroupFilterCounts
@@ -47,6 +49,7 @@ export type PublicMapSidebarProps = {
   setActiveGroup: (group: PublicMapGroupFilterKey) => void
   retryResourceItems?: () => void
   toggleFavorite: (orgId: string) => void
+  toggleCollectedResource?: (resourceId: string) => void
   onSelectItem: (itemId: string) => void
   onGuideSelect?: (guideId: string) => void
   onSelectOrganization: (organizationId: string) => void

--- a/src/components/public/public-map-index/sidebar-detail-panels.tsx
+++ b/src/components/public/public-map-index/sidebar-detail-panels.tsx
@@ -50,13 +50,17 @@ export function PublicMapRailDetailPanel({
 
 export function PublicMapResourceRailDetailPanel({
   canManageResourceMap = false,
+  collected = false,
   item,
   onBack,
+  onToggleCollected,
   resourceMapCurationAction,
 }: {
   canManageResourceMap?: boolean
+  collected?: boolean
   item: ExternalResourceMapItem
   onBack: () => void
+  onToggleCollected?: (resourceId: string) => void
   resourceMapCurationAction?: PublicMapResourceCurationAction
 }) {
   return (
@@ -69,8 +73,10 @@ export function PublicMapResourceRailDetailPanel({
       >
         <PublicMapResourceDetail
           canManageResourceMap={canManageResourceMap}
+          collected={collected}
           item={item}
           onBack={onBack}
+          onToggleCollected={onToggleCollected}
           resourceMapCurationAction={resourceMapCurationAction}
         />
       </ScrollArea>
@@ -120,14 +126,18 @@ export function PublicMapDrawerDetailPanel({
 
 export function PublicMapResourceDrawerDetailPanel({
   canManageResourceMap = false,
+  collected = false,
   item,
   onBack,
+  onToggleCollected,
   resourceMapCurationAction,
 }: {
   canManageResourceMap?: boolean
+  collected?: boolean
   item: ExternalResourceMapItem
   drawerBodyScrollable?: boolean
   onBack: () => void
+  onToggleCollected?: (resourceId: string) => void
   resourceMapCurationAction?: PublicMapResourceCurationAction
 }) {
   return (
@@ -140,8 +150,10 @@ export function PublicMapResourceDrawerDetailPanel({
       <div className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 mx-auto w-full max-w-3xl motion-safe:duration-200">
         <PublicMapResourceDetail
           canManageResourceMap={canManageResourceMap}
+          collected={collected}
           item={item}
           onBack={onBack}
+          onToggleCollected={onToggleCollected}
           resourceMapCurationAction={resourceMapCurationAction}
           compact
         />

--- a/src/components/public/public-map-index/sidebar-member-panels.tsx
+++ b/src/components/public/public-map-index/sidebar-member-panels.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useCallback, type CSSProperties, type ReactNode } from "react"
+
+import { Sidebar, SidebarProvider } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
+
+import { PublicMapLiquidGlassShell } from "./liquid-glass-shell"
+import { PublicMapMemberRail, type PublicMapMemberTab } from "./member-rail"
+import type { PublicMapSidebarProps } from "./sidebar-contract"
+import { PUBLIC_MAP_SIDEBAR_RAIL_CLASSNAME } from "./sidebar-theme"
+
+export function PublicMapRailPanel({
+  directoryRail,
+  directoryMode,
+  guides,
+  savedOrganizations,
+  savedResources,
+  onGuideSelect,
+  onSelectOrganization,
+  onSelectResource,
+  onToggleFavorite,
+  onToggleCollectedResource,
+}: {
+  directoryRail: ReactNode
+  directoryMode: "search" | "details"
+  guides: NonNullable<PublicMapSidebarProps["guides"]>
+  savedOrganizations: NonNullable<PublicMapSidebarProps["savedOrganizations"]>
+  savedResources: NonNullable<PublicMapSidebarProps["savedResources"]>
+  onGuideSelect: PublicMapSidebarProps["onGuideSelect"]
+  onSelectOrganization: PublicMapSidebarProps["onSelectOrganization"]
+  onSelectResource: PublicMapSidebarProps["onSelectItem"]
+  onToggleFavorite: PublicMapSidebarProps["toggleFavorite"]
+  onToggleCollectedResource: NonNullable<
+    PublicMapSidebarProps["toggleCollectedResource"]
+  >
+}) {
+  const providerStyle = { "--sidebar-width": "100%" } as CSSProperties
+
+  return (
+    <SidebarProvider
+      defaultOpen
+      className="h-full min-h-0 w-full bg-transparent"
+      style={providerStyle}
+    >
+      <PublicMapLiquidGlassShell
+        className={cn(
+          "pointer-events-auto h-full w-full",
+          PUBLIC_MAP_SIDEBAR_RAIL_CLASSNAME
+        )}
+      >
+        <Sidebar
+          collapsible="none"
+          className="text-sidebar-foreground h-full w-full overflow-hidden bg-transparent"
+        >
+          <PublicMapMemberRail
+            directoryRail={directoryRail}
+            directoryMode={directoryMode}
+            guides={guides}
+            savedOrganizations={savedOrganizations}
+            savedResources={savedResources}
+            onGuideSelect={onGuideSelect}
+            onSelectOrganization={onSelectOrganization}
+            onSelectResource={onSelectResource}
+            onToggleFavorite={onToggleFavorite}
+            onToggleCollectedResource={onToggleCollectedResource}
+          />
+        </Sidebar>
+      </PublicMapLiquidGlassShell>
+    </SidebarProvider>
+  )
+}
+
+export function usePublicMapDrawerSelectionHandlers({
+  onGuideSelect,
+  onSelectItem,
+  onSelectOrganization,
+  setActiveSnapIndex,
+  setDrawerTab,
+}: {
+  onGuideSelect: PublicMapSidebarProps["onGuideSelect"]
+  onSelectItem: PublicMapSidebarProps["onSelectItem"]
+  onSelectOrganization: PublicMapSidebarProps["onSelectOrganization"]
+  setActiveSnapIndex: (index: 0 | 1 | 2) => void
+  setDrawerTab: (tab: PublicMapMemberTab) => void
+}) {
+  const selectDirectory = useCallback(() => {
+    setDrawerTab("directory")
+    setActiveSnapIndex(1)
+  }, [setActiveSnapIndex, setDrawerTab])
+  const handleGuideSelect = useCallback(
+    (guideId: string) => {
+      onGuideSelect?.(guideId)
+      selectDirectory()
+    },
+    [onGuideSelect, selectDirectory]
+  )
+  const handleOrganizationSelect = useCallback(
+    (organizationId: string) => {
+      onSelectOrganization(organizationId)
+      selectDirectory()
+    },
+    [onSelectOrganization, selectDirectory]
+  )
+  const handleResourceSelect = useCallback(
+    (resourceId: string) => {
+      onSelectItem(resourceId)
+      selectDirectory()
+    },
+    [onSelectItem, selectDirectory]
+  )
+
+  return { handleGuideSelect, handleOrganizationSelect, handleResourceSelect }
+}

--- a/src/components/public/public-map-index/sidebar.tsx
+++ b/src/components/public/public-map-index/sidebar.tsx
@@ -1,12 +1,6 @@
 "use client"
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type CSSProperties,
-} from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import SearchIcon from "lucide-react/dist/esm/icons/search"
 
 import { Button } from "@/components/ui/button"
@@ -18,17 +12,19 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer"
-import { Sidebar, SidebarProvider } from "@/components/ui/sidebar"
 import { cn } from "@/lib/utils"
 
 import type { PublicMapGroupFilterKey } from "./category-filter"
 import type { SidebarMode } from "./constants"
-import { PublicMapLiquidGlassShell } from "./liquid-glass-shell"
 import {
   buildPublicMapDrawerSnapPoints,
   resolvePublicMapDrawerSnapPointIndex,
 } from "./sidebar-snap-points"
 import { PublicMapMemberRail, type PublicMapMemberTab } from "./member-rail"
+import {
+  PublicMapRailPanel,
+  usePublicMapDrawerSelectionHandlers,
+} from "./sidebar-member-panels"
 import {
   PublicMapDrawerDetailPanel,
   PublicMapDrawerSearchPanel,
@@ -44,7 +40,6 @@ import {
 import {
   PUBLIC_MAP_OVERLAY_GLASS_CLASSNAME,
   PUBLIC_MAP_SIDEBAR_ACTION_SURFACE_CLASSNAME,
-  PUBLIC_MAP_SIDEBAR_RAIL_CLASSNAME,
 } from "./sidebar-theme"
 
 export type { PublicMapSidebarSearchContext } from "./sidebar-panels"
@@ -102,8 +97,10 @@ export function PublicMapSidebar({
   organizationCurationAction,
   resourceMapCurationAction,
   favorites,
+  collectedResourceIds = [],
   guides = [],
-  savedOrganizations,
+  savedOrganizations = [],
+  savedResources = [],
   query,
   activeGroup,
   groupCounts,
@@ -115,6 +112,7 @@ export function PublicMapSidebar({
   setActiveGroup,
   retryResourceItems = noopPublicMapSidebarAction,
   toggleFavorite,
+  toggleCollectedResource = noopPublicMapSidebarAction,
   onSelectItem,
   onGuideSelect,
   onSelectOrganization,
@@ -122,7 +120,6 @@ export function PublicMapSidebar({
   onBackToSearch,
   setSidebarMode,
 }: PublicMapSidebarProps) {
-  const mapSidebarProviderStyle = { "--sidebar-width": "100%" } as CSSProperties
   const compact = panelPresentation === "drawer"
   const effectiveSidebarMode =
     compact && sidebarMode === "hidden"
@@ -179,22 +176,17 @@ export function PublicMapSidebar({
     },
     [setSidebarMode]
   )
-  const handleDrawerGuideSelect = useCallback(
-    (guideId: string) => {
-      onGuideSelect?.(guideId)
-      setDrawerTab("directory")
-      setActiveSnapIndex(1)
-    },
-    [onGuideSelect]
-  )
-  const handleDrawerOrganizationSelect = useCallback(
-    (organizationId: string) => {
-      onSelectOrganization(organizationId)
-      setDrawerTab("directory")
-      setActiveSnapIndex(1)
-    },
-    [onSelectOrganization]
-  )
+  const {
+    handleGuideSelect: handleDrawerGuideSelect,
+    handleOrganizationSelect: handleDrawerOrganizationSelect,
+    handleResourceSelect: handleDrawerResourceSelect,
+  } = usePublicMapDrawerSelectionHandlers({
+    onGuideSelect,
+    onSelectItem,
+    onSelectOrganization,
+    setActiveSnapIndex,
+    setDrawerTab,
+  })
   const {
     changeGroup: handleDrawerGroupChange,
     changeQuery: handleDrawerQueryChange,
@@ -207,67 +199,65 @@ export function PublicMapSidebar({
     setSidebarMode,
   })
 
+  const railDirectoryPanel =
+    effectiveSidebarMode === "search" ? (
+      <PublicMapRailSearchPanel
+        query={query}
+        searchContext={searchContext}
+        items={listItems}
+        organizations={filteredOrganizations}
+        selectedItemId={selectedItemId}
+        selectedOrgId={selectedOrganization?.id ?? null}
+        constrainedLayout={constrainedRailLayout}
+        activeGroup={activeGroup}
+        groupCounts={groupCounts}
+        resourceItemsLoadStatus={resourceItemsLoadStatus}
+        resourceItemsLoadError={resourceItemsLoadError}
+        searchPending={searchPending}
+        onQueryChange={setQuery}
+        onActiveGroupChange={setActiveGroup}
+        onHidePanel={() => setSidebarMode("hidden")}
+        onRetryResourceItems={retryResourceItems}
+        onSelectItem={onSelectItem}
+        onOpenDetails={(organizationId) =>
+          onOpenDetails(organizationId, {
+            preserveSearchContext: Boolean(searchContext),
+          })
+        }
+      />
+    ) : selectedOrganization ? (
+      <PublicMapRailDetailPanel
+        canManageResourceMap={canManageResourceMap}
+        organizationCurationAction={organizationCurationAction}
+        organization={selectedOrganization}
+        favorites={favorites}
+        onBack={onBackToSearch}
+        onToggleFavorite={toggleFavorite}
+      />
+    ) : selectedResourceItem ? (
+      <PublicMapResourceRailDetailPanel
+        canManageResourceMap={canManageResourceMap}
+        collected={collectedResourceIds.includes(selectedResourceItem.id)}
+        item={selectedResourceItem}
+        onBack={onBackToSearch}
+        onToggleCollected={toggleCollectedResource}
+        resourceMapCurationAction={resourceMapCurationAction}
+      />
+    ) : null
+
   const railPanel = (
-    <SidebarProvider
-      defaultOpen
-      className="h-full min-h-0 w-full bg-transparent"
-      style={mapSidebarProviderStyle}
-    >
-      <PublicMapLiquidGlassShell
-        className={cn(
-          "pointer-events-auto h-full w-full",
-          PUBLIC_MAP_SIDEBAR_RAIL_CLASSNAME
-        )}
-      >
-        <Sidebar
-          collapsible="none"
-          className="text-sidebar-foreground h-full w-full overflow-hidden bg-transparent"
-        >
-          {effectiveSidebarMode === "search" ? (
-            <PublicMapRailSearchPanel
-              query={query}
-              searchContext={searchContext}
-              items={listItems}
-              organizations={filteredOrganizations}
-              selectedItemId={selectedItemId}
-              selectedOrgId={selectedOrganization?.id ?? null}
-              constrainedLayout={constrainedRailLayout}
-              activeGroup={activeGroup}
-              groupCounts={groupCounts}
-              resourceItemsLoadStatus={resourceItemsLoadStatus}
-              resourceItemsLoadError={resourceItemsLoadError}
-              searchPending={searchPending}
-              onQueryChange={setQuery}
-              onActiveGroupChange={setActiveGroup}
-              onHidePanel={() => setSidebarMode("hidden")}
-              onRetryResourceItems={retryResourceItems}
-              onSelectItem={onSelectItem}
-              onOpenDetails={(organizationId) =>
-                onOpenDetails(organizationId, {
-                  preserveSearchContext: Boolean(searchContext),
-                })
-              }
-            />
-          ) : selectedOrganization ? (
-            <PublicMapRailDetailPanel
-              canManageResourceMap={canManageResourceMap}
-              organizationCurationAction={organizationCurationAction}
-              organization={selectedOrganization}
-              favorites={favorites}
-              onBack={onBackToSearch}
-              onToggleFavorite={toggleFavorite}
-            />
-          ) : selectedResourceItem ? (
-            <PublicMapResourceRailDetailPanel
-              canManageResourceMap={canManageResourceMap}
-              item={selectedResourceItem}
-              onBack={onBackToSearch}
-              resourceMapCurationAction={resourceMapCurationAction}
-            />
-          ) : null}
-        </Sidebar>
-      </PublicMapLiquidGlassShell>
-    </SidebarProvider>
+    <PublicMapRailPanel
+      directoryRail={railDirectoryPanel}
+      directoryMode={effectiveSidebarMode === "details" ? "details" : "search"}
+      guides={guides}
+      savedOrganizations={savedOrganizations}
+      savedResources={savedResources}
+      onGuideSelect={onGuideSelect}
+      onSelectOrganization={onSelectOrganization}
+      onSelectResource={onSelectItem}
+      onToggleFavorite={toggleFavorite}
+      onToggleCollectedResource={toggleCollectedResource}
+    />
   )
 
   const drawerDirectoryPanel =
@@ -307,8 +297,10 @@ export function PublicMapSidebar({
     ) : selectedResourceItem ? (
       <PublicMapResourceDrawerDetailPanel
         canManageResourceMap={canManageResourceMap}
+        collected={collectedResourceIds.includes(selectedResourceItem.id)}
         item={selectedResourceItem}
         onBack={onBackToSearch}
+        onToggleCollected={toggleCollectedResource}
         resourceMapCurationAction={resourceMapCurationAction}
       />
     ) : null
@@ -320,10 +312,13 @@ export function PublicMapSidebar({
       directoryMode={effectiveSidebarMode === "details" ? "details" : "search"}
       guides={guides}
       savedOrganizations={savedOrganizations}
+      savedResources={savedResources}
       onActiveTabChange={handleDrawerTabChange}
       onGuideSelect={handleDrawerGuideSelect}
       onSelectOrganization={handleDrawerOrganizationSelect}
+      onSelectResource={handleDrawerResourceSelect}
       onToggleFavorite={toggleFavorite}
+      onToggleCollectedResource={toggleCollectedResource}
     />
   )
 

--- a/src/components/public/public-map-index/use-public-map-actions.ts
+++ b/src/components/public/public-map-index/use-public-map-actions.ts
@@ -39,14 +39,16 @@ export function applyPublicMapOrganizationSelection({
     setCameraTargetOrgId(organizationId)
   }
   setRecentOrganizationIds((current) => {
-    const next = [organizationId, ...current.filter((entry) => entry !== organizationId)]
+    const next = [
+      organizationId,
+      ...current.filter((entry) => entry !== organizationId),
+    ]
     return next.slice(0, RECENT_ORGANIZATIONS_LIMIT)
   })
 }
 
 export function usePublicMapActions({
   organizationById,
-  isAuthenticated,
   searchParams,
   initialPublicSlug,
   selectedOrganization,
@@ -55,12 +57,9 @@ export function usePublicMapActions({
   setSidebarMode,
   setCameraTargetOrgId,
   setRecentOrganizationIds,
-  setPendingAuthOrgId,
-  setAuthSheetOpen,
   setFavorites,
 }: {
   organizationById: Map<string, PublicMapOrganization>
-  isAuthenticated: boolean
   searchParams: ReturnType<typeof useSearchParams>
   initialPublicSlug?: string
   selectedOrganization: PublicMapOrganization | null
@@ -69,8 +68,6 @@ export function usePublicMapActions({
   setSidebarMode: (mode: "search" | "details" | "hidden") => void
   setCameraTargetOrgId: (organizationId: string) => void
   setRecentOrganizationIds: React.Dispatch<React.SetStateAction<string[]>>
-  setPendingAuthOrgId: (organizationId: string) => void
-  setAuthSheetOpen: (open: boolean) => void
   setFavorites: React.Dispatch<React.SetStateAction<string[]>>
 }) {
   const handleSelectOrganization = useCallback(
@@ -100,17 +97,11 @@ export function usePublicMapActions({
       setRecentOrganizationIds,
       setSelectedOrgId,
       setSidebarMode,
-    ],
+    ]
   )
 
   const toggleFavorite = useCallback(
     (organizationId: string) => {
-      if (!isAuthenticated) {
-        setPendingAuthOrgId(organizationId)
-        setAuthSheetOpen(true)
-        return
-      }
-
       setFavorites((current) => {
         if (current.includes(organizationId)) {
           return current.filter((entry) => entry !== organizationId)
@@ -118,12 +109,7 @@ export function usePublicMapActions({
         return [organizationId, ...current].slice(0, 120)
       })
     },
-    [
-      isAuthenticated,
-      setAuthSheetOpen,
-      setFavorites,
-      setPendingAuthOrgId,
-    ],
+    [setFavorites]
   )
 
   const authRedirectTo = useMemo(() => {
@@ -136,12 +122,18 @@ export function usePublicMapActions({
 
     return buildMapHref({
       slug:
-        normalizeSlug(initialPublicSlug) || normalizeSlug(selectedOrganization?.publicSlug)
-          ? selectedOrganization?.publicSlug ?? initialPublicSlug
+        normalizeSlug(initialPublicSlug) ||
+        normalizeSlug(selectedOrganization?.publicSlug)
+          ? (selectedOrganization?.publicSlug ?? initialPublicSlug)
           : null,
       searchParams: baseRedirectParams,
     })
-  }, [initialPublicSlug, pendingAuthOrgId, searchParams, selectedOrganization?.publicSlug])
+  }, [
+    initialPublicSlug,
+    pendingAuthOrgId,
+    searchParams,
+    selectedOrganization?.publicSlug,
+  ])
 
   return { authRedirectTo, handleSelectOrganization, toggleFavorite }
 }

--- a/src/components/public/public-map-index/use-public-map-preferences.ts
+++ b/src/components/public/public-map-index/use-public-map-preferences.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react"
 
 import {
+  COLLECTED_RESOURCES_STORAGE_KEY,
   FAVORITES_STORAGE_KEY,
   RECENT_ORGANIZATIONS_STORAGE_KEY,
   SAVED_QUERIES_STORAGE_KEY,
@@ -31,6 +32,7 @@ export function usePublicMapPreferences({
   initialViewer = null,
 }: UsePublicMapPreferencesOptions = {}) {
   const [favorites, setFavorites] = useState<string[]>([])
+  const [collectedResourceIds, setCollectedResourceIds] = useState<string[]>([])
   const [savedQueries, setSavedQueries] = useState<string[]>([])
   const [recentOrganizationIds, setRecentOrganizationIds] = useState<string[]>(
     []
@@ -48,12 +50,17 @@ export function usePublicMapPreferences({
   useEffect(() => {
     if (typeof window === "undefined") return
     const localFavorites = readStoredArray(FAVORITES_STORAGE_KEY, 120)
+    const localCollectedResourceIds = readStoredArray(
+      COLLECTED_RESOURCES_STORAGE_KEY,
+      120
+    )
     const localSavedQueries = readStoredArray(SAVED_QUERIES_STORAGE_KEY, 40)
     const localRecentOrganizationIds = readStoredArray(
       RECENT_ORGANIZATIONS_STORAGE_KEY,
       40
     )
     setFavorites(localFavorites)
+    setCollectedResourceIds(localCollectedResourceIds)
     setSavedQueries(localSavedQueries)
     setRecentOrganizationIds(localRecentOrganizationIds)
     setPreferenceMode("guest")
@@ -157,7 +164,9 @@ export function usePublicMapPreferences({
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    if (preferenceMode === "authenticated") return
+    if (preferenceMode === "unknown" || preferenceMode === "authenticated") {
+      return
+    }
     window.localStorage.setItem(
       FAVORITES_STORAGE_KEY,
       JSON.stringify(favorites)
@@ -171,6 +180,15 @@ export function usePublicMapPreferences({
       JSON.stringify(recentOrganizationIds)
     )
   }, [favorites, preferenceMode, recentOrganizationIds, savedQueries])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (preferenceMode === "unknown") return
+    window.localStorage.setItem(
+      COLLECTED_RESOURCES_STORAGE_KEY,
+      JSON.stringify(collectedResourceIds)
+    )
+  }, [collectedResourceIds, preferenceMode])
 
   useEffect(() => {
     if (preferenceMode !== "authenticated") return
@@ -220,6 +238,7 @@ export function usePublicMapPreferences({
   }, [favorites, preferenceMode, recentOrganizationIds, savedQueries])
 
   return {
+    collectedResourceIds,
     favorites,
     savedQueries,
     recentOrganizationIds,
@@ -227,6 +246,7 @@ export function usePublicMapPreferences({
     preferencesSaveError,
     viewer,
     setFavorites,
+    setCollectedResourceIds,
     setSavedQueries,
     setRecentOrganizationIds,
   }

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -171,12 +171,14 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
   {
     id: "wave-4-my-map",
     sequence: 4,
-    status: "queued",
+    status: "active",
     title: "Collect and My Map completion",
     criteria: defineCriteria(4, [
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Isolated local My Map implementation passes focused lint, 49 focused tests, full acceptance, RLS, build, visual, and performance gates; merge, deployment, and production smoke remain",
+        ],
+        state: "in_progress",
         title:
           "Let visitors collect and remove nonprofits and resources locally",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1171,20 +1171,21 @@ describe("finance release planning graph", () => {
       "production_verified",
       "active",
       "active",
-      ...Array(4).fill("queued"),
+      "active",
+      ...Array(3).fill("queued"),
     ])
     expect(FINANCE_PLAN_WAVE_STATUS_COUNTS).toEqual({
-      active: 2,
+      active: 3,
       codeComplete: 0,
       previewVerified: 0,
       productionVerified: 1,
-      queued: 4,
+      queued: 3,
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 11,
-      inProgress: 3,
-      notStarted: 21,
+      inProgress: 4,
+      notStarted: 20,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(31)

--- a/tests/acceptance/public-find-route.test.ts
+++ b/tests/acceptance/public-find-route.test.ts
@@ -333,7 +333,7 @@ describe("public find routes", () => {
     expect(appShellSource).not.toContain("useFullBleedContent || isMobile")
   })
 
-  it("uses the same Find, Guides, and Saved drawer for public and authenticated find", () => {
+  it("uses the same Find, Guides, and My Map drawer for public and authenticated find", () => {
     const chromeSource = readRoute(
       "src/components/public/public-map-index/public-map-index-chrome.tsx"
     )
@@ -403,7 +403,7 @@ describe("public find routes", () => {
     )
     expect(memberRailSource).toContain(">Find</span>")
     expect(memberRailSource).toContain(">Guides</span>")
-    expect(memberRailSource).toContain(">Saved</span>")
+    expect(memberRailSource).toContain(">My Map</span>")
   })
 
   it("wires category filtering through the search rail and map markers", () => {

--- a/tests/acceptance/public-map-preferences.test.ts
+++ b/tests/acceptance/public-map-preferences.test.ts
@@ -20,10 +20,25 @@ describe("public map preferences", () => {
       ),
       "utf8"
     )
+    const actionsSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/public/public-map-index/use-public-map-actions.ts"
+      ),
+      "utf8"
+    )
 
     expect(surfaceSource).not.toContain("Saving map activity")
     expect(surfaceSource).not.toContain("isSavingPreferences")
     expect(preferencesSource).toContain('method: "PATCH"')
+    expect(preferencesSource).toContain("COLLECTED_RESOURCES_STORAGE_KEY")
+    expect(preferencesSource).toContain(
+      'if (preferenceMode === "unknown" || preferenceMode === "authenticated")'
+    )
+    expect(preferencesSource).toContain(
+      'if (preferenceMode === "unknown") return'
+    )
+    expect(actionsSource).not.toContain("setAuthSheetOpen")
   })
 
   it("skips remote preference loading for signed-out visitors", () => {

--- a/tests/acceptance/public-map-sidebar-layout.test.ts
+++ b/tests/acceptance/public-map-sidebar-layout.test.ts
@@ -20,6 +20,7 @@ import { PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR } from "@/components/public/pub
 import { resolveResourceIdentityTitle } from "@/components/public/public-map-index/resource-detail-primary-sections"
 import {
   filterPublicMapSavedOrganizations,
+  filterPublicMapSavedResources,
   PublicMapMemberRail,
 } from "@/components/public/public-map-index/member-rail"
 import { PublicMapSavedRail } from "@/components/public/public-map-index/saved-rail"
@@ -309,13 +310,21 @@ describe("public map sidebar layout", () => {
       join(process.cwd(), "src/components/public/public-map-index/sidebar.tsx"),
       "utf8"
     )
+    const sidebarMemberPanelsSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/public/public-map-index/sidebar-member-panels.tsx"
+      ),
+      "utf8"
+    )
 
     expect(shellSource).toContain('@samasante/liquid-glass"')
     expect(shellSource).toContain("PUBLIC_MAP_LIQUID_GLASS_OPTICS")
     expect(shellSource).toContain('height: "100%"')
     expect(shellSource).toContain('width: "100%"')
     expect(shellSource).not.toContain("filterResolution")
-    expect(sidebarSource).toContain("PublicMapLiquidGlassShell")
+    expect(sidebarSource).toContain("PublicMapRailPanel")
+    expect(sidebarMemberPanelsSource).toContain("PublicMapLiquidGlassShell")
 
     const markup = renderToStaticMarkup(
       React.createElement(
@@ -1204,7 +1213,7 @@ describe("public map sidebar layout", () => {
     expect(directoryMarkup).not.toContain("NYC Cooling Centers")
     expect(memberRailMarkup).toContain(">Find<")
     expect(memberRailMarkup).toContain(">Guides<")
-    expect(memberRailMarkup).toContain(">Saved<")
+    expect(memberRailMarkup).toContain(">My Map<")
     expect(memberRailMarkup).not.toContain(">Recent<")
     expect(memberRailMarkup).not.toContain(">Joined<")
     expect(memberRailMarkup).not.toContain(">Alerts<")
@@ -1303,7 +1312,7 @@ describe("public map sidebar layout", () => {
     expect(memberRailMarkup).toContain("Directory")
   })
 
-  it("lets the saved tab search and category-filter saved organizations", () => {
+  it("lets My Map search and category-filter collected organizations", () => {
     const communityOrganization = buildOrganization({
       id: "community-org",
       name: "Atlas Collective",
@@ -1344,7 +1353,7 @@ describe("public map sidebar layout", () => {
       })
     )
 
-    expect(markup).toContain(">Saved<")
+    expect(markup).toContain(">My Map<")
     const savedRailMarkup = renderToStaticMarkup(
       React.createElement(PublicMapSavedRail, {
         savedOrganizations: [communityOrganization, healthOrganization],
@@ -1387,14 +1396,12 @@ describe("public map sidebar layout", () => {
     expect(markup).toContain(">Health<")
     expect(markup).toContain(">2<")
     expect(markup).toContain(">1<")
-    expect(markup).toContain("Saved organizations")
+    expect(markup).toContain("My Map")
     expect(markup).toContain("mx-2 min-h-0 flex-1 bg-transparent")
     expect(markup).not.toContain("bg-card/95")
     expect(markup).toContain("Atlas Collective")
     expect(markup).toContain("Harbor Health")
-    expect(markup).toContain(
-      'aria-label="Remove Atlas Collective from saved organizations"'
-    )
+    expect(markup).toContain('aria-label="Remove Atlas Collective from My Map"')
     expect(markup).toContain("lucide-minus")
     expect(markup).toContain("size-11 shrink-0 rounded-full")
     expect(markup).not.toContain(">Remove<")
@@ -1420,6 +1427,41 @@ describe("public map sidebar layout", () => {
     expect(markup).toContain("text-left font-normal whitespace-normal")
     expect(markup).toContain("w-full min-w-0 overflow-hidden")
     expect(markup).not.toContain("max-h-[52vh]")
+  })
+
+  it("shows collected resources in My Map and supports removal", () => {
+    const resource = buildResourceItem()
+
+    expect(
+      filterPublicMapSavedResources({
+        activeGroup: "food",
+        query: "pantry",
+        savedResources: [resource],
+      }).map((item) => item.id)
+    ).toEqual([resource.id])
+    expect(
+      filterPublicMapSavedResources({
+        activeGroup: "health",
+        query: "",
+        savedResources: [resource],
+      })
+    ).toEqual([])
+
+    const markup = renderToStaticMarkup(
+      React.createElement(PublicMapMemberRail, {
+        savedOrganizations: [],
+        savedResources: [resource],
+        onSelectOrganization: () => {},
+        onSelectResource: () => {},
+        onToggleFavorite: () => {},
+        onToggleCollectedResource: () => {},
+      })
+    )
+
+    expect(markup).toContain(">My Map<")
+    expect(markup).toContain("Food pantry and meal support")
+    expect(markup).toContain('aria-label="Remove Seed Food Access from My Map"')
+    expect(markup).toContain('aria-pressed="true"')
   })
 
   it("uses the right rail directory detail view when a map organization is selected", () => {
@@ -1474,9 +1516,7 @@ describe("public map sidebar layout", () => {
     expect(markup).toContain('data-slot="scroll-area"')
     expect(markup).toContain(organization.name)
     expect(markup).toContain('aria-label="Back to search"')
-    expect(markup).toContain(
-      'aria-label="Remove Atlas Collective from favorites"'
-    )
+    expect(markup).toContain('aria-label="Remove Atlas Collective from My Map"')
     expect(markup).toContain('aria-pressed="true"')
   })
 
@@ -1616,9 +1656,9 @@ describe("public map sidebar layout", () => {
     )
     expect(markup).toContain("scroll-fade-effect-y")
     expect(markup).toContain('aria-label="Share"')
-    expect(markup).toContain('aria-label="Add Atlas Collective to favorites"')
+    expect(markup).toContain('aria-label="Collect Atlas Collective in My Map"')
     expect(
-      markup.indexOf('aria-label="Add Atlas Collective to favorites"')
+      markup.indexOf('aria-label="Collect Atlas Collective in My Map"')
     ).toBeGreaterThan(markup.indexOf('aria-label="Share"'))
     expect(markup).not.toContain('aria-label="Search public organizations"')
     expect(markup).not.toContain('aria-label="Hide organization panel"')

--- a/tests/visual/public-shell.visual.spec.ts
+++ b/tests/visual/public-shell.visual.spec.ts
@@ -47,7 +47,9 @@ async function stabilizeForScreenshot(page: Page) {
 async function waitForHomeCanvasHydration(page: Page) {
   await page.waitForFunction(() => {
     const panel = document.querySelector("[data-home-canvas-panel]")
-    return Object.keys(panel ?? {}).some((key) => key.startsWith("__reactProps$"))
+    return Object.keys(panel ?? {}).some((key) =>
+      key.startsWith("__reactProps$")
+    )
   })
 }
 
@@ -301,7 +303,7 @@ test("public Find uses the shared tabs in its permanent drawer", async ({
     "active"
   )
   await expect(tabList.getByRole("tab", { name: "Guides" })).toBeVisible()
-  await expect(tabList.getByRole("tab", { name: "Saved" })).toBeVisible()
+  await expect(tabList.getByRole("tab", { name: "My Map" })).toBeVisible()
   await expect(
     drawer.getByRole("searchbox", {
       name: "Find organizations and resources",
@@ -323,7 +325,7 @@ test("public Find keeps its mobile drawer controls visible when collapsed", asyn
   await expect(tabList.getByRole("tab")).toHaveCount(3)
   await expect(tabList.getByRole("tab", { name: "Find" })).toBeVisible()
   await expect(tabList.getByRole("tab", { name: "Guides" })).toBeVisible()
-  await expect(tabList.getByRole("tab", { name: "Saved" })).toBeVisible()
+  await expect(tabList.getByRole("tab", { name: "My Map" })).toBeVisible()
   await expect(
     drawer.getByRole("searchbox", {
       name: "Find organizations and resources",


### PR DESCRIPTION
## Summary
- let signed-out visitors collect and remove nonprofits locally without signup interruption
- add local resource collection and combine nonprofits/resources in the renamed My Map rail and drawer
- preserve existing signed-in organization sync and update the PRD tracker to Wave 4 active

## Validation
- focused Find tests: 49 passed
- acceptance: 2,074 passed, 1 skipped
- snapshots and all RLS suites passed
- production build passed
- visual regression: 30 passed
- performance budgets passed
- pre-push guardrails passed

## Scope
Resource collections remain local in this slice. Cross-device account persistence and progressive/stale collected-item resolution remain separate Wave 4 criteria.