### PR TITLE
[STEP S69] Refresh exact resource publication counts

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
-**13 not started**.
+revision. Current progress: **20/35 complete (57%)**, **6 in progress**, and
+**9 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -175,11 +175,11 @@ revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
 - [x] `wave-5-criterion-2` **Complete:** Provide a simple accessible graph, text equivalent, Activity list, and History — Evidence: PR #121 merged as `a6016231` and deployed to both production projects; the source-composition rail exposes an accessible description plus visible labeled amounts, focused coverage passes, and authenticated production verification opened both Activity and History.
 - [x] `wave-5-criterion-3` **Complete:** Reconcile visible reporting to authorized external records and correction history — Evidence: merged reporting counts only verified, non-corrected USD inflows while retaining corrected originals and replacements in History; immutable correction storage, organization-scoped reads, focused correction coverage, and the connected Finance RLS matrix passed with PR #121 and its production deployment.
 - [x] `wave-5-criterion-4` **Complete:** Verify accurate CSV and PDF exports — Evidence: PR #164 merged as `f6ceb0c4`; main quality and both production deployments passed, and authenticated production displays the released CSV/PDF Export control. Nine focused tests parse the PDF and verify exact CSV fields, authorization, route behavior, formula neutralization, pagination, and bounded failures.
-- [ ] `wave-5-criterion-5` **In progress:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback — Evidence: branch `feat/finance-board-sharing-20260813` gives the owner a compact existing-board-member control for explicit Viewer, Manager, and No access states. Grants and revocations use the existing scoped table; RLS now requires current board membership and automatically removes a grant when membership is removed, added, or changes role so stale access cannot revive. Eight focused action, loader, failure, and UI tests, 30 existing Finance tests, local Finance RLS, targeted guardrails, and the production build pass; merge, deployment, authenticated production proof, and rollback remain.
+- [ ] `wave-5-criterion-5` **In progress:** Verify explicit revocable board sharing, role isolation, failure states, and production rollback — Evidence: PR #165 merged as `2387591e`; main quality, the production migration, and both production deployments passed. Owners can explicitly assign Viewer, Manager, or No access to existing board members; RLS requires current board membership and removes grants across membership changes so stale access cannot revive. Eight focused action, loader, failure, and UI tests, 30 existing Finance tests, and Finance RLS pass; one authenticated production grant/revoke journey and a forward database rollback remain.
 
 **Wave 6 — Qualified resources and varied guides**
 
