### PR TITLE
[STEP S74] Verify immigrant provider identity evidence

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -180,7 +180,7 @@ revision. Current progress: **20/35 complete (57%)**, **7 in progress**, and
 **Wave 6 — Qualified resources and varied guides**
 
 - [x] `wave-6-criterion-1` **Complete:** Report exact candidate, complete, verified, publishable, promoted, and public counts — Evidence: the 2026-08-13 read-only count refresh reports the expanded local curated snapshot separately at `5,046` candidates and `741` complete/verified/publishable records. Exact production aggregates report `2,184` staged and parity at `853` verified, administrator-approved, publishable, promoted, and anonymous public rows; artifact hashes and reproduction steps are recorded.
-- [ ] `wave-6-criterion-2` **In progress:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: the Chicago housing group has every required descriptive field and increased from `92/106` to `99/106` listings with two sources, with seven held. Three food repairs now read provider phone numbers already present in the public source and add official food-bank finders for Cook County and Northern Illinois listings without direct contact details. Food listings with contact information or an intake link increased from `644/752` to `748/752`; listings with that access path and two sources increased from `615/752` to `647/752`. Nothing was approved or published.
+- [ ] `wave-6-criterion-2` **In progress:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: the Chicago housing group has every required descriptive field and increased from `92/106` to `99/106` listings with two sources, with seven held. Three food repairs increased contact or intake coverage from `644/752` to `748/752` and access-plus-comparison coverage from `615/752` to `647/752`. The Cook County immigrant/refugee cohort increased from `68/84` to `79/84` listings with two-source identity evidence; `74/79` service-eligible listings now have that evidence and five remain held. Nothing was approved or published.
 - [ ] `wave-6-criterion-3` **Not started:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records.
 - [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
 - [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
@@ -274,6 +274,9 @@ revision. Current progress: **20/35 complete (57%)**, **7 in progress**, and
 - The first Chicago housing repair raised listings with two sources from
   `92/106` to `99/106`. The remaining seven stay hidden pending usable provider
   evidence; no record was imported, approved, or published.
+- The Cook County immigrant/refugee repair raised listings with two-source
+  identity evidence from `68/84` to `79/84`. `74/79` service-eligible listings
+  now have that evidence; five remain held behind provider-page failures.
 - No raw intake queue, synthetic seed, local preview, or unverified discovery
   record was added to `/find`.
 

--- a/docs/plans/2026-08-13-resource-map-immigrant-provider-evidence.md
+++ b/docs/plans/2026-08-13-resource-map-immigrant-provider-evidence.md
@@ -1,0 +1,45 @@
+# Immigrant and refugee provider evidence repair
+
+Date: 2026-08-13
+
+Status: local Wave 6 evidence repair. No record was imported, approved,
+published, or changed in production.
+
+## Result
+
+- The Cook County directory cohort contains `84` records. `79` name a specific
+  service and remain eligible for review; five do not.
+- The previous provider-page artifact gave `68/84` records two-source identity
+  evidence.
+- A current bounded refresh raised that to `79/84`: nine provider pages now
+  fetch and match under the existing rules, and two established organization
+  acronyms now match under the new strict rule.
+- `74/79` service-eligible records now have two-source identity evidence. The
+  other five remain held.
+
+## Matching rule
+
+An acronym counts only when it is four to ten letters, is derived from the
+provider's full name after removing connectors and Chicago/Illinois location
+words, and appears either as a whole page-text token or in the same-site domain.
+A successful page fetch alone still does not count as a second source.
+
+This closes the valid `HIAS` page-text match for Hebrew Immigrant Aid Society
+of Chicago and the `CASL` domain match for Chinese American Service League.
+
+## Held records
+
+- Access Living and Council on American-Islamic Relations returned HTTP `403`.
+- Chinese Mutual Aid Association exceeded the bounded page-size limit.
+- Albany Park Community Center has no retained safe provider website.
+- Japanese American Citizens League returned an unusable redirect response.
+
+These records keep one-source or missing-provider status. No override was
+added.
+
+## Verification
+
+- Current provider comparison: `supported=79`, `unavailable=4`,
+  `no_website=1` across `84` records.
+- Focused provider comparison and Cook County importer tests: `10/10` pass.
+- Output stayed in ignored/local artifacts under `/private/tmp`.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3264,3 +3264,19 @@
   link. Nothing was imported, approved, published, or changed in production.
 - Focused importer and coverage tests pass `10/10`. Overall PRD completion
   remains `20/35` (`57%`).
+
+2026-08-13 17:28 EDT - repaired immigrant and refugee provider identity evidence.
+
+- Refreshed only the 16 Cook County directory records that lacked a second
+  provider identity comparison. Nine current provider pages now fetch and
+  match under the existing rules.
+- Added strict four-to-ten-letter provider acronym matching for whole page-text
+  tokens and same-site domains. This corroborates HIAS Chicago and CASL without
+  treating a successful fetch alone as evidence.
+- Two-source identity coverage increased from `68/84` to `79/84`.
+  `74/79` service-eligible records now have that evidence. Five eligible records
+  remain held behind HTTP `403`, oversized-page, missing-site, or unusable
+  redirect results; no override was added.
+- Focused provider comparison and Cook County importer tests pass `10/10`. No
+  source record was imported, approved, published, or changed in production.
+  Overall PRD completion remains `20/35` (`57%`).

--- a/scripts/resource-map/lib/provider-page-comparison.mjs
+++ b/scripts/resource-map/lib/provider-page-comparison.mjs
@@ -27,6 +27,18 @@ const NAME_STOP_WORDS = new Set([
   "the",
 ])
 
+const ACRONYM_STOP_WORDS = new Set([
+  "and",
+  "at",
+  "chicago",
+  "for",
+  "illinois",
+  "in",
+  "of",
+  "on",
+  "the",
+])
+
 function readString(...values) {
   for (const value of values) {
     if (typeof value === "string" && value.trim()) return value.trim()
@@ -60,6 +72,20 @@ function meaningfulNameTokens(value) {
         )
     ),
   ]
+}
+
+function providerNameAcronym(value) {
+  const acronym = normalizeText(value)
+    .split(" ")
+    .filter(
+      (token) =>
+        token.length >= 2 &&
+        !ACRONYM_STOP_WORDS.has(token) &&
+        !/^\d+$/u.test(token)
+    )
+    .map((token) => token[0])
+    .join("")
+  return acronym.length >= 4 && acronym.length <= 10 ? acronym : null
 }
 
 function phoneDigits(value) {
@@ -273,9 +299,21 @@ export function compareProviderPageSnapshot(record, snapshot) {
     const normalized = normalizeText(name)
     return normalized.length >= 5 && text.includes(normalized)
   })
+  const pageTokens = new Set(normalizeText(text).split(" "))
+  const matchedAcronym = providerNames
+    .map(providerNameAcronym)
+    .find((acronym) => acronym && pageTokens.has(acronym))
   const phone = phoneDigits(fields.phone)
   const phoneMatch = phone.length === 7 && allDigits(text).includes(phone)
   const hostText = normalizeText(new URL(snapshot.finalUrl).hostname)
+  const crossSiteRedirect =
+    baseDomain(new URL(snapshot.websiteUrl).hostname) !==
+    baseDomain(new URL(snapshot.finalUrl).hostname)
+  const acronymDomainMatch = providerNames
+    .map(providerNameAcronym)
+    .some(
+      (acronym) => !crossSiteRedirect && acronym && hostText.includes(acronym)
+    )
   const domainTokenMatch = allTokens.some(
     (token) =>
       token.length >= 5 && hostText.includes(token) && text.includes(token)
@@ -287,16 +325,20 @@ export function compareProviderPageSnapshot(record, snapshot) {
     addressNumber && text.includes(addressNumber)
   )
   const supported =
-    exactName || phoneMatch || multiTokenMatch || domainTokenMatch
-  const crossSiteRedirect =
-    baseDomain(new URL(snapshot.websiteUrl).hostname) !==
-    baseDomain(new URL(snapshot.finalUrl).hostname)
+    exactName ||
+    Boolean(matchedAcronym) ||
+    acronymDomainMatch ||
+    phoneMatch ||
+    multiTokenMatch ||
+    domainTokenMatch
   return {
     ...snapshot,
     addressNumberMatch,
     crossSiteRedirect,
     matchedSignals: [
       exactName ? "exact_provider_name" : null,
+      matchedAcronym ? "provider_name_acronym" : null,
+      acronymDomainMatch ? "provider_acronym_domain" : null,
       phoneMatch ? "phone" : null,
       multiTokenMatch ? "provider_name_tokens" : null,
       domainTokenMatch ? "provider_domain" : null,

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -281,7 +281,7 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
       },
       {
         evidence: [
-          "The Chicago housing group increased from 92/106 to 99/106 listings with two sources; three food repairs increased listings with contact information or an intake link from 644/752 to 748/752 and listings with that access path and two sources from 615/752 to 647/752; unresolved listings remain held and nothing was approved or published",
+          "The Chicago housing group increased from 92/106 to 99/106 listings with two sources; three food repairs increased contact or intake coverage from 644/752 to 748/752 and access-plus-comparison coverage from 615/752 to 647/752; the Cook County immigrant/refugee cohort increased from 68/84 to 79/84 listings with two-source identity evidence, with unresolved listings held and nothing approved or published",
         ],
         state: "in_progress",
         title:

--- a/tests/acceptance/resource-map-provider-page-comparison.test.ts
+++ b/tests/acceptance/resource-map-provider-page-comparison.test.ts
@@ -73,6 +73,73 @@ describe("resource-map provider page comparison", () => {
     expect(enriched.rawSnapshot.providerPageEvidence.contentHash).toBe("abc123")
   })
 
+  it("supports an established whole-token provider acronym", () => {
+    const acronymRecord = {
+      ...record,
+      extractedFields: {
+        ...record.extractedFields,
+        organizationName: "Hebrew Immigrant Aid Society of Chicago",
+        providerName: "Hebrew Immigrant Aid Society of Chicago",
+      },
+    }
+    const comparison = compareProviderPageSnapshot(
+      acronymRecord,
+      fetchedSnapshot({
+        pageTitle: "HIAS Chicago",
+        visibleText: "HIAS Chicago immigration and citizenship services",
+      })
+    )
+
+    expect(comparison.status).toBe("supported")
+    expect(comparison.matchedSignals).toContain("provider_name_acronym")
+  })
+
+  it("supports an established provider acronym in the same-site domain", () => {
+    const acronymRecord = {
+      ...record,
+      extractedFields: {
+        ...record.extractedFields,
+        organizationName: "Chinese American Service League",
+        providerName: "Chinese American Service League",
+        websiteUrl: "https://www.caslservice.org",
+      },
+    }
+    const comparison = compareProviderPageSnapshot(
+      acronymRecord,
+      fetchedSnapshot({
+        finalUrl: "https://www.caslservice.org/",
+        visibleText: "",
+        websiteUrl: "https://www.caslservice.org",
+      })
+    )
+
+    expect(comparison.status).toBe("supported")
+    expect(comparison.matchedSignals).toContain("provider_acronym_domain")
+  })
+
+  it("does not trust an acronym on a cross-site redirect domain", () => {
+    const acronymRecord = {
+      ...record,
+      extractedFields: {
+        ...record.extractedFields,
+        organizationName: "Chinese American Service League",
+        providerName: "Chinese American Service League",
+        websiteUrl: "https://www.caslservice.org",
+      },
+    }
+    const comparison = compareProviderPageSnapshot(
+      acronymRecord,
+      fetchedSnapshot({
+        finalUrl: "https://casl-example.net/",
+        visibleText: "",
+        websiteUrl: "https://www.caslservice.org",
+      })
+    )
+
+    expect(comparison.status).toBe("contradicted")
+    expect(comparison.matchedSignals).not.toContain("provider_acronym_domain")
+  })
+
   it("removes a provider link that redirects cross-site without an identity match", () => {
     const comparison = compareProviderPageSnapshot(
       record,


### PR DESCRIPTION
## Summary
- add strict whole-token and same-site-domain matching for established provider acronyms
- increase Cook County immigrant/refugee two-source identity evidence from 68/84 to 79/84
- retain five service-eligible records behind provider-page failures; no overrides
- update Wave 6 evidence, tracker, and August runlog

## Scope
- no import, approval, publication, database, or production mutation

## Verification
- focused resource and PRD tests: 47 passed
- `pnpm check:prepush`: 2,112 tests passed; 1 skipped