### PR TITLE
[STEP S62] feat(find): sync My Map resources to accounts

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **11/35 complete (31%)**, **4 in progress**, and
-**20 not started**.
+revision. Current progress: **13/35 complete (37%)**, **4 in progress**, and
+**18 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -163,9 +163,9 @@ revision. Current progress: **11/35 complete (31%)**, **4 in progress**, and
 
 **Wave 4 — Collect and My Map completion**
 
-- [ ] `wave-4-criterion-1` **In progress:** Let visitors collect and remove nonprofits and resources locally — Evidence: isolated local My Map implementation passes focused lint, 49 focused tests, full acceptance, RLS, build, visual, and performance gates; merge, deployment, and production smoke remain.
-- [ ] `wave-4-criterion-2` **Not started:** Persist signed-in collections across devices with safe idempotent replay.
-- [ ] `wave-4-criterion-3` **Not started:** Build My Map on the existing saved-organization foundation without separate Finder onboarding.
+- [x] `wave-4-criterion-1` **Complete:** Let visitors collect and remove nonprofits and resources locally — Evidence: PR #158 merged as `8f5196ab`; main quality and deployment passed, production `/find` returned `200`, and focused plus full release gates cover local collect, remove, persistence, and hydration.
+- [ ] `wave-4-criterion-2` **In progress:** Persist signed-in collections across devices with safe idempotent replay — Evidence: isolated account-sync implementation now normalizes, merges, and persists resource IDs through the existing authenticated preference endpoint; focused route and preference tests pass 6/6 plus lint.
+- [x] `wave-4-criterion-3` **Complete:** Build My Map on the existing saved-organization foundation without separate Finder onboarding — Evidence: PR #158 renamed and extended the existing saved-organization rail and drawer for nonprofits and resources, retained shared account/navigation behavior, and added no Finder onboarding.
 - [ ] `wave-4-criterion-4` **Not started:** Keep collected records resolvable through loading, empty, stale, and error states.
 - [ ] `wave-4-criterion-5` **Not started:** Verify guest, account, and Builder journeys with RLS, production monitoring, and rollback proof.
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3039,3 +3039,24 @@
   5.9 seconds. A partial dependency install was moved to
   `/private/tmp/coach-house-my-map-partial-node-modules-20260812-1625`; nothing
   was deleted.
+
+2026-08-12 17:29 EDT - released guest My Map and started account persistence.
+
+- PR #158 merged as `8f5196ab`; main quality and deployment passed, and
+  production `/find` returned `200`. Marked Wave 4 criteria 1 and 3 complete:
+  visitor nonprofit/resource collection is released through the existing My
+  Map foundation with no separate Finder onboarding.
+- Started isolated branch `feat/my-map-account-sync-20260812` from that merge.
+  Resource IDs now use the existing authenticated map-preference endpoint and
+  the same bounded remote/local merge and idempotent desired-state PATCH used
+  by saved nonprofits. No migration or new data system was added.
+- Focused account-route and preference coverage passes 6/6 plus lint. The
+  tracker and focused safeguard set passes 43/43; all source guardrails,
+  snapshots, all RLS suites, 2,077 acceptance tests, and the production build
+  pass. No visual baseline changed because this slice changes persistence only.
+  Marked Wave 4 criterion 2 in progress; merge, deployment, and authenticated
+  cross-device proof remain.
+- Quarantined the incomplete dependency tree at
+  `/private/tmp/coach-house-my-map-account-sync-partial-node-modules-20260812-1727`
+  and replaced it with a full copy from the lockfile-matched release worktree;
+  nothing was deleted.