-- [ ] `wave-6-criterion-1` **Not started:** Report exact candidate, complete, verified, publishable, promoted, and public counts.
+- [x] `wave-6-criterion-1` **Complete:** Report exact candidate, complete, verified, publishable, promoted, and public counts — Evidence: the 2026-08-13 read-only count refresh reports the expanded local curated snapshot separately at `5,046` candidates and `741` complete/verified/publishable records. Exact production aggregates report `2,184` staged and parity at `853` verified, administrator-approved, publishable, promoted, and anonymous public rows; artifact hashes and reproduction steps are recorded.
 - [ ] `wave-6-criterion-2` **Not started:** Close provider, eligibility, summary, access, contact, and comparison evidence gaps by cohort.
 - [ ] `wave-6-criterion-3` **Not started:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records.
 - [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
@@ -261,6 +261,18 @@ revision. Current progress: **17/35 complete (49%)**, **5 in progress**, and
   Viewer, Manager, and No access states for existing board members. Database
   authorization requires current board membership and prevents stale grants
   from surviving or reviving across membership changes.
+
+#### Wave 6 current evidence
+
+- The [2026-08-13 count refresh](./2026-08-13-resource-map-count-refresh.md)
+  separates local artifacts from production instead of combining unlike
+  snapshots into a false funnel.
+- The expanded local curated snapshot has `5,046` candidates and `741`
+  contract-complete, independently verified, publishable records.
+- Production has `2,184` staged records and exact parity at `853` verified,
+  administrator-approved, publishable, promoted, and anonymous public rows.
+- No raw intake queue, synthetic seed, local preview, or unverified discovery
+  record was added to `/find`.
 
 #### Wave branch rules
 

--- a/docs/plans/2026-08-13-resource-map-count-refresh.md
+++ b/docs/plans/2026-08-13-resource-map-count-refresh.md
@@ -1,0 +1,67 @@
+# Resource Map Count Refresh
+
+Measured: 2026-08-13 15:56 EDT
+
+Status: read-only Wave 6 evidence. No source was fetched, imported, reviewed,
+promoted, unpublished, or otherwise changed.
+
+## Exact Counts
+
+Local artifacts and production are separate snapshots. They are not added
+together or treated as one conversion funnel.
+
+| Scope                   | Stage                                              | Count | Evidence                                                             |
+| ----------------------- | -------------------------------------------------- | ----: | -------------------------------------------------------------------- |
+| Local intake            | Primary discovered candidates                      | 4,249 | `candidate-records.jsonl` line count                                 |
+| Local curated expansion | Candidates including the Brooklyn directory cohort | 5,046 | `source-family-plus-brooklyn-preview.jsonl` line count               |
+| Local curated expansion | Contract-complete                                  |   741 | Deterministic enrichment coverage audit                              |
+| Local curated expansion | Independently verified                             |   741 | Approved verification, two comparisons, no blocking gaps             |
+| Local curated expansion | Publishable                                        |   741 | Deterministic publication contract audit                             |
+| Production              | Staged import records                              | 2,184 | Exact aggregate read                                                 |
+| Production              | Contract-verified                                  |   853 | Approved verification fields and completed clean verification ledger |
+| Production              | Administrator-approved                             |   853 | Identified reviewer and review time                                  |
+| Production              | Publishable                                        |   853 | Verification and approval gates combined                             |
+| Production              | Promoted                                           |   853 | Promoted state and canonical organization/service IDs                |
+| Production              | Public                                             |   853 | Complete pagination through the anonymous sanitized RPC              |
+
+The expanded local snapshot has `4,305` records that are not currently
+publishable. Production has `1,331` staged records that have not crossed the
+verified publication contract. Production parity is exact at
+verified = approved = publishable = promoted = public = `853`.
+
+## Definitions
+
+- `Contract-complete` requires title, named service, summary, category,
+  location or service area, contact or actionable provider link, eligibility,
+  access instructions, source, two comparison passes, and approved independent
+  verification.
+- `Contract-verified` additionally requires a real verification timestamp and
+  a completed approved verification-ledger entry with no issues, unsupported
+  claims, or contradictions.
+- `Publishable` requires the verification contract plus an identified
+  administrator and review timestamp.
+- `Promoted` requires the promoted import state and both canonical IDs.
+- `Public` counts every row returned through the paginated anonymous sanitized
+  projection, not raw import records or local preview rows.
+
+## Snapshot Identity
+
+| Artifact                                    |       Bytes | Modified             | SHA-256                                                            |
+| ------------------------------------------- | ----------: | -------------------- | ------------------------------------------------------------------ |
+| `candidate-records.jsonl`                   | 146,262,663 | 2026-07-02 14:57 EDT | `17489e22dfb7fd2c20d4158f0f5bacaab3fff5536327317d0a455845b0e9eab9` |
+| `source-family-plus-brooklyn-preview.jsonl` | 236,550,259 | 2026-08-02 23:20 EDT | `5220520505c1f06668591e7be7b17c15679b26c179c9ef34247d94051c677051` |
+
+## Reproduction
+
+Local counts are reproducible without network or writes:
+
+```bash
+wc -l data/resource-map/.engine/candidate-records.jsonl
+node scripts/resource-map/audit-enrichment-coverage.mjs \
+  --input data/resource-map/.engine/source-family-plus-brooklyn-preview.jsonl
+```
+
+Production values came from exact aggregate reads over staged records and a
+complete 500-row pagination of `get_resource_map_public_items_page`. Only the
+counts above were retained; no production row contents or credentials were
+written to this report.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3178,3 +3178,24 @@
 - Progress is `19/35` complete (`54%`), with `6` in progress and `10` not
   started. No account, membership, Finance record, connection, or production
   data mutation occurred.
+
+2026-08-13 15:56 EDT - production-verified Finance sharing release and refreshed exact resource counts.
+
+- PR #165 merged as `2387591e`; main quality, Supabase production migration,
+  GitHub Pages, and both Vercel production deployments passed. The disposable
+  Supabase preview had returned `400 Resource has been removed`, but the same
+  migration applied successfully to the linked production ledger.
+- Finance sharing remains in progress until one authenticated owner-to-board
+  grant/revoke journey and a forward database rollback are complete. No
+  production access grant, membership, or Finance record was mutated here.
+- Started isolated branch `docs/wave6-resource-counts-20260813` from the merge.
+  A read-only audit reports the expanded local curated snapshot separately at
+  `5,046` candidates and `741` complete, independently verified, publishable
+  records. The primary intake queue remains `4,249` records.
+- Exact production aggregates report `2,184` staged records and parity at `853`
+  verified, administrator-approved, publishable, promoted, and anonymous public
+  rows. Artifact hashes, definitions, and reproduction steps are recorded in a
+  dated count report; no source fetch, import, review, promotion, unpublish, or
+  production data mutation occurred.
+- Marked Wave 6 criterion 1 complete. Progress is `20/35` (`57%`), with `6` in
+  progress and `9` not started.

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -257,7 +257,7 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
       },
       {
         evidence: [
-          "Branch feat/finance-board-sharing-20260813 adds explicit owner-managed Viewer, Manager, and No access states for existing board members; RLS requires current board membership and removes grants across membership changes, with focused action, loader, UI, and local RLS proof passing while merge, production proof, and rollback remain",
+          "PR #165 merged as 2387591e; main quality, the production migration, and both deployments passed, while focused sharing and RLS proof covers explicit Viewer, Manager, No access, role isolation, and failures; one authenticated production grant/revoke journey and a forward database rollback remain",
         ],
         state: "in_progress",
         title:
@@ -268,12 +268,14 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
   {
     id: "wave-6-resources-guides",
     sequence: 6,
-    status: "queued",
+    status: "active",
     title: "Qualified resources and varied guides",
     criteria: defineCriteria(6, [
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "The 2026-08-13 read-only count refresh separates local and production snapshots: the expanded local curated artifact has 5,046 candidates and 741 complete, verified, publishable records; production has 2,184 staged records and exact parity at 853 verified, administrator-approved, publishable, promoted, and anonymous public rows",
+        ],
+        state: "complete",
         title:
           "Report exact candidate, complete, verified, publishable, promoted, and public counts",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1169,24 +1169,24 @@ describe("finance release planning graph", () => {
     )
     expect(FINANCE_PLAN_WAVES.map((wave) => wave.status)).toEqual([
       "production_verified",
-      ...Array(4).fill("active"),
-      ...Array(2).fill("queued"),
+      ...Array(5).fill("active"),
+      "queued",
     ])
     expect(FINANCE_PLAN_WAVE_STATUS_COUNTS).toEqual({
-      active: 4,
+      active: 5,
       codeComplete: 0,
       previewVerified: 0,
       productionVerified: 1,
-      queued: 2,
+      queued: 1,
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
-      complete: 19,
+      complete: 20,
       inProgress: 6,
-      notStarted: 10,
+      notStarted: 9,
       total: 35,
     })
-    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(54)
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(57)
     expect(sourceCriteria).toHaveLength(35)
     expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
       trackedCriteria.map((criterion) => criterion.id)
@@ -1275,9 +1275,9 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      complete: 19,
-      percentage: 54,
-      remaining: 16,
+      complete: 20,
+      percentage: 57,
+      remaining: 15,
       total: 35,
       waveId: "wave-2-signup-legal",
       waveLabel: "Wave 2: Signup, recovery, and legal",


### PR DESCRIPTION
## Summary
- record exact local candidate, complete, verified, and publishable counts
- record exact production staged, verified, approved, publishable, promoted, and public counts
- keep local and production snapshots separate and identify local artifacts by hash
- mark Wave 6 count reporting complete and PRD progress at 20/35 (57%)

## Current counts
- local expanded curated snapshot: 5,046 candidates; 741 complete/verified/publishable
- production: 2,184 staged; 853 verified/approved/publishable/promoted/public

## Safety
- read-only aggregate queries and local audits only
- no fetch, import, review, promotion, unpublish, database, or public-data mutation

## Verification
- 37 focused tracker tests
- 2,097 full acceptance tests; 1 intentional skip
- source guardrails and snapshots pass