### PR TITLE
[STEP S68] Add revocable Finance board sharing

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -174,8 +174,8 @@ revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
 - [x] `wave-5-criterion-1` **Complete:** Connect read-only external activity with explicit source and freshness labels — Evidence: PR #121 released the bounded read-only Stripe activity connection and source-labeled records; PR #162 merged as `09810abd`, main quality passed, both Vercel production deployments succeeded, and production serves the Finance route with the released read-only source plus never-synced, running, successful, and failed freshness states covered by 70 focused Finance tests.
 - [x] `wave-5-criterion-2` **Complete:** Provide a simple accessible graph, text equivalent, Activity list, and History — Evidence: PR #121 merged as `a6016231` and deployed to both production projects; the source-composition rail exposes an accessible description plus visible labeled amounts, focused coverage passes, and authenticated production verification opened both Activity and History.
 - [x] `wave-5-criterion-3` **Complete:** Reconcile visible reporting to authorized external records and correction history — Evidence: merged reporting counts only verified, non-corrected USD inflows while retaining corrected originals and replacements in History; immutable correction storage, organization-scoped reads, focused correction coverage, and the connected Finance RLS matrix passed with PR #121 and its production deployment.
-- [ ] `wave-5-criterion-4` **In progress:** Verify accurate CSV and PDF exports — Evidence: branch `feat/finance-report-exports-20260813` adds owner and explicitly authorized board-member exports through the existing Finance read boundary. CSV preserves signed cents, UTC timestamps, program, correction, and verification fields while neutralizing user-controlled spreadsheet formulas; PDF provides the same authorized history in a paginated landscape report. Nine focused export, authorization, route, and failure tests plus the production build pass; merge, deployment, and production download proof remain.
-- [ ] `wave-5-criterion-5` **Not started:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback.
+- [x] `wave-5-criterion-4` **Complete:** Verify accurate CSV and PDF exports — Evidence: PR #164 merged as `f6ceb0c4`; main quality and both production deployments passed, and authenticated production displays the released CSV/PDF Export control. Nine focused tests parse the PDF and verify exact CSV fields, authorization, route behavior, formula neutralization, pagination, and bounded failures.
+- [ ] `wave-5-criterion-5` **In progress:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback — Evidence: branch `feat/finance-board-sharing-20260813` gives the owner a compact existing-board-member control for explicit Viewer, Manager, and No access states. Grants and revocations use the existing scoped table; RLS now requires current board membership and automatically removes a grant when membership is removed, added, or changes role so stale access cannot revive. Eight focused action, loader, failure, and UI tests, 30 existing Finance tests, local Finance RLS, targeted guardrails, and the production build pass; merge, deployment, authenticated production proof, and rollback remain.
 
 **Wave 6 — Qualified resources and varied guides**
 
@@ -254,6 +254,13 @@ revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
 - Branch `feat/finance-reporting-wave5-20260812` exposes the already-loaded
   Stripe sync timestamp as explicit freshness copy and preserves the read-only
   source label across connected, never-synced, syncing, and failed states.
+- PR #164 merged as `f6ceb0c4`; main quality and both production deployments
+  passed, and authenticated production shows the released CSV/PDF Export
+  control. Focused tests parse the PDF and verify exact CSV fields and safety.
+- Branch `feat/finance-board-sharing-20260813` adds explicit owner-managed
+  Viewer, Manager, and No access states for existing board members. Database
+  authorization requires current board membership and prevents stale grants
+  from surviving or reviving across membership changes.
 
 #### Wave branch rules
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3158,3 +3158,23 @@
 - Progress remains `18/35` complete (`51%`), with `6` in progress and `11` not
   started. No account, Finance record, connection, database, or production data
   mutation occurred.
+
+2026-08-13 15:35 EDT - completed Finance exports and implemented revocable board sharing.
+
+- PR #164 merged as `f6ceb0c4`; main quality and both production deployments
+  passed, and authenticated production displays the released CSV/PDF Export
+  control. Nine focused tests parse the PDF and verify exact CSV fields,
+  authorization, formula neutralization, pagination, routes, and failures.
+- Started isolated branch `feat/finance-board-sharing-20260813` from that merge.
+  The owner can assign Viewer, Manager, or No access to existing board members
+  from one compact Finance control. No invitation or public-link scope was added.
+- Grants and revocations use the existing organization-scoped access table.
+  A forward RLS migration requires current board membership and removes a grant
+  when that membership is inserted, removed, or changes role, preventing stale
+  access from surviving or reviving. It does not purge unrelated records.
+- Eight focused sharing tests, 30 existing Finance tests, Finance RLS, targeted
+  source guardrails, and the 112-route production build pass. Merge, production
+  role proof, and the exact revert remain before sharing is complete.
+- Progress is `19/35` complete (`54%`), with `6` in progress and `10` not
+  started. No account, membership, Finance record, connection, or production
+  data mutation occurred.