--- a/src/app/api/account/map-preferences/route.ts
+++ b/src/app/api/account/map-preferences/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route"
 
 type MapPreferences = {
+  collectedResourceIds: string[]
   favorites: string[]
   savedQueries: string[]
   recentOrganizationIds: string[]
@@ -28,6 +29,10 @@ function normalizeStringArray(value: unknown, limit = 80) {
 function parseMapPreferences(metadata: unknown): MapPreferences {
   const mapPreferences = isRecord(metadata) && isRecord(metadata.map_preferences) ? metadata.map_preferences : {}
   return {
+    collectedResourceIds: normalizeStringArray(
+      mapPreferences.collectedResourceIds,
+      120,
+    ),
     favorites: normalizeStringArray(mapPreferences.favorites, 120),
     savedQueries: normalizeStringArray(mapPreferences.savedQueries, 40),
     recentOrganizationIds: normalizeStringArray(
@@ -80,6 +85,10 @@ export async function PATCH(request: NextRequest) {
   const current = parseMapPreferences(user.user_metadata ?? {})
 
   const next: MapPreferences = {
+    collectedResourceIds:
+      "collectedResourceIds" in payloadRecord
+        ? normalizeStringArray(payloadRecord.collectedResourceIds, 120)
+        : current.collectedResourceIds,
     favorites:
       "favorites" in payloadRecord
         ? normalizeStringArray(payloadRecord.favorites, 120)

--- a/src/components/public/public-map-index/helpers.ts
+++ b/src/components/public/public-map-index/helpers.ts
@@ -2,6 +2,7 @@ import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import type { PublicMapGroupKey } from "@/lib/public-map/groups"
 
 export type PublicMapPreferences = {
+  collectedResourceIds: string[]
   favorites: string[]
   savedQueries: string[]
   recentOrganizationIds: string[]

--- a/src/components/public/public-map-index/use-public-map-preferences.ts
+++ b/src/components/public/public-map-index/use-public-map-preferences.ts
@@ -98,6 +98,10 @@ export function usePublicMapPreferences({
             ? payload.preferences
             : {}
         const nextFavorites = normalizeStringArray(preferences.favorites, 120)
+        const nextCollectedResourceIds = normalizeStringArray(
+          preferences.collectedResourceIds,
+          120
+        )
         const nextSavedQueries = normalizeStringArray(
           preferences.savedQueries,
           40
@@ -109,6 +113,11 @@ export function usePublicMapPreferences({
         const mergedFavorites = mergeUniqueStrings(
           nextFavorites,
           localFavorites,
+          120
+        )
+        const mergedCollectedResourceIds = mergeUniqueStrings(
+          nextCollectedResourceIds,
+          localCollectedResourceIds,
           120
         )
         const mergedSavedQueries = mergeUniqueStrings(
@@ -123,6 +132,10 @@ export function usePublicMapPreferences({
         )
         const shouldSyncMergedPreferences =
           !stringArraysEqual(mergedFavorites, nextFavorites) ||
+          !stringArraysEqual(
+            mergedCollectedResourceIds,
+            nextCollectedResourceIds
+          ) ||
           !stringArraysEqual(mergedSavedQueries, nextSavedQueries) ||
           !stringArraysEqual(
             mergedRecentOrganizationIds,
@@ -132,6 +145,7 @@ export function usePublicMapPreferences({
         if (!cancelled) {
           shouldSkipRemoteSyncRef.current = !shouldSyncMergedPreferences
           setFavorites(mergedFavorites)
+          setCollectedResourceIds(mergedCollectedResourceIds)
           setSavedQueries(mergedSavedQueries)
           setRecentOrganizationIds(mergedRecentOrganizationIds)
           setPreferenceMode("authenticated")
@@ -212,6 +226,7 @@ export function usePublicMapPreferences({
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
+              collectedResourceIds,
               favorites,
               savedQueries,
               recentOrganizationIds,
@@ -235,7 +250,13 @@ export function usePublicMapPreferences({
         clearTimeout(saveTimerRef.current)
       }
     }
-  }, [favorites, preferenceMode, recentOrganizationIds, savedQueries])
+  }, [
+    collectedResourceIds,
+    favorites,
+    preferenceMode,
+    recentOrganizationIds,
+    savedQueries,
+  ])
 
   return {
     collectedResourceIds,

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -176,21 +176,25 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
     criteria: defineCriteria(4, [
       {
         evidence: [
-          "Isolated local My Map implementation passes focused lint, 49 focused tests, full acceptance, RLS, build, visual, and performance gates; merge, deployment, and production smoke remain",
+          "PR #158 merged as 8f5196ab; main quality and deployment passed, production /find returned 200, and focused plus full release gates cover local collect, remove, persistence, and hydration",
         ],
-        state: "in_progress",
+        state: "complete",
         title:
           "Let visitors collect and remove nonprofits and resources locally",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Isolated account-sync implementation normalizes, merges, and persists resource IDs through the existing authenticated preference endpoint; focused route and preference tests pass 6/6 plus lint",
+        ],
+        state: "in_progress",
         title:
           "Persist signed-in collections across devices with safe idempotent replay",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "PR #158 extended the existing saved-organization rail and drawer for nonprofits and resources while retaining shared account and navigation behavior and adding no Finder onboarding",
+        ],
+        state: "complete",
         title:
           "Build My Map on the existing saved-organization foundation without separate Finder onboarding",
       },

--- a/tests/acceptance/account-map-preferences-route.test.ts
+++ b/tests/acceptance/account-map-preferences-route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const { createSupabaseRouteHandlerClientMock } = vi.hoisted(() => ({
+  createSupabaseRouteHandlerClientMock: vi.fn(),
+}))
+
+vi.mock("@/lib/supabase/route", () => ({
+  createSupabaseRouteHandlerClient: createSupabaseRouteHandlerClientMock,
+}))
+
+function buildSupabaseStub(mapPreferences: Record<string, unknown> = {}) {
+  const updateUser = vi.fn().mockResolvedValue({ error: null })
+  return {
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: "user-1",
+              email: "member@example.test",
+              user_metadata: { map_preferences: mapPreferences },
+            },
+          },
+          error: null,
+        }),
+        updateUser,
+      },
+    },
+    updateUser,
+  }
+}
+
+function buildPatchRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/account/map-preferences", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("account map preferences route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns normalized account-backed resource collections", async () => {
+    const { supabase } = buildSupabaseStub({
+      collectedResourceIds: ["resource-1", " resource-2 ", "resource-1"],
+    })
+    createSupabaseRouteHandlerClientMock.mockReturnValue(supabase)
+
+    const { GET } = await import("@/app/api/account/map-preferences/route")
+    const response = await GET(
+      new NextRequest("http://localhost/api/account/map-preferences")
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      preferences: {
+        collectedResourceIds: ["resource-1", "resource-2"],
+      },
+    })
+  })
+
+  it("persists resource collections without replacing other preferences", async () => {
+    const { supabase, updateUser } = buildSupabaseStub({
+      favorites: ["organization-1"],
+      savedQueries: ["food access"],
+      recentOrganizationIds: ["organization-2"],
+    })
+    createSupabaseRouteHandlerClientMock.mockReturnValue(supabase)
+
+    const { PATCH } = await import("@/app/api/account/map-preferences/route")
+    const response = await PATCH(
+      buildPatchRequest({
+        collectedResourceIds: ["resource-1", " resource-2 ", "resource-1"],
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateUser).toHaveBeenCalledWith({
+      data: {
+        map_preferences: {
+          collectedResourceIds: ["resource-1", "resource-2"],
+          favorites: ["organization-1"],
+          savedQueries: ["food access"],
+          recentOrganizationIds: ["organization-2"],
+        },
+      },
+    })
+  })
+
+  it("replays the same desired collection state idempotently", async () => {
+    const { supabase, updateUser } = buildSupabaseStub()
+    createSupabaseRouteHandlerClientMock.mockReturnValue(supabase)
+
+    const { PATCH } = await import("@/app/api/account/map-preferences/route")
+    const desiredState = { collectedResourceIds: ["resource-1"] }
+    const first = await PATCH(buildPatchRequest(desiredState))
+    const replay = await PATCH(buildPatchRequest(desiredState))
+
+    expect(first.status).toBe(200)
+    expect(replay.status).toBe(200)
+    expect(updateUser).toHaveBeenCalledTimes(2)
+    expect(updateUser.mock.calls[0]).toEqual(updateUser.mock.calls[1])
+  })
+})

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1183,12 +1183,12 @@ describe("finance release planning graph", () => {
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
-      complete: 11,
+      complete: 13,
       inProgress: 4,
-      notStarted: 20,
+      notStarted: 18,
       total: 35,
     })
-    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(31)
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(37)
     expect(sourceCriteria).toHaveLength(35)
     expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
       trackedCriteria.map((criterion) => criterion.id)
@@ -1277,9 +1277,9 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      complete: 11,
-      percentage: 31,
-      remaining: 24,
+      complete: 13,
+      percentage: 37,
+      remaining: 22,
       total: 35,
       waveId: "wave-2-signup-legal",
       waveLabel: "Wave 2: Signup, recovery, and legal",

--- a/tests/acceptance/public-map-preferences.test.ts
+++ b/tests/acceptance/public-map-preferences.test.ts
@@ -32,6 +32,8 @@ describe("public map preferences", () => {
     expect(surfaceSource).not.toContain("isSavingPreferences")
     expect(preferencesSource).toContain('method: "PATCH"')
     expect(preferencesSource).toContain("COLLECTED_RESOURCES_STORAGE_KEY")
+    expect(preferencesSource).toContain("mergedCollectedResourceIds")
+    expect(preferencesSource).toContain("collectedResourceIds,")
     expect(preferencesSource).toContain(
       'if (preferenceMode === "unknown" || preferenceMode === "authenticated")'
     )


### PR DESCRIPTION
## Scope
- persist collected resource IDs in existing account map preferences
- merge account and local collections before bounded replay
- retain the existing saved-organization foundation; no migration or onboarding
- update Wave 4 tracking to 13/35

## Verification
- focused: 43/43
- acceptance: 2,077 passed, 1 skipped
- lint and all source guardrails
- snapshots and RLS
- production build

## Remaining evidence
- authenticated cross-device production proof after merge