### PR TITLE
[STEP S65] Complete core Finance reporting evidence

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **15/35 complete (43%)**, **4 in progress**, and
-**16 not started**.
+revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
+**13 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -171,9 +171,9 @@ revision. Current progress: **15/35 complete (43%)**, **4 in progress**, and
 
 **Wave 5 — Finance reporting completion**
 
-- [ ] `wave-5-criterion-1` **Not started:** Connect read-only external activity with explicit source and freshness labels.
-- [ ] `wave-5-criterion-2` **Not started:** Provide a simple accessible graph, text equivalent, Activity list, and History.
-- [ ] `wave-5-criterion-3` **Not started:** Reconcile visible reporting to authorized external records and correction history.
+- [ ] `wave-5-criterion-1` **In progress:** Connect read-only external activity with explicit source and freshness labels — Evidence: PR #121 released the bounded read-only Stripe activity connection and source-labeled records; branch `feat/finance-reporting-wave5-20260812` adds visible read-only source and last-sync states with 70 focused Finance tests passing. Merge and production proof remain.
+- [x] `wave-5-criterion-2` **Complete:** Provide a simple accessible graph, text equivalent, Activity list, and History — Evidence: PR #121 merged as `a6016231` and deployed to both production projects; the source-composition rail exposes an accessible description plus visible labeled amounts, focused coverage passes, and authenticated production verification opened both Activity and History.
+- [x] `wave-5-criterion-3` **Complete:** Reconcile visible reporting to authorized external records and correction history — Evidence: merged reporting counts only verified, non-corrected USD inflows while retaining corrected originals and replacements in History; immutable correction storage, organization-scoped reads, focused correction coverage, and the connected Finance RLS matrix passed with PR #121 and its production deployment.
 - [ ] `wave-5-criterion-4` **Not started:** Verify accurate CSV and PDF exports.
 - [ ] `wave-5-criterion-5` **Not started:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback.
 
@@ -238,6 +238,22 @@ revision. Current progress: **15/35 complete (43%)**, **4 in progress**, and
 - The legal text remains pending qualified legal approval. The exact entity
   details, postal address, retention schedule, vendor agreements, and state-law
   applicability must be confirmed before production release.
+
+#### Wave 5 current evidence
+
+- PR #121 merged as `a6016231` with the Finance workspace release. GitHub
+  quality passed, and both Vercel production deployments completed
+  successfully on 2026-08-09.
+- The authenticated production rollout verified that Finance opens its Activity
+  and History views. The shipped source rail has a programmatic text equivalent
+  and visible source labels and amounts.
+- Raised, source composition, and program progress derive only from authorized,
+  verified, non-corrected USD inflows. Corrected originals and their verified
+  replacements remain linked and visible in History behind organization-scoped
+  RLS; the connected Finance matrix passed.
+- Branch `feat/finance-reporting-wave5-20260812` exposes the already-loaded
+  Stripe sync timestamp as explicit freshness copy and preserves the read-only
+  source label across connected, never-synced, syncing, and failed states.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3094,3 +3094,30 @@
   (`6b2ac883`), then PR #158 (`8f5196ab`) as needed. Existing saved
   organizations and account data are preserved; no destructive data rollback
   is required.
+
+2026-08-12 22:16 EDT - advanced Wave 5 Finance reporting toward production proof.
+
+- Started isolated branch `feat/finance-reporting-wave5-20260812` from
+  `origin/main` at `c6b96ef2`; preserved all existing worktrees and avoided the
+  stale root branch.
+- Confirmed PR #121 merged as `a6016231`, its quality gate passed, both Vercel
+  production deployments succeeded, and the authenticated rollout opened the
+  released Activity and History views.
+- Kept the existing Finance surface compact while making a connected Stripe
+  row explicitly read-only and exposing its loaded last-sync timestamp. The
+  freshness copy handles never-synced, running, successful, and failed states
+  and updates immediately after a manual sync.
+- Focused Finance acceptance passes `70/70`, and the Finance plan plus feature
+  set passes `107/107`. The first full gate correctly rejected stale Prototype
+  Lab counts; aligning its Wave 5 states resolved the only failure.
+- Final `pnpm check:quality` passes all lint and source guardrails, snapshots,
+  `2,080` acceptance tests with one intentional skip, fiscal and Finance RLS,
+  the 111-page production build, `30/30` visuals, and performance budgets.
+- Read-only production browser proof displayed Activity, Connections, the
+  accessible empty Raised graph, and History with no console errors. Stripe is
+  not configured for the current organization, so no connection, sync, record,
+  account, database, migration, or production mutation occurred.
+- Marked Wave 5 criteria 2 and 3 complete from merged production and connected
+  RLS evidence. Criterion 1 remains in progress until this branch merges and
+  deploys. Progress is `17/35` complete (`49%`), with `5` in progress and `13`
+  not started.

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -219,24 +219,30 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
   {
     id: "wave-5-finance-reporting",
     sequence: 5,
-    status: "queued",
+    status: "active",
     title: "Finance reporting completion",
     criteria: defineCriteria(5, [
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "PR #121 released bounded read-only Stripe activity and source-labeled records; branch feat/finance-reporting-wave5-20260812 adds visible read-only source and last-sync states with 70 focused Finance tests passing; merge and production proof remain",
+        ],
+        state: "in_progress",
         title:
           "Connect read-only external activity with explicit source and freshness labels",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "PR #121 merged as a6016231 and deployed to both production projects; the source-composition rail exposes an accessible description plus visible labeled amounts, focused coverage passes, and authenticated production verification opened Activity and History",
+        ],
+        state: "complete",
         title:
           "Provide a simple accessible graph, text equivalent, Activity list, and History",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Merged reporting counts only verified, non-corrected USD inflows while retaining corrected originals and replacements in History; immutable correction storage, organization-scoped reads, focused correction coverage, and connected Finance RLS passed with PR #121 and production deployment",
+        ],
+        state: "complete",
         title:
           "Reconcile visible reporting to authorized external records and correction history",
       },