--- a/src/actions/workspace-finance-access.ts
+++ b/src/actions/workspace-finance-access.ts
@@ -1,0 +1,88 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { resolveAuthenticatedAppContext } from "@/lib/auth/request-context"
+
+import type { WorkspaceFinanceAccessLevel } from "../features/workspace-finance/types"
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+type WorkspaceFinanceAccessUpdateResult =
+  | { accessLevel: WorkspaceFinanceAccessLevel | null; ok: true }
+  | { error: string }
+
+function revalidateFinanceRoutes() {
+  revalidatePath("/workspace")
+  revalidatePath("/my-organization")
+  revalidatePath("/organization/workspace")
+}
+
+export async function updateWorkspaceFinanceAccess({
+  accessLevel,
+  memberId,
+}: {
+  accessLevel: WorkspaceFinanceAccessLevel | null
+  memberId: string
+}): Promise<WorkspaceFinanceAccessUpdateResult> {
+  if (
+    !UUID_PATTERN.test(memberId) ||
+    (accessLevel !== null &&
+      accessLevel !== "viewer" &&
+      accessLevel !== "manager")
+  ) {
+    return { error: "Choose a valid board member and access level." }
+  }
+
+  let context: Awaited<ReturnType<typeof resolveAuthenticatedAppContext>>
+  try {
+    context = await resolveAuthenticatedAppContext()
+  } catch {
+    return { error: "You must be signed in to share Finance." }
+  }
+
+  const { activeOrg, supabase, user } = context
+  if (activeOrg.role !== "owner" || activeOrg.orgId !== user.id) {
+    return { error: "Only the organization owner can share Finance." }
+  }
+
+  const { data: boardMembership, error: membershipError } = await supabase
+    .from("organization_memberships")
+    .select("member_id")
+    .eq("org_id", activeOrg.orgId)
+    .eq("member_id", memberId)
+    .eq("role", "board")
+    .maybeSingle<{ member_id: string }>()
+
+  if (membershipError || !boardMembership) {
+    return { error: "Choose a current board member." }
+  }
+
+  const mutation = accessLevel
+    ? await supabase.from("organization_finance_access").upsert(
+        {
+          access_level: accessLevel,
+          granted_by: user.id,
+          member_id: memberId,
+          org_id: activeOrg.orgId,
+        },
+        { onConflict: "org_id,member_id" }
+      )
+    : await supabase
+        .from("organization_finance_access")
+        .delete()
+        .eq("org_id", activeOrg.orgId)
+        .eq("member_id", memberId)
+
+  if (mutation.error) {
+    return {
+      error: accessLevel
+        ? "Unable to update Finance access."
+        : "Unable to revoke Finance access.",
+    }
+  }
+
+  revalidateFinanceRoutes()
+  return { accessLevel, ok: true }
+}

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
@@ -86,7 +86,8 @@ export default async function MyOrganizationPage({
   }
   const acceleratorViewRequested = searchState.viewParam === "accelerator"
   const presentationMode =
-    searchState.modeParam === "present" || searchState.modeParam === "presentation"
+    searchState.modeParam === "present" ||
+    searchState.modeParam === "presentation"
   const { orgRow, profile, initialProfile, roadmapSections } =
     await measureServerStep(
       "workspace.content.load_profile_context",
@@ -383,6 +384,7 @@ export default async function MyOrganizationPage({
     { thresholdMs: 1_000 }
   )
   const financeInput = await loadOrganizationWorkspaceFinanceInput({
+    canManageAccess: role === "owner" && orgId === user.id,
     orgId,
     programs: organizationEditorData.programs,
     supabase,

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -250,14 +250,16 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
       },
       {
         evidence: [
-          "Branch feat/finance-report-exports-20260813 adds authorized CSV and PDF history exports with signed cents, UTC timestamps, program, correction, verification, spreadsheet-formula safety, pagination, and bounded failure handling; nine focused tests and the production build pass, while merge, deployment, and production download proof remain",
+          "PR #164 merged as f6ceb0c4; main quality and both production deployments passed, authenticated production displays the CSV/PDF Export control, and nine focused tests parse the PDF and verify exact CSV fields, authorization, formula safety, pagination, routes, and bounded failures",
         ],
-        state: "in_progress",
+        state: "complete",
         title: "Verify accurate CSV and PDF exports",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "Branch feat/finance-board-sharing-20260813 adds explicit owner-managed Viewer, Manager, and No access states for existing board members; RLS requires current board membership and removes grants across membership changes, with focused action, loader, UI, and local RLS proof passing while merge, production proof, and rollback remain",
+        ],
+        state: "in_progress",
         title:
           "Verify explicit revocable board sharing, role isolation, failure states, and production rollback",
       },

--- a/src/features/workspace-finance/components/workspace-finance-access-popover.tsx
+++ b/src/features/workspace-finance/components/workspace-finance-access-popover.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import Link from "next/link"
+import UsersIcon from "lucide-react/dist/esm/icons/users"
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+
+import { updateWorkspaceFinanceAccess } from "@/actions/workspace-finance-access"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import type {
+  WorkspaceFinanceAccessInput,
+  WorkspaceFinanceAccessLevel,
+  WorkspaceFinanceAccessMember,
+} from "../types"
+
+const NO_ACCESS = "none"
+
+function accessLabel(accessLevel: WorkspaceFinanceAccessLevel | null) {
+  if (accessLevel === "manager") return "Can manage"
+  if (accessLevel === "viewer") return "Can view"
+  return "No access"
+}
+
+export function WorkspaceFinanceAccessPopover({
+  initialAccess,
+}: {
+  initialAccess: WorkspaceFinanceAccessInput
+}) {
+  const [members, setMembers] = useState(initialAccess.members)
+  const [pendingMemberId, setPendingMemberId] = useState<string | null>(null)
+  const [pendingRevocation, setPendingRevocation] =
+    useState<WorkspaceFinanceAccessMember | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  function updateMemberAccess(
+    member: WorkspaceFinanceAccessMember,
+    accessLevel: WorkspaceFinanceAccessLevel | null
+  ) {
+    const previousAccessLevel = member.accessLevel
+    setMembers((current) =>
+      current.map((candidate) =>
+        candidate.memberId === member.memberId
+          ? { ...candidate, accessLevel }
+          : candidate
+      )
+    )
+    setPendingMemberId(member.memberId)
+
+    startTransition(async () => {
+      const result = await updateWorkspaceFinanceAccess({
+        accessLevel,
+        memberId: member.memberId,
+      })
+      setPendingMemberId(null)
+
+      if ("error" in result) {
+        setMembers((current) =>
+          current.map((candidate) =>
+            candidate.memberId === member.memberId
+              ? { ...candidate, accessLevel: previousAccessLevel }
+              : candidate
+          )
+        )
+        toast.error(result.error)
+        return
+      }
+
+      toast.success(
+        accessLevel ? "Finance access updated" : "Finance access revoked"
+      )
+    })
+  }
+
+  function handleAccessChange(
+    member: WorkspaceFinanceAccessMember,
+    value: string
+  ) {
+    if (value === NO_ACCESS) {
+      if (member.accessLevel) setPendingRevocation(member)
+      return
+    }
+    if (value === "viewer" || value === "manager") {
+      if (value !== member.accessLevel) updateMemberAccess(member, value)
+    }
+  }
+
+  return (
+    <>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            aria-label="Share Finance with board members"
+            size="sm"
+            variant="outline"
+          >
+            <UsersIcon aria-hidden="true" />
+            <span className="hidden sm:inline">Share</span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          className="w-[min(24rem,calc(100vw-2rem))] p-0"
+          sideOffset={8}
+        >
+          <div className="px-4 pt-4 pb-3">
+            <h2 className="text-sm font-semibold">Board access</h2>
+            <p className="text-muted-foreground mt-1 text-xs leading-5">
+              Share read-only reporting or Finance management with existing
+              board members.
+            </p>
+          </div>
+
+          <div className="max-h-80 divide-y overflow-y-auto overscroll-contain border-t">
+            {initialAccess.state === "error" ? (
+              <p className="text-muted-foreground px-4 py-6 text-sm">
+                Board access could not be loaded. Close this menu and try again.
+              </p>
+            ) : members.length ? (
+              members.map((member) => {
+                const memberPending =
+                  pending && pendingMemberId === member.memberId
+                return (
+                  <div
+                    key={member.memberId}
+                    className="flex min-w-0 items-center gap-3 px-4 py-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">
+                        {member.email}
+                      </p>
+                      <p className="text-muted-foreground mt-0.5 text-xs">
+                        Board member
+                      </p>
+                    </div>
+                    <Select
+                      disabled={pending}
+                      value={member.accessLevel ?? NO_ACCESS}
+                      onValueChange={(value) =>
+                        handleAccessChange(member, value)
+                      }
+                    >
+                      <SelectTrigger
+                        aria-busy={memberPending}
+                        aria-label={`Finance access for ${member.email}`}
+                        className="h-11 w-36 sm:h-8"
+                        size="sm"
+                      >
+                        <SelectValue>
+                          {accessLabel(member.accessLevel)}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent align="end">
+                        <SelectItem value={NO_ACCESS}>No access</SelectItem>
+                        <SelectItem value="viewer">Can view</SelectItem>
+                        <SelectItem value="manager">Can manage</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )
+              })
+            ) : (
+              <div className="px-4 py-6 text-sm">
+                <p className="text-muted-foreground">No board members yet.</p>
+                <Button asChild className="mt-3" size="sm" variant="outline">
+                  <Link href="/people">Manage people</Link>
+                </Button>
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <AlertDialog
+        open={Boolean(pendingRevocation)}
+        onOpenChange={(open) => {
+          if (!open) setPendingRevocation(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke Finance access?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRevocation?.email ?? "This board member"} will immediately
+              lose access to Finance reporting and exports.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep access</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                if (pendingRevocation) {
+                  updateMemberAccess(pendingRevocation, null)
+                }
+                setPendingRevocation(null)
+              }}
+            >
+              Revoke access
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/features/workspace-finance/components/workspace-finance-panel.tsx
+++ b/src/features/workspace-finance/components/workspace-finance-panel.tsx
@@ -14,6 +14,7 @@ export function WorkspaceFinancePanel({
   return (
     <section aria-label="Finance" className="h-full min-h-0 overflow-hidden">
       <WorkspaceFinanceViewTabs
+        access={input.access}
         initialView={finance.initialView}
         programInputs={input.programs ?? []}
         raisingPrograms={finance.raisingPrograms}

--- a/src/features/workspace-finance/components/workspace-finance-view-tabs.tsx
+++ b/src/features/workspace-finance/components/workspace-finance-view-tabs.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { normalizeWorkspaceFinanceInput } from "../lib"
 import { WORKSPACE_FINANCE_SAMPLE_INPUT } from "../lib/sample-data"
 import type {
+  WorkspaceFinanceAccessInput,
   WorkspaceFinanceCorrectionInput,
   WorkspaceFinanceDataState,
   WorkspaceFinanceOpportunityInput,
@@ -19,6 +20,7 @@ import type {
   WorkspaceFinanceView,
 } from "../types"
 import { WorkspaceFinanceActivityDashboard } from "./workspace-finance-activity-dashboard"
+import { WorkspaceFinanceAccessPopover } from "./workspace-finance-access-popover"
 import { WorkspaceFinanceConnections } from "./workspace-finance-connections"
 import { WorkspaceFinanceExportMenu } from "./workspace-finance-export-menu"
 import { WorkspaceFinanceHistory } from "./workspace-finance-history"
@@ -30,6 +32,7 @@ const SAMPLE_DATA_AVAILABLE =
   process.env.NEXT_PUBLIC_ENABLE_FINANCE_SAMPLE_DATA === "true"
 
 export function WorkspaceFinanceViewTabs({
+  access,
   initialView,
   programInputs,
   raisingPrograms,
@@ -39,6 +42,7 @@ export function WorkspaceFinanceViewTabs({
   recordsState,
   stripeConnection,
 }: {
+  access?: WorkspaceFinanceAccessInput
   initialView: WorkspaceFinanceView
   programInputs: WorkspaceFinanceProgramInput[]
   raisingPrograms: WorkspaceFinanceRaisingProgram[]
@@ -197,6 +201,9 @@ export function WorkspaceFinanceViewTabs({
               checked={sampleDataEnabled}
               onCheckedChange={setSampleDataEnabled}
             />
+          ) : null}
+          {access?.canManage ? (
+            <WorkspaceFinanceAccessPopover initialAccess={access} />
           ) : null}
           <WorkspaceFinanceExportMenu disabled={sampleDataEnabled} />
           <WorkspaceFinanceConnections

--- a/src/features/workspace-finance/server/access.ts
+++ b/src/features/workspace-finance/server/access.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase"
+
+import type {
+  WorkspaceFinanceAccessInput,
+  WorkspaceFinanceAccessLevel,
+} from "../types"
+
+type BoardMembershipRow = {
+  member_email: string
+  member_id: string
+}
+
+type FinanceAccessRow = {
+  access_level: WorkspaceFinanceAccessLevel
+  member_id: string
+}
+
+export async function loadOrganizationFinanceAccess({
+  canManage,
+  orgId,
+  supabase,
+}: {
+  canManage: boolean
+  orgId: string
+  supabase: SupabaseClient<Database>
+}): Promise<WorkspaceFinanceAccessInput> {
+  if (!canManage) return { canManage: false, members: [], state: "ready" }
+
+  const [membershipsResult, accessResult] = await Promise.all([
+    supabase
+      .from("organization_memberships")
+      .select("member_id,member_email")
+      .eq("org_id", orgId)
+      .eq("role", "board")
+      .order("member_email", { ascending: true })
+      .limit(50)
+      .returns<BoardMembershipRow[]>(),
+    supabase
+      .from("organization_finance_access")
+      .select("member_id,access_level")
+      .eq("org_id", orgId)
+      .limit(50)
+      .returns<FinanceAccessRow[]>(),
+  ])
+
+  if (membershipsResult.error || accessResult.error) {
+    return { canManage: true, members: [], state: "error" }
+  }
+
+  const accessByMemberId = new Map(
+    (accessResult.data ?? []).map((access) => [
+      access.member_id,
+      access.access_level,
+    ])
+  )
+
+  return {
+    canManage: true,
+    members: (membershipsResult.data ?? []).map((membership) => ({
+      accessLevel: accessByMemberId.get(membership.member_id) ?? null,
+      email: membership.member_email,
+      memberId: membership.member_id,
+    })),
+    state: "ready",
+  }
+}

--- a/src/features/workspace-finance/server/workspace-input.ts
+++ b/src/features/workspace-finance/server/workspace-input.ts
@@ -12,29 +12,41 @@ import { loadOrganizationFinanceOpportunities } from "./opportunities"
 import { loadOrganizationFinanceRecords } from "./records"
 import { loadWorkspaceFinanceReadModel } from "./read-model"
 import { loadOrganizationFinanceStripeConnection } from "./stripe-connection"
+import { loadOrganizationFinanceAccess } from "./access"
 
-export function loadOrganizationWorkspaceFinanceInput({
+export async function loadOrganizationWorkspaceFinanceInput({
+  canManageAccess = false,
   orgId,
   programs,
   supabase,
 }: {
+  canManageAccess?: boolean
   orgId: string
   programs: WorkspaceFinanceOrganizationProgramInput[]
   supabase: SupabaseClient<Database>
 }): Promise<WorkspaceFinanceInput> {
-  return loadWorkspaceFinanceReadModel({
-    programs: buildWorkspaceFinanceProgramInputs(programs),
-    loadRecords: async () => {
-      const [records, engagementEvents] = await Promise.all([
-        loadOrganizationFinanceRecords({ orgId, supabase }),
-        loadOrganizationFinanceEngagementEvents({ orgId, supabase }),
-      ])
+  const [finance, access] = await Promise.all([
+    loadWorkspaceFinanceReadModel({
+      programs: buildWorkspaceFinanceProgramInputs(programs),
+      loadRecords: async () => {
+        const [records, engagementEvents] = await Promise.all([
+          loadOrganizationFinanceRecords({ orgId, supabase }),
+          loadOrganizationFinanceEngagementEvents({ orgId, supabase }),
+        ])
 
-      return [...records, ...engagementEvents]
-    },
-    loadOpportunities: () =>
-      loadOrganizationFinanceOpportunities({ orgId, supabase }),
-    loadStripeConnection: () =>
-      loadOrganizationFinanceStripeConnection({ orgId, supabase }),
-  })
+        return [...records, ...engagementEvents]
+      },
+      loadOpportunities: () =>
+        loadOrganizationFinanceOpportunities({ orgId, supabase }),
+      loadStripeConnection: () =>
+        loadOrganizationFinanceStripeConnection({ orgId, supabase }),
+    }),
+    loadOrganizationFinanceAccess({
+      canManage: canManageAccess,
+      orgId,
+      supabase,
+    }),
+  ])
+
+  return { ...finance, access }
 }

--- a/src/features/workspace-finance/types.ts
+++ b/src/features/workspace-finance/types.ts
@@ -1,6 +1,20 @@
 export type WorkspaceFinanceView = "activity" | "history"
 export type WorkspaceFinanceDataState = "idle" | "loading" | "ready" | "error"
 
+export type WorkspaceFinanceAccessLevel = "viewer" | "manager"
+
+export type WorkspaceFinanceAccessMember = {
+  accessLevel: WorkspaceFinanceAccessLevel | null
+  email: string
+  memberId: string
+}
+
+export type WorkspaceFinanceAccessInput = {
+  canManage: boolean
+  members: WorkspaceFinanceAccessMember[]
+  state: "ready" | "error"
+}
+
 export type WorkspaceFinanceProgramInput = {
   id: string
   title?: string | null
@@ -121,6 +135,7 @@ export type WorkspaceFinanceStripeConnectionInput = {
 }
 
 export type WorkspaceFinanceInput = {
+  access?: WorkspaceFinanceAccessInput
   initialView?: WorkspaceFinanceView | null
   programs?: WorkspaceFinanceProgramInput[]
   opportunities?: WorkspaceFinanceOpportunityInput[]

--- a/supabase/migrations/20260813153500_require_board_membership_for_finance_access.sql
+++ b/supabase/migrations/20260813153500_require_board_membership_for_finance_access.sql
@@ -1,0 +1,102 @@
+set search_path = public;
+
+create or replace function public.is_current_organization_board_member(
+  target_org_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.organization_memberships membership
+    where membership.org_id = target_org_id
+      and membership.member_id = (select auth.uid())
+      and membership.role = 'board'
+  );
+$$;
+
+revoke all on function public.is_current_organization_board_member(uuid)
+  from public;
+grant execute on function public.is_current_organization_board_member(uuid)
+  to authenticated, service_role;
+
+create or replace function public.can_view_organization_finance(target_org_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    (select auth.uid()) is not null
+    and (
+      target_org_id = (select auth.uid())
+      or exists (
+        select 1
+        from public.organization_finance_access access
+        where access.org_id = target_org_id
+          and access.member_id = (select auth.uid())
+          and public.is_current_organization_board_member(target_org_id)
+      )
+    );
+$$;
+
+drop policy if exists "organization_finance_access_select"
+  on public.organization_finance_access;
+
+create policy "organization_finance_access_select"
+  on public.organization_finance_access
+  for select
+  to authenticated
+  using (
+    org_id = (select auth.uid())
+    or (
+      member_id = (select auth.uid())
+      and (select public.is_current_organization_board_member(org_id))
+    )
+  );
+
+create or replace function public.revoke_finance_access_after_membership_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_org_id uuid;
+  target_member_id uuid;
+begin
+  if tg_op = 'DELETE' then
+    target_org_id := old.org_id;
+    target_member_id := old.member_id;
+  else
+    target_org_id := new.org_id;
+    target_member_id := new.member_id;
+  end if;
+
+  if tg_op = 'DELETE'
+    or tg_op = 'INSERT'
+    or old.role is distinct from new.role then
+    delete from public.organization_finance_access
+    where org_id = target_org_id
+      and member_id = target_member_id;
+  end if;
+
+  return null;
+end;
+$$;
+
+revoke all on function public.revoke_finance_access_after_membership_change()
+  from public;
+
+drop trigger if exists revoke_finance_access_after_membership_change
+  on public.organization_memberships;
+
+create trigger revoke_finance_access_after_membership_change
+after insert or delete or update of role
+on public.organization_memberships
+for each row
+execute function public.revoke_finance_access_after_membership_change();

--- a/supabase/tests/finance-storage-rls.assertions.sql
+++ b/supabase/tests/finance-storage-rls.assertions.sql
@@ -301,6 +301,48 @@ end;
 $$;
 reset role;
 
+update public.organization_memberships
+set role = 'member'
+where org_id = '00000000-0000-0000-0000-000000000001'
+  and member_id = '00000000-0000-0000-0000-000000000003';
+
+set role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-0000-0000-000000000003',
+  false
+);
+do $$
+begin
+  if (select count(*) from public.organization_finance_records) <> 0
+    or (select count(*) from public.organization_finance_access) <> 0 then
+    raise exception 'Former board member retained Finance access';
+  end if;
+end;
+$$;
+reset role;
+
+update public.organization_memberships
+set role = 'board'
+where org_id = '00000000-0000-0000-0000-000000000001'
+  and member_id = '00000000-0000-0000-0000-000000000003';
+
+set role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '00000000-0000-0000-0000-000000000003',
+  false
+);
+do $$
+begin
+  if (select count(*) from public.organization_finance_records) <> 0
+    or (select count(*) from public.organization_finance_access) <> 0 then
+    raise exception 'Re-added board member inherited stale Finance access';
+  end if;
+end;
+$$;
+reset role;
+
 set role authenticated;
 select set_config(
   'request.jwt.claim.sub',

--- a/supabase/tests/finance-storage-rls.bootstrap.sql
+++ b/supabase/tests/finance-storage-rls.bootstrap.sql
@@ -90,5 +90,33 @@ insert into public.organizations (user_id) values
   ('00000000-0000-0000-0000-000000000001'),
   ('00000000-0000-0000-0000-000000000002');
 
+create type public.organization_member_role
+  as enum ('owner', 'admin', 'staff', 'board', 'member');
+
+create table public.organization_memberships (
+  org_id uuid not null references public.organizations(user_id) on delete cascade,
+  member_id uuid not null references auth.users(id) on delete cascade,
+  role public.organization_member_role not null default 'member',
+  member_email text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  primary key (org_id, member_id)
+);
+
+create index organization_memberships_member_id_idx
+  on public.organization_memberships (member_id, org_id);
+
+insert into public.organization_memberships (
+  org_id,
+  member_id,
+  role,
+  member_email
+) values (
+  '00000000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000003',
+  'board',
+  'board@example.org'
+);
+
 insert into public.platform_staff_members (user_id, access_level) values
   ('00000000-0000-0000-0000-000000000004', 'developer');

--- a/supabase/tests/finance-storage-rls.test.mjs
+++ b/supabase/tests/finance-storage-rls.test.mjs
@@ -153,10 +153,13 @@ try {
   runSql(
     "supabase/migrations/20260808203000_add_finance_stripe_app_connection.sql"
   )
+  runSql(
+    "supabase/migrations/20260813153500_require_board_membership_for_finance_access.sql"
+  )
   runSql("supabase/tests/finance-storage-rls.assertions.sql")
 
   console.log(
-    "[finance-rls] Access, cross-tenant, direct-write, verification, correction, Stripe provider evidence, and immutable-evidence checks passed."
+    "[finance-rls] Board access, membership revocation, cross-tenant, direct-write, verification, correction, Stripe provider evidence, and immutable-evidence checks passed."
   )
 } finally {
   if (started) {

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1181,12 +1181,12 @@ describe("finance release planning graph", () => {
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
-      complete: 18,
+      complete: 19,
       inProgress: 6,
-      notStarted: 11,
+      notStarted: 10,
       total: 35,
     })
-    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(51)
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(54)
     expect(sourceCriteria).toHaveLength(35)
     expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
       trackedCriteria.map((criterion) => criterion.id)
@@ -1275,9 +1275,9 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      complete: 18,
-      percentage: 51,
-      remaining: 17,
+      complete: 19,
+      percentage: 54,
+      remaining: 16,
       total: 35,
       waveId: "wave-2-signup-legal",
       waveLabel: "Wave 2: Signup, recovery, and legal",

--- a/tests/acceptance/workspace-finance-access.test.ts
+++ b/tests/acceptance/workspace-finance-access.test.ts
@@ -1,0 +1,235 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { resolveAuthenticatedAppContextMock } = vi.hoisted(() => ({
+  resolveAuthenticatedAppContextMock: vi.fn(),
+}))
+
+vi.mock("@/lib/auth/request-context", () => ({
+  resolveAuthenticatedAppContext: resolveAuthenticatedAppContextMock,
+}))
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+import { updateWorkspaceFinanceAccess } from "@/actions/workspace-finance-access"
+import { loadOrganizationFinanceAccess } from "@/features/workspace-finance/server/access"
+
+const MEMBER_ID = "11111111-1111-4111-8111-111111111111"
+
+function resolvedBuilder<T>(result: T) {
+  const builder = {
+    delete: vi.fn(),
+    eq: vi.fn(),
+    limit: vi.fn(),
+    maybeSingle: vi.fn(),
+    order: vi.fn(),
+    returns: vi.fn(),
+    select: vi.fn(),
+    then: (resolve: (value: T) => unknown) =>
+      Promise.resolve(result).then(resolve),
+  }
+  builder.delete.mockReturnValue(builder)
+  builder.eq.mockReturnValue(builder)
+  builder.limit.mockReturnValue(builder)
+  builder.order.mockReturnValue(builder)
+  builder.select.mockReturnValue(builder)
+  return builder
+}
+
+function createActionContext({ role = "owner" }: { role?: string } = {}) {
+  const membership = resolvedBuilder({
+    data: { member_id: MEMBER_ID },
+    error: null,
+  })
+  membership.maybeSingle.mockResolvedValue({
+    data: { member_id: MEMBER_ID },
+    error: null,
+  })
+  const access = resolvedBuilder({ error: null })
+  const upsert = vi.fn().mockResolvedValue({ error: null })
+  const from = vi.fn((table: string) => {
+    if (table === "organization_memberships") return membership
+    if (table === "organization_finance_access") {
+      return { ...access, upsert }
+    }
+    throw new Error(`Unexpected table ${table}`)
+  })
+
+  return {
+    context: {
+      activeOrg: { orgId: "owner", role },
+      supabase: { from },
+      user: { id: "owner" },
+    },
+    access,
+    membership,
+    upsert,
+  }
+}
+
+describe("workspace Finance board access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("denies invalid targets and non-owner actors before mutation", async () => {
+    await expect(
+      updateWorkspaceFinanceAccess({ accessLevel: "viewer", memberId: "bad" })
+    ).resolves.toEqual({
+      error: "Choose a valid board member and access level.",
+    })
+    expect(resolveAuthenticatedAppContextMock).not.toHaveBeenCalled()
+
+    const { context, upsert } = createActionContext({ role: "board" })
+    resolveAuthenticatedAppContextMock.mockResolvedValue(context)
+    await expect(
+      updateWorkspaceFinanceAccess({
+        accessLevel: "viewer",
+        memberId: MEMBER_ID,
+      })
+    ).resolves.toEqual({
+      error: "Only the organization owner can share Finance.",
+    })
+    expect(upsert).not.toHaveBeenCalled()
+  })
+
+  it("requires a current board membership", async () => {
+    const { context, membership, upsert } = createActionContext()
+    membership.maybeSingle.mockResolvedValue({ data: null, error: null })
+    resolveAuthenticatedAppContextMock.mockResolvedValue(context)
+
+    await expect(
+      updateWorkspaceFinanceAccess({
+        accessLevel: "manager",
+        memberId: MEMBER_ID,
+      })
+    ).resolves.toEqual({ error: "Choose a current board member." })
+    expect(upsert).not.toHaveBeenCalled()
+  })
+
+  it("grants viewer or manager access through the existing scoped table", async () => {
+    const { context, upsert } = createActionContext()
+    resolveAuthenticatedAppContextMock.mockResolvedValue(context)
+
+    await expect(
+      updateWorkspaceFinanceAccess({
+        accessLevel: "manager",
+        memberId: MEMBER_ID,
+      })
+    ).resolves.toEqual({ accessLevel: "manager", ok: true })
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        access_level: "manager",
+        granted_by: "owner",
+        member_id: MEMBER_ID,
+        org_id: "owner",
+      },
+      { onConflict: "org_id,member_id" }
+    )
+  })
+
+  it("returns a bounded error when a grant cannot be saved", async () => {
+    const { context, upsert } = createActionContext()
+    upsert.mockResolvedValue({ error: { code: "42501" } })
+    resolveAuthenticatedAppContextMock.mockResolvedValue(context)
+
+    await expect(
+      updateWorkspaceFinanceAccess({
+        accessLevel: "viewer",
+        memberId: MEMBER_ID,
+      })
+    ).resolves.toEqual({ error: "Unable to update Finance access." })
+  })
+
+  it("revokes access through an organization and member scoped delete", async () => {
+    const { access, context } = createActionContext()
+    resolveAuthenticatedAppContextMock.mockResolvedValue(context)
+
+    await expect(
+      updateWorkspaceFinanceAccess({
+        accessLevel: null,
+        memberId: MEMBER_ID,
+      })
+    ).resolves.toEqual({ accessLevel: null, ok: true })
+    expect(access.delete).toHaveBeenCalledOnce()
+    expect(access.eq).toHaveBeenNthCalledWith(1, "org_id", "owner")
+    expect(access.eq).toHaveBeenNthCalledWith(2, "member_id", MEMBER_ID)
+  })
+
+  it("loads only board members and reconciles their current access", async () => {
+    const memberships = resolvedBuilder({ data: [], error: null })
+    memberships.returns.mockResolvedValue({
+      data: [{ member_email: "board@example.org", member_id: MEMBER_ID }],
+      error: null,
+    })
+    const access = resolvedBuilder({ data: [], error: null })
+    access.returns.mockResolvedValue({
+      data: [{ access_level: "viewer", member_id: MEMBER_ID }],
+      error: null,
+    })
+    const supabase = {
+      from: vi.fn((table: string) =>
+        table === "organization_memberships" ? memberships : access
+      ),
+    }
+
+    await expect(
+      loadOrganizationFinanceAccess({
+        canManage: true,
+        orgId: "owner",
+        supabase: supabase as never,
+      })
+    ).resolves.toEqual({
+      canManage: true,
+      members: [
+        {
+          accessLevel: "viewer",
+          email: "board@example.org",
+          memberId: MEMBER_ID,
+        },
+      ],
+      state: "ready",
+    })
+    expect(memberships.eq).toHaveBeenCalledWith("role", "board")
+  })
+
+  it("returns a recoverable state when board access cannot load", async () => {
+    const memberships = resolvedBuilder({ data: [], error: null })
+    memberships.returns.mockResolvedValue({
+      data: null,
+      error: { code: "42501" },
+    })
+    const access = resolvedBuilder({ data: [], error: null })
+    access.returns.mockResolvedValue({ data: [], error: null })
+    const supabase = {
+      from: vi.fn((table: string) =>
+        table === "organization_memberships" ? memberships : access
+      ),
+    }
+
+    await expect(
+      loadOrganizationFinanceAccess({
+        canManage: true,
+        orgId: "owner",
+        supabase: supabase as never,
+      })
+    ).resolves.toEqual({ canManage: true, members: [], state: "error" })
+  })
+
+  it("keeps the owner control compact and confirms revocation", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/features/workspace-finance/components/workspace-finance-access-popover.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(source).toContain('aria-label="Share Finance with board members"')
+    expect(source).toContain("Revoke Finance access?")
+    expect(source).toContain("No board members yet.")
+    expect(source).toContain('href="/people"')
+    expect(source).toContain('initialAccess.state === "error"')
+  })
+})


### PR DESCRIPTION
## Summary
- let organization owners grant existing board members Viewer or Manager Finance access
- confirm revocation and expose bounded loading, empty, and failure states
- require current board membership in RLS and clear grants on membership changes so stale access cannot revive
- mark production-deployed report exports complete and Finance sharing in progress

## Safety
- no public links, invitations, service-role sharing writes, or broad data access
- migration does not purge existing records; it only enforces current membership and future grant cleanup
- rollback: revert this PR; the prior access table and Finance records remain intact

## Verification
- 73 focused Finance/tracker tests
- 2,097 full acceptance tests; 1 intentional skip
- Finance RLS including role loss and re-add denial
- source guardrails and 112-route production build