### PR TITLE
[STEP S63] fix(find): preserve My Map recovery state

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **13/35 complete (37%)**, **4 in progress**, and
-**18 not started**.
+revision. Current progress: **13/35 complete (37%)**, **5 in progress**, and
+**17 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -166,7 +166,7 @@ revision. Current progress: **13/35 complete (37%)**, **4 in progress**, and
 - [x] `wave-4-criterion-1` **Complete:** Let visitors collect and remove nonprofits and resources locally — Evidence: PR #158 merged as `8f5196ab`; main quality and deployment passed, production `/find` returned `200`, and focused plus full release gates cover local collect, remove, persistence, and hydration.
 - [ ] `wave-4-criterion-2` **In progress:** Persist signed-in collections across devices with safe idempotent replay — Evidence: isolated account-sync implementation now normalizes, merges, and persists resource IDs through the existing authenticated preference endpoint; focused route and preference tests pass 6/6 plus lint.
 - [x] `wave-4-criterion-3` **Complete:** Build My Map on the existing saved-organization foundation without separate Finder onboarding — Evidence: PR #158 renamed and extended the existing saved-organization rail and drawer for nonprofits and resources, retained shared account/navigation behavior, and added no Finder onboarding.
-- [ ] `wave-4-criterion-4` **Not started:** Keep collected records resolvable through loading, empty, stale, and error states.
+- [ ] `wave-4-criterion-4` **In progress:** Keep collected records resolvable through loading, empty, stale, and error states — Evidence: isolated resilience implementation retains resolved collected resource cards during loading and failed refreshes, replaces false-empty states with loading or recovery feedback, permits confirmed unpublishing after successful refresh, and passes 78 focused tests plus lint.
 - [ ] `wave-4-criterion-5` **Not started:** Verify guest, account, and Builder journeys with RLS, production monitoring, and rollback proof.
 
 **Wave 5 — Finance reporting completion**

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3060,3 +3060,17 @@
   `/private/tmp/coach-house-my-map-account-sync-partial-node-modules-20260812-1727`
   and replaced it with a full copy from the lockfile-matched release worktree;
   nothing was deleted.
+
+2026-08-12 18:25 EDT - started My Map loading and recovery resilience.
+
+- PR #159 merged as `6b2ac883`; started isolated branch
+  `feat/my-map-resilience-20260812` from that merge for Wave 4 criterion 4.
+- My Map now retains previously resolved collected resource cards while a
+  refresh is loading or fails, but a confirmed successful refresh can still
+  remove an unpublished resource. Unresolved collected IDs render loading
+  or offline/unavailable recovery feedback instead of the false-empty
+  “Nothing collected yet” state, with an accessible retry action on errors.
+- Focused tracker, resource, preference, and sidebar coverage passes 78/78 plus
+  focused lint, routes, and boundaries. RLS and the production build pass. The
+  exact branch is running on `localhost:3000/find` and focused in Chrome;
+  normal loaded-state visuals are unchanged.

--- a/src/components/public/public-map-index.tsx
+++ b/src/components/public/public-map-index.tsx
@@ -13,7 +13,6 @@ import { useRouter } from "next/navigation"
 import { useTheme } from "next-themes"
 import type mapboxgl from "mapbox-gl"
 import "mapbox-gl/dist/mapbox-gl.css"