--- a/src/features/workspace-finance/components/workspace-finance-stripe-connection.tsx
+++ b/src/features/workspace-finance/components/workspace-finance-stripe-connection.tsx
@@ -21,6 +21,7 @@ import type {
   WorkspaceFinanceRecordInput,
   WorkspaceFinanceStripeConnectionInput,
 } from "../types"
+import { formatWorkspaceFinanceSyncFreshness } from "../lib/sync-freshness"
 
 const RECORD_TYPES = [
   { value: "donation", label: "Donations" },
@@ -30,8 +31,8 @@ const RECORD_TYPES = [
 ] as const
 
 function accountLabel(accountId: string | null | undefined) {
-  if (!accountId) return "Connected"
-  return `Connected · ${accountId.slice(-4)}`
+  if (!accountId) return "Read-only source"
+  return `Read-only source · Account ••••${accountId.slice(-4)}`
 }
 
 export function WorkspaceFinanceStripeConnection({
@@ -45,9 +46,14 @@ export function WorkspaceFinanceStripeConnection({
   }) => void
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [lastSyncedAt, setLastSyncedAt] = useState(
+    connection.lastSyncedAt ?? null
+  )
+  const [syncStatus, setSyncStatus] = useState(connection.lastSyncStatus)
   const [pending, startTransition] = useTransition()
 
   function sync() {
+    setSyncStatus("running")
     startTransition(async () => {
       try {
         const response = await fetch(
@@ -63,6 +69,8 @@ export function WorkspaceFinanceStripeConnection({
         if (!response.ok || !result.records || !result.syncedAt) {
           throw new Error(result.error || "Stripe could not be synced.")
         }
+        setLastSyncedAt(result.syncedAt)
+        setSyncStatus("succeeded")
         onSynced({ records: result.records, syncedAt: result.syncedAt })
         toast.success(
           result.imported
@@ -70,6 +78,7 @@ export function WorkspaceFinanceStripeConnection({
             : "Stripe is up to date"
         )
       } catch (error) {
+        setSyncStatus("failed")
         toast.error(
           error instanceof Error ? error.message : "Stripe could not be synced."
         )
@@ -90,6 +99,17 @@ export function WorkspaceFinanceStripeConnection({
               ? accountLabel(connection.accountId)
               : "Read-only transaction sync"}
           </span>
+          {connection.state === "connected" ? (
+            <span
+              aria-live="polite"
+              className="text-muted-foreground mt-0.5 block truncate text-xs"
+            >
+              {formatWorkspaceFinanceSyncFreshness({
+                lastSyncedAt,
+                status: syncStatus,
+              })}
+            </span>
+          ) : null}
         </span>
 
         {connection.state === "connected" ? (
@@ -101,7 +121,7 @@ export function WorkspaceFinanceStripeConnection({
             disabled={pending}
             onClick={sync}
           >
-            {pending ? "Syncing" : "Sync"}
+            {pending ? "Syncing…" : "Sync"}
           </Button>
         ) : connection.state === "not_connected" ? (
           <Button

--- a/src/features/workspace-finance/lib/sync-freshness.ts
+++ b/src/features/workspace-finance/lib/sync-freshness.ts
@@ -1,0 +1,28 @@
+import type { WorkspaceFinanceStripeConnectionInput } from "../types"
+
+type WorkspaceFinanceSyncStatus = NonNullable<
+  WorkspaceFinanceStripeConnectionInput["lastSyncStatus"]
+>
+
+export function formatWorkspaceFinanceSyncFreshness({
+  lastSyncedAt,
+  status,
+  locale,
+}: {
+  lastSyncedAt?: string | null
+  status?: WorkspaceFinanceSyncStatus | null
+  locale?: string
+}) {
+  const syncedAt = lastSyncedAt ? new Date(lastSyncedAt) : null
+  const hasValidSync = syncedAt && !Number.isNaN(syncedAt.getTime())
+  const lastSyncLabel = hasValidSync
+    ? `Last synced ${new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(syncedAt)}`
+    : "Not synced yet"
+
+  if (status === "running") return `Sync in progress · ${lastSyncLabel}`
+  if (status === "failed") return `Sync failed · ${lastSyncLabel}`
+  return lastSyncLabel
+}

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1169,26 +1169,24 @@ describe("finance release planning graph", () => {
     )
     expect(FINANCE_PLAN_WAVES.map((wave) => wave.status)).toEqual([
       "production_verified",
-      "active",
-      "active",
-      "active",
-      ...Array(3).fill("queued"),
+      ...Array(4).fill("active"),
+      ...Array(2).fill("queued"),
     ])
     expect(FINANCE_PLAN_WAVE_STATUS_COUNTS).toEqual({
-      active: 3,
+      active: 4,
       codeComplete: 0,
       previewVerified: 0,
       productionVerified: 1,
-      queued: 3,
+      queued: 2,
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
-      complete: 15,
-      inProgress: 4,
-      notStarted: 16,
+      complete: 17,
+      inProgress: 5,
+      notStarted: 13,
       total: 35,
     })
-    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(43)
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(49)
     expect(sourceCriteria).toHaveLength(35)
     expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
       trackedCriteria.map((criterion) => criterion.id)
@@ -1277,9 +1275,9 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      complete: 15,
-      percentage: 43,
-      remaining: 20,
+      complete: 17,
+      percentage: 49,
+      remaining: 18,
       total: 35,
       waveId: "wave-2-signup-legal",
       waveLabel: "Wave 2: Signup, recovery, and legal",

--- a/tests/acceptance/workspace-finance.test.ts
+++ b/tests/acceptance/workspace-finance.test.ts
@@ -24,6 +24,7 @@ import {
   mapGrantsGovSearchResponse,
 } from "@/features/workspace-finance/lib/grants-gov"
 import { parseWorkspaceFinanceCsvPreview } from "@/features/workspace-finance/lib/csv-preview"
+import { formatWorkspaceFinanceSyncFreshness } from "@/features/workspace-finance/lib/sync-freshness"
 import { WORKSPACE_FINANCE_SAMPLE_INPUT } from "@/features/workspace-finance/lib/sample-data"
 import { loadWorkspaceFinanceReadModel } from "@/features/workspace-finance/server/read-model"
 
@@ -583,6 +584,9 @@ describe("workspace-finance feature contract", () => {
     expect(source).toContain("<WorkspaceFinanceStripeConnection")
     expect(stripe).toContain("Stripe")
     expect(stripe).toContain("Read-only transaction sync")
+    expect(stripe).toContain("Read-only source")
+    expect(stripe).toContain("formatWorkspaceFinanceSyncFreshness")
+    expect(stripe).toContain('aria-live="polite"')
     expect(stripe).toContain("Continue to Stripe")
     expect(stripe).not.toContain("OAuth")
     expect(source).toContain("Manual record")
@@ -601,6 +605,27 @@ describe("workspace-finance feature contract", () => {
       manualAction.indexOf("createSupabaseAdminClient()")
     )
     expect(manualAction).toContain('.eq("user_id", activeOrg.orgId)')
+  })
+
+  it("labels Stripe source freshness without implying money movement", () => {
+    expect(
+      formatWorkspaceFinanceSyncFreshness({
+        lastSyncedAt: "2026-08-12T18:30:00.000Z",
+        status: "succeeded",
+        locale: "en-US",
+      })
+    ).toMatch(/^Last synced Aug 12, 2026, /)
+    expect(
+      formatWorkspaceFinanceSyncFreshness({
+        lastSyncedAt: "2026-08-12T18:30:00.000Z",
+        status: "failed",
+        locale: "en-US",
+      })
+    ).toMatch(/^Sync failed · Last synced Aug 12, 2026, /)
+    expect(formatWorkspaceFinanceSyncFreshness({ status: "running" })).toBe(
+      "Sync in progress · Not synced yet"
+    )
+    expect(formatWorkspaceFinanceSyncFreshness({})).toBe("Not synced yet")
   })
 
   it("normalizes manual records without guessing reconciliation or corrections", () => {


### PR DESCRIPTION
## What changed

- keep connected Stripe activity explicitly labeled as a read-only source
- display locale-aware last-sync freshness, including never-synced, running, and failed states
- align the root PRD and Prototype Lab tracker at 17/35 complete (49%)
- close Wave 5 criteria 2 and 3 from merged production, browser, and connected-RLS evidence

## Why

The released Finance reporting already had the accessible source rail, Activity, History, verified-only totals, immutable corrections, and organization-scoped reads. The remaining visible gap was that a connected Stripe row hid the read-only boundary and its loaded sync timestamp.

## Validation

- `pnpm check:quality`
  - 2,080 acceptance tests passed; 1 intentional skip
  - fiscal and Finance RLS passed
  - 111-page production build passed
  - 30/30 visual tests passed
  - performance budgets passed
- focused Finance and plan coverage: 107/107
- authenticated production read-only check: Activity, Connections, accessible empty Raised graph, and History rendered with no console errors

## Release and rollback

Criterion 1 remains in progress until merge and production deployment prove the new freshness labels. Roll back code with a normal revert of this PR; no migration or data rollback is required.

## UI artifacts

The production Finance History tab is left focused in Chrome for review. The current organization has no configured Stripe connection, so the new connected freshness row is covered by focused tests and will be checked after deployment where available.
