### PR TITLE
[STEP S70] Repair Chicago housing source evidence

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **20/35 complete (57%)**, **6 in progress**, and
-**9 not started**.
+revision. Current progress: **20/35 complete (57%)**, **7 in progress**, and
+**8 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -180,7 +180,7 @@ revision. Current progress: **20/35 complete (57%)**, **6 in progress**, and
 **Wave 6 — Qualified resources and varied guides**
 
 - [x] `wave-6-criterion-1` **Complete:** Report exact candidate, complete, verified, publishable, promoted, and public counts — Evidence: the 2026-08-13 read-only count refresh reports the expanded local curated snapshot separately at `5,046` candidates and `741` complete/verified/publishable records. Exact production aggregates report `2,184` staged and parity at `853` verified, administrator-approved, publishable, promoted, and anonymous public rows; artifact hashes and reproduction steps are recorded.
-- [ ] `wave-6-criterion-2` **Not started:** Close provider, eligibility, summary, access, contact, and comparison evidence gaps by cohort.
+- [ ] `wave-6-criterion-2` **In progress:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: the first 106-listing Chicago housing group already has every required descriptive field. This pass raised listings with a second provider source from `92` to `99`; the remaining `7` stay held because five listings' provider pages reject automated checks, one provider has no website, and one provider site is dead. Nothing was approved or published.
 - [ ] `wave-6-criterion-3` **Not started:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records.
 - [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
 - [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
@@ -271,6 +271,9 @@ revision. Current progress: **20/35 complete (57%)**, **6 in progress**, and
   contract-complete, independently verified, publishable records.
 - Production has `2,184` staged records and exact parity at `853` verified,
   administrator-approved, publishable, promoted, and anonymous public rows.
+- The first Chicago housing repair raised listings with two sources from
+  `92/106` to `99/106`. The remaining seven stay hidden pending usable provider
+  evidence; no record was imported, approved, or published.
 - No raw intake queue, synthetic seed, local preview, or unverified discovery
   record was added to `/find`.
 

--- a/docs/plans/2026-08-13-resource-map-housing-source-repair.md
+++ b/docs/plans/2026-08-13-resource-map-housing-source-repair.md
@@ -1,0 +1,53 @@
+# Chicago housing listing source repair
+
+Date: 2026-08-13
+
+## Outcome
+
+The saved Chicago housing group contains 106 listings. All 106 already include
+a service, summary, category, location, contact, eligibility, access steps, and
+the 211 Metro Chicago source.
+
+This pass raised listings with a second provider source from 92 to 99. Nothing
+was imported, approved, published, or changed in production.
+
+| Result                                                     | Listings |
+| ---------------------------------------------------------- | -------: |
+| Ready for later human review                               |       99 |
+| Held because a second provider source could not be checked |        7 |
+| Total                                                      |      106 |
+
+## Repaired listings
+
+- Community Supportive Living Systems — Emerald House
+- Lincoln Park Community Services — Permanent Supportive and Affordable Housing
+- Family Promise Chicago North Shore — Family Transitional Housing
+- Brave Space Alliance — Jasmine Alexander Housing Initiative
+- Covenant House Illinois — Residential Program
+- Josselyn — Resiliency Center
+- Puerto Rican Cultural Center — Drop-in center or day shelter
+
+The source-specific importer now replaces stale links with current provider
+pages. The checker remains bounded but accepts modern provider pages up to 1.5
+MB; the four supported pages that exceeded the former limit were 789 KB to
+1.28 MB.
+
+## Listings still held
+
+- Four AIDS Foundation of Chicago listings: the official site returned HTTP 403
+  to the automated checker.
+- Child Link — Transitional Living Program: the official site returned HTTP 403.
+- The L.A.M. House Transitional Home: no provider-owned website was found.
+- Willis House of Refuge: the provider website redirects to a 404 page.
+
+The checker does not treat those seven listings as independently supported.
+They remain unavailable for automatic promotion.
+
+## Evidence
+
+- Input artifact: `211-metro-chicago-housing-services.provider-verified.jsonl`
+- Input SHA-256:
+  `dc6f5eac3b11597673ee1268ca3533e48e3af2d73cede724cb2365462d54ed72`
+- Focused importer and provider-page tests: 11 passed.
+- The documented `pnpm resource-map:verify-provider-pages` command is now wired
+  into `package.json`.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3199,3 +3199,20 @@
   production data mutation occurred.
 - Marked Wave 6 criterion 1 complete. Progress is `20/35` (`57%`), with `6` in
   progress and `9` not started.
+
+2026-08-13 16:25 EDT - repaired the first Chicago housing source group.
+
+- Audited the 14 Chicago housing listings missing a second provider source.
+  Current provider pages resolved seven, raising the group from `92/106` to
+  `99/106` listings with two sources. All 106 already have the required service,
+  summary, category, location, contact, eligibility, and access fields.
+- Replaced nine stale provider links during deterministic 211 ingestion, raised
+  the bounded provider-page response limit from 750 KB to 1.5 MB for current
+  provider sites, and restored the documented package command for the checker.
+- Four AIDS Foundation of Chicago listings and one Child Link listing remain
+  held after HTTP 403 responses; L.A.M. House remains held without a provider
+  website; Willis House remains held because its site redirects to a 404 page.
+- Focused importer and provider-page tests pass `11/11`. No source record was
+  imported, approved, published, or changed in production. Wave 6 criterion 2
+  is now in progress; overall completion remains `20/35` (`57%`), with `7` in
+  progress and `8` not started.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "resource-map:source-freshness": "node scripts/resource-map/check-source-freshness.mjs",
     "resource-map:enrich": "node scripts/resource-map/enrich-candidates.mjs",
     "resource-map:audit-enrichment": "node scripts/resource-map/audit-enrichment-readiness.mjs",
+    "resource-map:verify-provider-pages": "node scripts/resource-map/verify-provider-pages.mjs",
     "resource-map:enrich-library": "node scripts/resource-map/enrich-library-candidates.mjs",
     "resource-map:sync-library": "node scripts/resource-map/sync-library-public-records.mjs",
     "scaffold:feature": "node scripts/new-feature.mjs",

--- a/scripts/resource-map/lib/metro-chicago-shelters.mjs
+++ b/scripts/resource-map/lib/metro-chicago-shelters.mjs
@@ -1,7 +1,25 @@
 const SOURCE_ID = "211-metro-chicago-housing-services"
 const SOURCE_NAME = "211 Metro Chicago shelter and housing-services directory"
 const SOURCE_URL = "https://211metrochicago.org/search-for-resources/"
-const METHOD_VERSION = "211-metro-chicago-shelters-v2-program-titles"
+const METHOD_VERSION = "211-metro-chicago-shelters-v3-official-provider-links"
+
+const PROGRAM_WEBSITE_OVERRIDES = new Map([
+  [
+    "80919766",
+    "https://www.aidschicago.org/our-work/housing/permanent-housing/",
+  ],
+  ["80919768", "https://www.aidschicago.org/i-need/housing/"],
+  ["80919772", "https://www.aidschicago.org/i-need/housing/"],
+  ["80919773", "https://www.aidschicago.org/i-need/housing/"],
+  ["80919825", "https://www.familypromisechicagons.org/about"],
+  ["80919900", "https://www.csls.org/services"],
+  ["82808175", "https://childlink.org/programs/"],
+  ["86742794", "https://www.lpcschicago.org/what-we-do"],
+  [
+    "87878951",
+    "https://www.josselyn.org/community-programs/resiliency-center/",
+  ],
+])
 
 const PUBLIC_RESOURCE_SERVICE_PATTERN =
   /Domestic Violence Shelters|Youth Shelters|Community Shelters|Emergency Shelter Clearinghouses|Homeless Permanent Supportive Housing|Family Permanent Supportive Housing|Transitional Housing\/Shelter|Drop In Centers|Single Room Occupancy Housing|Rapid Re-Housing Programs/iu
@@ -281,7 +299,11 @@ export function buildMetroChicagoShelterRecord({
     program.site?.contact_email,
     program.agency?.email
   )?.toLowerCase()
-  const website = normalizeUrl(program.website ?? program.agency?.website)
+  const website = normalizeUrl(
+    PROGRAM_WEBSITE_OVERRIDES.get(String(programId)) ??
+      program.website ??
+      program.agency?.website
+  )
   const hours = normalizeHours(program)
   const description = buildDescription(program, agencyName)
   const eligibility =

--- a/scripts/resource-map/lib/provider-page-comparison.mjs
+++ b/scripts/resource-map/lib/provider-page-comparison.mjs
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { lookup } from "node:dns/promises"
 import { isIP } from "node:net"
 
-const MAX_BODY_BYTES = 750_000
+const MAX_BODY_BYTES = 1_500_000
 const MAX_REDIRECTS = 5
 const REQUEST_HEADERS = {
   Accept: "text/html,application/xhtml+xml",

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -280,10 +280,12 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Report exact candidate, complete, verified, publishable, promoted, and public counts",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "The first 106-listing Chicago housing group has every required descriptive field; current provider-page checks raised listings with two sources from 92 to 99, while seven remain held and nothing was approved or published",
+        ],
+        state: "in_progress",
         title:
-          "Close provider, eligibility, summary, access, contact, and comparison evidence gaps by cohort",
+          "Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source",
       },
       {
         evidence: [],

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1182,8 +1182,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 20,
-      inProgress: 6,
-      notStarted: 9,
+      inProgress: 7,
+      notStarted: 8,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(57)

--- a/tests/acceptance/resource-map-metro-chicago-shelters.test.ts
+++ b/tests/acceptance/resource-map-metro-chicago-shelters.test.ts
@@ -135,4 +135,36 @@ describe("211 Metro Chicago shelter ingestion", () => {
     )
     expect(record.extractedFields.title).not.toContain("Administration Office")
   })
+
+  it.each([
+    [
+      80919766,
+      "https://www.aidschicago.org/our-work/housing/permanent-housing",
+    ],
+    [80919768, "https://www.aidschicago.org/i-need/housing"],
+    [80919772, "https://www.aidschicago.org/i-need/housing"],
+    [80919773, "https://www.aidschicago.org/i-need/housing"],
+    [80919900, "https://www.csls.org/services"],
+    [80919825, "https://www.familypromisechicagons.org/about"],
+    [82808175, "https://childlink.org/programs"],
+    [86742794, "https://www.lpcschicago.org/what-we-do"],
+    [87878951, "https://www.josselyn.org/community-programs/resiliency-center"],
+  ])(
+    "uses the current official provider page for program %s",
+    (id, website) => {
+      const record = buildMetroChicagoShelterRecord({
+        cityName: "Chicago",
+        fetchedAt: "2026-08-13T12:00:00.000Z",
+        program: { ...program, id },
+        rawApiUrl:
+          "https://api.211metrochicago.org/api/programs?category_id=142&page=1",
+        requestedCategoryId: 142,
+      })
+
+      expect(record.extractedFields.websiteUrl).toBe(website)
+      expect(record.extractedFields.links).toContainEqual(
+        expect.objectContaining({ url: website })
+      )
+    }
+  )
 })


### PR DESCRIPTION
## Summary
- replace stale provider links for the 211 Chicago housing importer
- support bounded modern provider pages up to 1.5 MB
- raise second-source coverage from 92/106 to 99/106; keep seven listings held
- wire the documented provider-page command and update the PRD tracker

## Safety
- no import, approval, publication, database, or production mutation

## Checks
- `pnpm check:prepush`
- focused resource-map and PRD tracker tests: 53 passed