-
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
 import {
@@ -238,10 +237,11 @@ export function PublicMapIndex({
     favorites,
     organizationById,
   })
-  const { savedResources, toggleCollectedResource } =
+  const { savedResources, toggleCollectedResource, unresolvedCollectedResourceCount } =
     usePublicMapCollectedResources({
       collectedResourceIds,
       resourceItems,
+      retainMissingResources: resourceItemsLoadStatus !== "ready",
       setCollectedResourceIds,
     })
   const authAction = searchParams.get("auth_action")
@@ -414,6 +414,7 @@ export function PublicMapIndex({
       guides={resourceGuides}
       savedOrganizations={savedOrganizations}
       savedResources={savedResources}
+      unresolvedCollectedResourceCount={unresolvedCollectedResourceCount}
       query={query}
       activeGroup={activeGroup}
       groupCounts={groupCounts}

--- a/src/components/public/public-map-index/map-items-state.ts
+++ b/src/components/public/public-map-index/map-items-state.ts
@@ -1,4 +1,10 @@
-import { useCallback, useMemo, type Dispatch, type SetStateAction } from "react"
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type Dispatch,
+  type SetStateAction,
+} from "react"
 
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import {
@@ -202,19 +208,26 @@ export function usePublicMapSavedOrganizations({
 export function usePublicMapCollectedResources({
   collectedResourceIds,
   resourceItems,
+  retainMissingResources,
   setCollectedResourceIds,
 }: {
   collectedResourceIds: string[]
   resourceItems: ExternalResourceMapItem[]
+  retainMissingResources: boolean
   setCollectedResourceIds: Dispatch<SetStateAction<string[]>>
 }) {
+  const retainedResourcesRef = useRef<ExternalResourceMapItem[]>([])
   const savedResources = useMemo(() => {
-    const resourceById = new Map(resourceItems.map((item) => [item.id, item]))
-    return collectedResourceIds.flatMap((resourceId) => {
-      const item = resourceById.get(resourceId)
-      return item ? [item] : []
+    const resolvedResources = resolvePublicMapCollectedResources({
+      collectedResourceIds,
+      resourceItems,
+      retainedResources: retainMissingResources
+        ? retainedResourcesRef.current
+        : [],
     })
-  }, [collectedResourceIds, resourceItems])
+    retainedResourcesRef.current = resolvedResources
+    return resolvedResources
+  }, [collectedResourceIds, resourceItems, retainMissingResources])
 
   const toggleCollectedResource = useCallback(
     (resourceId: string) => {
@@ -227,5 +240,35 @@ export function usePublicMapCollectedResources({
     [setCollectedResourceIds]
   )
 
-  return { savedResources, toggleCollectedResource }
+  return {
+    savedResources,
+    toggleCollectedResource,
+    unresolvedCollectedResourceCount:
+      collectedResourceIds.length - savedResources.length,
+  }
+}
+
+export function resolvePublicMapCollectedResources({
+  collectedResourceIds,
+  resourceItems,
+  retainedResources = [],
+}: {
+  collectedResourceIds: string[]
+  resourceItems: ExternalResourceMapItem[]
+  retainedResources?: ExternalResourceMapItem[]
+}) {
+  const collectedResourceIdSet = new Set(collectedResourceIds)
+  const resourceById = new Map(
+    retainedResources
+      .filter((item) => collectedResourceIdSet.has(item.id))
+      .map((item) => [item.id, item] as const)
+  )
+  for (const item of resourceItems) {
+    if (collectedResourceIdSet.has(item.id)) resourceById.set(item.id, item)
+  }
+
+  return collectedResourceIds.flatMap((resourceId) => {
+    const item = resourceById.get(resourceId)
+    return item ? [item] : []
+  })
 }

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -56,6 +56,7 @@ type PublicMapSurfaceProps = {
   guides?: PublicMapResourceGuide[]
   savedOrganizations: PublicMapOrganization[]
   savedResources?: ExternalResourceMapItem[]
+  unresolvedCollectedResourceCount?: number
   query: string
   activeGroup: PublicMapGroupFilterKey
   groupCounts: PublicMapGroupFilterCounts
@@ -109,6 +110,7 @@ export function PublicMapSurface({
   guides = [],
   savedOrganizations,
   savedResources = [],
+  unresolvedCollectedResourceCount = 0,
   query,
   activeGroup,
   groupCounts,
@@ -227,6 +229,7 @@ export function PublicMapSurface({
           guides={guides}
           savedOrganizations={savedOrganizations}
           savedResources={savedResources}
+          unresolvedCollectedResourceCount={unresolvedCollectedResourceCount}
           query={query}
           activeGroup={activeGroup}
           groupCounts={groupCounts}

--- a/src/components/public/public-map-index/member-rail.tsx
+++ b/src/components/public/public-map-index/member-rail.tsx
@@ -11,6 +11,7 @@ import {
 
 import BookmarkIcon from "lucide-react/dist/esm/icons/bookmark"
 
+import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
@@ -36,6 +37,7 @@ import {
   filterPublicMapOrganizationIds,
 } from "./search-index"
 import { publicMapListItemMatchesQuery } from "./map-items-state"
+import type { PublicMapResourceItemsLoadStatus } from "./use-resource-map-items"
 
 const PUBLIC_MAP_MEMBER_TABS_LIST_CLASSNAME =
   "mx-auto h-7 w-fit max-w-full min-w-0 justify-center gap-0 self-center p-0"
@@ -50,6 +52,10 @@ type PublicMapMemberRailProps = {
   guides?: PublicMapResourceGuide[]
   savedOrganizations: PublicMapOrganization[]
   savedResources?: ExternalResourceMapItem[]
+  unresolvedCollectedResourceCount?: number
+  resourceItemsLoadStatus?: PublicMapResourceItemsLoadStatus
+  resourceItemsLoadError?: string | null
+  onRetryResourceItems?: () => void
   onActiveTabChange?: (tab: PublicMapMemberTab) => void
   onGuideSelect?: (guideId: string) => void
   onSelectOrganization: (organizationId: string) => void
@@ -119,6 +125,10 @@ export function PublicMapMemberRail({
   guides = [],
   savedOrganizations,
   savedResources = [],
+  unresolvedCollectedResourceCount = 0,
+  resourceItemsLoadStatus = "ready",
+  resourceItemsLoadError = null,
+  onRetryResourceItems,
   onActiveTabChange,
   onGuideSelect,
   onSelectOrganization,
@@ -316,12 +326,21 @@ export function PublicMapMemberRail({
               organizations={filteredSavedOrganizations}
               resources={filteredSavedResources}
               emptyTitle={
-                hasSavedFilters
+                unresolvedCollectedResourceCount > 0 && !hasSavedFilters
+                  ? resourceItemsLoadStatus === "loading"
+                    ? "Loading My Map"
+                    : "Collected resources unavailable"
+                  : hasSavedFilters
                   ? "No collected results"
                   : "Nothing collected yet"
               }
               emptyDescription={
-                hasSavedFilters
+                unresolvedCollectedResourceCount > 0 && !hasSavedFilters
+                  ? resourceItemsLoadStatus === "loading"
+                    ? "Your collected resources will appear here."
+                    : resourceItemsLoadError ??
+                      "Try again to restore your collected resources."
+                  : hasSavedFilters
                   ? "Try a different search or category filter."
                   : "Collect nonprofits and resources to keep them here."
               }
@@ -332,6 +351,31 @@ export function PublicMapMemberRail({
               onToggleCollectedResource={onToggleCollectedResource}
               removable
             />
+            {unresolvedCollectedResourceCount > 0 ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="border-border/70 bg-background/80 text-muted-foreground mx-2 flex shrink-0 items-center justify-between gap-3 rounded-xl border px-3 py-2 text-xs"
+              >
+                <span className="min-w-0 break-words">
+                  {resourceItemsLoadStatus === "loading"
+                    ? "Loading collected resources…"
+                    : resourceItemsLoadError ??
+                      "Some collected resources are temporarily unavailable."}
+                </span>
+                {resourceItemsLoadStatus === "error" && onRetryResourceItems ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-11 shrink-0"
+                    onClick={onRetryResourceItems}
+                  >
+                    Try again
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </TabsContent>
       </Tabs>

--- a/src/components/public/public-map-index/sidebar-contract.ts
+++ b/src/components/public/public-map-index/sidebar-contract.ts
@@ -38,6 +38,7 @@ export type PublicMapSidebarProps = {
   guides?: PublicMapResourceGuide[]
   savedOrganizations?: PublicMapOrganization[]
   savedResources?: ExternalResourceMapItem[]
+  unresolvedCollectedResourceCount?: number
   query: string
   activeGroup: PublicMapGroupFilterKey
   groupCounts: PublicMapGroupFilterCounts

--- a/src/components/public/public-map-index/sidebar-member-panels.tsx
+++ b/src/components/public/public-map-index/sidebar-member-panels.tsx
@@ -16,6 +16,10 @@ export function PublicMapRailPanel({
   guides,
   savedOrganizations,
   savedResources,
+  unresolvedCollectedResourceCount,
+  resourceItemsLoadStatus,
+  resourceItemsLoadError,
+  onRetryResourceItems,
   onGuideSelect,
   onSelectOrganization,
   onSelectResource,
@@ -27,6 +31,14 @@ export function PublicMapRailPanel({
   guides: NonNullable<PublicMapSidebarProps["guides"]>
   savedOrganizations: NonNullable<PublicMapSidebarProps["savedOrganizations"]>
   savedResources: NonNullable<PublicMapSidebarProps["savedResources"]>
+  unresolvedCollectedResourceCount: number
+  resourceItemsLoadStatus: NonNullable<
+    PublicMapSidebarProps["resourceItemsLoadStatus"]
+  >
+  resourceItemsLoadError: string | null
+  onRetryResourceItems: NonNullable<
+    PublicMapSidebarProps["retryResourceItems"]
+  >
   onGuideSelect: PublicMapSidebarProps["onGuideSelect"]
   onSelectOrganization: PublicMapSidebarProps["onSelectOrganization"]
   onSelectResource: PublicMapSidebarProps["onSelectItem"]
@@ -59,6 +71,10 @@ export function PublicMapRailPanel({
             guides={guides}
             savedOrganizations={savedOrganizations}
             savedResources={savedResources}
+            unresolvedCollectedResourceCount={unresolvedCollectedResourceCount}
+            resourceItemsLoadStatus={resourceItemsLoadStatus}
+            resourceItemsLoadError={resourceItemsLoadError}
+            onRetryResourceItems={onRetryResourceItems}
             onGuideSelect={onGuideSelect}
             onSelectOrganization={onSelectOrganization}
             onSelectResource={onSelectResource}

--- a/src/components/public/public-map-index/sidebar.tsx
+++ b/src/components/public/public-map-index/sidebar.tsx
@@ -101,6 +101,7 @@ export function PublicMapSidebar({
   guides = [],
   savedOrganizations = [],
   savedResources = [],
+  unresolvedCollectedResourceCount = 0,
   query,
   activeGroup,
   groupCounts,
@@ -136,20 +137,17 @@ export function PublicMapSidebar({
     () => buildPublicMapDrawerSnapPoints(surfaceHeight),
     [surfaceHeight]
   )
-  const [activeSnapIndex, setActiveSnapIndex] = useState<0 | 1 | 2>(0)
-  const [drawerTab, setDrawerTab] = useState<PublicMapMemberTab>("directory")
+  const [activeSnapIndex, setActiveSnapIndex] = useState<0 | 1 | 2>(0), [drawerTab, setDrawerTab] = useState<PublicMapMemberTab>("directory")
   const activeSnapPoint = snapPoints[activeSnapIndex]
   const drawerIsFullscreen = activeSnapIndex === 2
   const drawerViewportHeight = drawerIsFullscreen
     ? "calc(100% - 1.625rem)"
     : `calc(${activeSnapPoint} - 1.625rem)`
-
   useEffect(() => {
     if (compact && sidebarMode === "hidden") {
       setSidebarMode("search")
     }
   }, [compact, setSidebarMode, sidebarMode])
-
   useEffect(() => {
     if (panelPresentation !== "drawer") return
     if (!panelOpen) {
@@ -252,6 +250,8 @@ export function PublicMapSidebar({
       guides={guides}
       savedOrganizations={savedOrganizations}
       savedResources={savedResources}
+      unresolvedCollectedResourceCount={unresolvedCollectedResourceCount} onRetryResourceItems={retryResourceItems}
+      resourceItemsLoadStatus={resourceItemsLoadStatus} resourceItemsLoadError={resourceItemsLoadError}
       onGuideSelect={onGuideSelect}
       onSelectOrganization={onSelectOrganization}
       onSelectResource={onSelectItem}
@@ -313,6 +313,8 @@ export function PublicMapSidebar({
       guides={guides}
       savedOrganizations={savedOrganizations}
       savedResources={savedResources}
+      unresolvedCollectedResourceCount={unresolvedCollectedResourceCount} onRetryResourceItems={retryResourceItems}
+      resourceItemsLoadStatus={resourceItemsLoadStatus} resourceItemsLoadError={resourceItemsLoadError}
       onActiveTabChange={handleDrawerTabChange}
       onGuideSelect={handleDrawerGuideSelect}
       onSelectOrganization={handleDrawerOrganizationSelect}

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -199,8 +199,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Build My Map on the existing saved-organization foundation without separate Finder onboarding",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Isolated resilience implementation retains resolved collected resource cards during loading and failed refreshes, replaces false-empty states with recovery feedback, permits confirmed unpublishing after successful refresh, and passes 78 focused tests plus lint",
+        ],
+        state: "in_progress",
         title:
           "Keep collected records resolvable through loading, empty, stale, and error states",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1184,8 +1184,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 13,
-      inProgress: 4,
-      notStarted: 18,
+      inProgress: 5,
+      notStarted: 17,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(37)

--- a/tests/acceptance/public-map-sidebar-layout.test.ts
+++ b/tests/acceptance/public-map-sidebar-layout.test.ts
@@ -23,6 +23,7 @@ import {
   filterPublicMapSavedResources,
   PublicMapMemberRail,
 } from "@/components/public/public-map-index/member-rail"
+import { resolvePublicMapCollectedResources } from "@/components/public/public-map-index/map-items-state"
 import { PublicMapSavedRail } from "@/components/public/public-map-index/saved-rail"
 import { PublicMapSidebar } from "@/components/public/public-map-index/sidebar"
 import { PublicMapShellSidebarPanel } from "@/components/public/public-map-index/sidebar-shell-panel"
@@ -1462,6 +1463,67 @@ describe("public map sidebar layout", () => {
     expect(markup).toContain("Food pantry and meal support")
     expect(markup).toContain('aria-label="Remove Seed Food Access from My Map"')
     expect(markup).toContain('aria-pressed="true"')
+  })
+
+  it("retains resolved My Map resources through empty and stale refreshes", () => {
+    const resource = buildResourceItem()
+    const initial = resolvePublicMapCollectedResources({
+      collectedResourceIds: [resource.id],
+      resourceItems: [resource],
+    })
+    const retained = resolvePublicMapCollectedResources({
+      collectedResourceIds: [resource.id],
+      resourceItems: [],
+      retainedResources: initial,
+    })
+
+    expect(retained).toEqual([resource])
+    expect(
+      resolvePublicMapCollectedResources({
+        collectedResourceIds: [resource.id],
+        resourceItems: [],
+        retainedResources: [],
+      })
+    ).toEqual([])
+    expect(
+      resolvePublicMapCollectedResources({
+        collectedResourceIds: [],
+        resourceItems: [],
+        retainedResources: retained,
+      })
+    ).toEqual([])
+  })
+
+  it("does not show a false-empty My Map while collected resources resolve", () => {
+    const loadingMarkup = renderToStaticMarkup(
+      React.createElement(PublicMapMemberRail, {
+        savedOrganizations: [],
+        savedResources: [],
+        unresolvedCollectedResourceCount: 2,
+        resourceItemsLoadStatus: "loading",
+        onSelectOrganization: () => {},
+        onToggleFavorite: () => {},
+      })
+    )
+    const errorMarkup = renderToStaticMarkup(
+      React.createElement(PublicMapMemberRail, {
+        savedOrganizations: [],
+        savedResources: [],
+        unresolvedCollectedResourceCount: 2,
+        resourceItemsLoadStatus: "error",
+        resourceItemsLoadError: PUBLIC_MAP_RESOURCE_ITEMS_OFFLINE_ERROR,
+        onRetryResourceItems: () => {},
+        onSelectOrganization: () => {},
+        onToggleFavorite: () => {},
+      })
+    )
+
+    expect(loadingMarkup).toContain("Loading My Map")
+    expect(loadingMarkup).toContain("Loading collected resources…")
+    expect(loadingMarkup).not.toContain("Nothing collected yet")
+    expect(errorMarkup).toContain("Collected resources unavailable")
+    expect(errorMarkup).toContain("You’re offline")
+    expect(errorMarkup).toContain("Try again")
   })
 
   it("uses the right rail directory detail view when a map organization is selected", () => {


### PR DESCRIPTION
## Scope
- retain resolved collected resource cards while the index reloads or fails
- replace false-empty My Map states with accessible loading and recovery feedback
- allow confirmed successful refreshes to remove unpublished resources
- keep the existing My Map layout and controls

## Verification
- focused tracker/resource/preference/sidebar: 78 passed
- acceptance: 2,079 passed, 1 skipped
- lint and all source guardrails
- snapshots and RLS
- production build
- localhost:3000 focused in Chrome

## Remaining evidence
- merge, deployment, and production smoke