### PR TITLE
[STEP S76] Guard resource publication canaries

### DIFF
--- a/docs/agent/resource-map-enrichment.md
+++ b/docs/agent/resource-map-enrichment.md
@@ -53,6 +53,12 @@ pnpm resource-map:audit-enrichment -- --input <enriched.jsonl> --require-publish
   completed promotion return the existing canonical IDs.
 - Promoted contacts and links remain private. Staged field evidence is copied to
   canonical targets in the same transaction.
+- Plan a source canary with `pnpm resource-map:publish-source-canary --
+--source-slug <slug> --input <records.jsonl>`. The dry run compares current
+  local evidence with staging and consumes stored review state without writing.
+- Applied source canaries accept at most five explicit import IDs and require
+  `--publish --apply --confirm-source <slug>`. The command never creates review
+  or verification evidence and never changes contact or link visibility.
 
 Evidence collection and enrichment are dry-run-first. Network access requires
 `--network true`; local output persistence requires `--write`. Import, review, promotion,

--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **21/35 complete (60%)**, **6 in progress**, and
-**8 not started**.
+revision. Current progress: **21/35 complete (60%)**, **7 in progress**, and
+**7 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -181,7 +181,7 @@ revision. Current progress: **21/35 complete (60%)**, **6 in progress**, and
 
 - [x] `wave-6-criterion-1` **Complete:** Report exact candidate, complete, verified, publishable, promoted, and public counts — Evidence: the 2026-08-13 read-only count refresh reports the expanded local curated snapshot separately at `5,046` candidates and `741` complete/verified/publishable records. Exact production aggregates report `2,184` staged and parity at `853` verified, administrator-approved, publishable, promoted, and anonymous public rows; artifact hashes and reproduction steps are recorded.
 - [x] `wave-6-criterion-2` **Complete:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: PRs #167-#171 repaired the selected housing, food, and immigrant/refugee cohorts; #171 hosted quality and both deployments passed. Housing two-source coverage increased from `92/106` to `99/106`; food contact or intake coverage increased from `644/752` to `748/752` and access-plus-comparison coverage from `615/752` to `647/752`; immigrant/refugee two-source identity coverage increased from `68/84` to `79/84`, including `74/79` service-eligible listings. Records blocked by real provider evidence failures remain explicitly held. Nothing was approved or published.
-- [ ] `wave-6-criterion-3` **Not started:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records.
+- [ ] `wave-6-criterion-3` **In progress:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records — Evidence: the guarded Cook County cooling-center dry run found `34/35` current local records passing the publication contract, with one held, `25` matching existing unapproved staging rows, and nine not yet staged. It selected zero publication candidates because staging still lacks the refreshed fields, independent verification ledger, and identified administrator review. The canary command can no longer manufacture those gates or expose contacts and links.
 - [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
 - [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
 

--- a/docs/plans/2026-08-13-resource-map-publication-canary-guard.md
+++ b/docs/plans/2026-08-13-resource-map-publication-canary-guard.md
@@ -1,0 +1,51 @@
+# Resource publication canary guard
+
+Date: 2026-08-13
+
+Status: read-only Wave 6 canary preparation. No review, verification,
+visibility, publication, database, or production state changed.
+
+## Guard repair
+
+The prior source publication command could assign approved verification,
+administrator review, and publication in one execution. That collapsed three
+required gates and could expose contacts and links automatically.
+
+The guarded command now:
+
+- consumes only review and verification evidence already stored in production;
+- requires a completed clean approved verification-ledger entry;
+- limits a canary to five explicit import-record IDs;
+- requires `--publish`, `--apply`, and an exact `--confirm-source` match;
+- uses the atomic promotion RPC without changing review evidence; and
+- leaves contact and link visibility unchanged.
+
+The separate review command now requires an existing administrator actor for
+every applied decision. Dry runs remain read-only.
+
+## Cook County dry run
+
+The first candidate is the official Cook County cooling-center source because
+it is local, actionable during August heat, bounded, and already supported by
+the deterministic source-family enrichment contract.
+
+| Gate                                                   | Count |
+| ------------------------------------------------------ | ----: |
+| Current local source records                           |    35 |
+| Pass local publication contract                        |    34 |
+| Explicitly held locally                                |     1 |
+| Publishable local records matching staging             |    25 |
+| Publishable local records not yet staged               |     9 |
+| Staged records retaining final review and verification |     0 |
+
+The command selected five exact staged refresh candidates but correctly
+selected zero publication candidates. All 25 matched staging rows remain held
+because they contain older incomplete fields and no final administrator review
+or approved verification ledger.
+
+## Required next gate
+
+Refresh only the 25 matching unapproved staging rows from the current retained
+local evidence. Then independently verify and present at most five exact IDs to
+an administrator for review. Promotion remains a separate approved production
+operation with count parity and reversible unpublish proof.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3296,3 +3296,23 @@
   changed in production.
 - Overall PRD completion is now `21/35` (`60%`), with `6` in progress and `8`
   not started.
+
+2026-08-13 18:25 EDT - guarded the first Wave 6 publication canary.
+
+- Found that the existing source publication command could create approved
+  verification, administrator review, and public promotion in one operation.
+  Reworked it to consume stored review evidence only, require a clean approved
+  verification ledger, cap canaries at five explicit IDs, require exact source
+  confirmation, and preserve private contact/link visibility.
+- The separate review command now requires an existing administrator actor for
+  every applied decision. No command can use an arbitrary actor ID to approve
+  records through this workflow.
+- A connected read-only Cook County cooling-center dry run found `34/35` local
+  records passing the publication contract, one held, 25 matching unapproved
+  staging rows, and nine publishable local records not yet staged. Zero records
+  were selected for publication because the staged rows retain older incomplete
+  fields and lack final review and verification evidence.
+- Focused import and guard coverage passes `18/18`. Wave 6 criterion 3 is in
+  progress. Overall PRD completion remains `21/35` (`60%`), with `7` in
+  progress and `7` not started. No review, verification, visibility,
+  publication, database, or production state changed.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "resource-map:review-imports": "node scripts/resource-map/review-import-records.mjs",
     "resource-map:review-matches": "node scripts/resource-map/review-match-candidates.mjs",
     "resource-map:promote": "node scripts/resource-map/promote-approved-records.mjs",
+    "resource-map:publish-source-canary": "node scripts/resource-map/verify-and-publish-source-records.mjs",
     "resource-map:source-freshness": "node scripts/resource-map/check-source-freshness.mjs",
     "resource-map:enrich": "node scripts/resource-map/enrich-candidates.mjs",
     "resource-map:audit-enrichment": "node scripts/resource-map/audit-enrichment-readiness.mjs",

--- a/scripts/resource-map/review-import-records.mjs
+++ b/scripts/resource-map/review-import-records.mjs
@@ -180,6 +180,19 @@ async function applyReview({ admin, ids, status, reason, actorId }) {
   return afterRecords ?? []
 }
 
+async function requireAdminActor(admin, actorId) {
+  if (!actorId) throw new Error("--actor-id is required with --apply.")
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id,role")
+    .eq("id", actorId)
+    .maybeSingle()
+  if (error) throw error
+  if (!data || data.role !== "admin") {
+    throw new Error("The review actor must be an existing administrator.")
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   if (args.get("help")) {
@@ -218,6 +231,8 @@ async function main() {
     printRecords(records)
     return
   }
+
+  await requireAdminActor(admin, actorId)
 
   const updated = await applyReview({ admin, ids, status, reason, actorId })
   console.log(`Reviewed ${updated.length} staged import records as ${status}.`)

--- a/scripts/resource-map/verify-and-publish-source-records.mjs
+++ b/scripts/resource-map/verify-and-publish-source-records.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto"
 import { pathToFileURL } from "node:url"
 
 import { analyzeResourceEnrichmentReadiness } from "./lib/enrichment-quality.mjs"
 import { createResourceMapAdminClient } from "./lib/env.mjs"
 import { buildCanonicalPayload } from "./lib/promotion-payloads.mjs"
+import { readResourceMapRecords } from "./lib/read-records.mjs"
 
-const CONCURRENCY = 6
-const MAX_ATTEMPTS = 5
+const DEFAULT_LIMIT = 5
+const MAX_CANARY_SIZE = 5
+const LOOKUP_CHUNK_SIZE = 100
 
 function parseArgs(argv) {
   const args = new Map()
@@ -25,184 +26,138 @@ function parseArgs(argv) {
   return args
 }
 
-function stableHash(value) {
-  return createHash("sha256").update(JSON.stringify(value)).digest("hex")
+function normalizeLimit(value) {
+  const parsed = Number.parseInt(String(value ?? DEFAULT_LIMIT), 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT
+  return Math.min(Math.max(parsed, 1), MAX_CANARY_SIZE)
 }
 
-function wait(milliseconds) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+function normalizeIds(value) {
+  return [
+    ...new Set(
+      String(value ?? "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    ),
+  ]
 }
 
-async function withRetry(operation) {
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
-    try {
-      return await operation()
-    } catch (error) {
-      const transient =
-        error instanceof TypeError && /fetch failed/iu.test(error.message)
-      if (!transient || attempt === MAX_ATTEMPTS) throw error
-      await wait(attempt * 1000)
-    }
+function chunks(values, size = LOOKUP_CHUNK_SIZE) {
+  const result = []
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size))
   }
-  throw new Error("Retry loop ended unexpectedly.")
+  return result
 }
 
 async function requireData(operation) {
-  const response = await withRetry(operation)
+  const response = await operation()
   if (response.error) throw response.error
   return response.data
 }
 
-async function mapConcurrent(values, operation, concurrency = CONCURRENCY) {
-  const results = new Array(values.length)
-  let nextIndex = 0
-  async function worker() {
-    while (nextIndex < values.length) {
-      const index = nextIndex
-      nextIndex += 1
-      results[index] = await operation(values[index], index)
-    }
-  }
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, values.length) }, worker)
-  )
-  return results
+function verificationResult(run) {
+  return run?.structured_result?.verification ?? run?.structured_result ?? {}
 }
 
-function readUrl(value) {
-  if (typeof value !== "string" || !value.trim()) return null
-  try {
-    const url = new URL(value.trim())
-    return ["http:", "https:"].includes(url.protocol) ? url.toString() : null
-  } catch {
-    return null
-  }
-}
-
-function sourceUrlsForRecord(record, fields) {
-  const raw = record.raw_snapshot ?? {}
-  return [
-    record.source_url,
-    fields.websiteUrl,
-    fields.website_url,
-    fields.intakeUrl,
-    fields.intake_url,
-    raw.rawApiUrl,
-    raw.raw_api_url,
-  ]
-    .map(readUrl)
-    .filter(Boolean)
-    .filter((value, index, values) => values.indexOf(value) === index)
-}
-
-export function buildVerifiedRecord(record, verifiedAt) {
-  const fields = structuredClone(record.extracted_fields ?? {})
-  const enrichment = fields.enrichment ?? {}
-  const previousVerification = enrichment.verification ?? {}
-  fields.enrichment = {
-    ...enrichment,
-    needsReview: false,
-    verification: {
-      ...previousVerification,
-      contradictions: [],
-      status: "approved",
-      unsupportedClaims: [],
-    },
-  }
-  return {
-    ...record,
-    extracted_fields: fields,
-    last_verified_at: record.last_verified_at ?? verifiedAt,
-    needs_review: false,
-  }
-}
-
-function buildVerificationLedger(record, actorId) {
-  const fields = record.extracted_fields
-  const enrichment = fields.enrichment
-  const verification = enrichment.verification
-  const sourceUrls = sourceUrlsForRecord(record, fields)
-  const promptVersion = `${enrichment.methodVersion ?? "source-specific"}-production-verification-v1`
-  const inputHash = stableHash({
-    rawSnapshot: record.raw_snapshot,
-    sourceRecordId: record.source_record_id,
-    sourceUrls,
-  })
-  return {
-    actor_id: actorId,
-    attempt_count: 1,
-    completed_at: record.last_verified_at,
-    import_record_id: record.id,
-    input_sha256: inputHash,
-    issues: [],
-    output_sha256: stableHash(verification),
-    pass_number: 1,
-    pass_type: "verification",
-    prompt_version: promptVersion,
-    provider: "deterministic",
-    source_urls: sourceUrls,
-    started_at: record.last_verified_at,
-    status: "completed",
-    structured_result: verification,
-  }
-}
-
-async function verifyRecord(admin, record, actorId, reason, verifiedAt) {
-  const verifiedRecord = buildVerifiedRecord(record, verifiedAt)
-  const ledger = buildVerificationLedger(verifiedRecord, actorId)
-  const reviewWasNew =
-    record.review_status !== "approved" || !record.reviewed_at
-
-  await requireData(() =>
-    admin
-      .from("resource_map_import_records")
-      .update({
-        extracted_fields: verifiedRecord.extracted_fields,
-        last_verified_at: verifiedRecord.last_verified_at,
-        needs_review: false,
-        promotion_status: "ready",
-        review_status: "approved",
-        reviewed_at: record.reviewed_at ?? verifiedAt,
-        reviewed_by: actorId,
-      })
-      .eq("id", record.id)
-  )
-
-  await requireData(() =>
-    admin.from("resource_map_enrichment_runs").upsert(ledger, {
-      ignoreDuplicates: true,
-      onConflict:
-        "import_record_id,pass_type,pass_number,input_sha256,prompt_version",
-    })
-  )
-
-  if (reviewWasNew) {
-    await requireData(() =>
-      admin.from("resource_map_curation_events").insert({
-        action: "approve",
-        actor_id: actorId,
-        after_state: {
-          lastVerifiedAt: verifiedRecord.last_verified_at,
-          reviewStatus: "approved",
-          verificationStatus: "approved",
-        },
-        before_state: {
-          reviewStatus: record.review_status,
-          verificationStatus:
-            record.extracted_fields?.enrichment?.verification?.status ?? null,
-        },
-        import_record_id: record.id,
-        reason,
-      })
+export function hasApprovedVerificationLedger(runs) {
+  return runs.some((run) => {
+    const result = verificationResult(run)
+    return (
+      run.status === "completed" &&
+      result.status === "approved" &&
+      Array.isArray(run.issues) &&
+      run.issues.length === 0 &&
+      (result.unsupportedClaims ?? result.unsupported_claims ?? []).length ===
+        0 &&
+      (result.contradictions ?? []).length === 0
     )
-  }
+  })
+}
 
+export function storedApprovalGaps(record, verificationRuns = []) {
+  const gaps = []
+  if (record.review_status !== "approved") gaps.push("not_admin_approved")
+  if (!record.reviewed_by || !record.reviewed_at) {
+    gaps.push("missing_identified_reviewer")
+  }
+  if (!record.last_verified_at) gaps.push("missing_verification_time")
+  const readiness = analyzeResourceEnrichmentReadiness(record)
+  gaps.push(...readiness.blockingGaps.map((gap) => gap.code))
+  if (!hasApprovedVerificationLedger(verificationRuns)) {
+    gaps.push("missing_approved_verification_ledger")
+  }
+  return [...new Set(gaps)]
+}
+
+async function loadVerificationRuns(admin, recordIds) {
+  const runs = []
+  for (const idChunk of chunks(recordIds)) {
+    const data =
+      (await requireData(() =>
+        admin
+          .from("resource_map_enrichment_runs")
+          .select("import_record_id,status,structured_result,issues")
+          .in("import_record_id", idChunk)
+          .eq("pass_type", "verification")
+      )) ?? []
+    runs.push(...data)
+  }
+  return runs
+}
+
+async function loadAcceptedMatches(admin, recordIds) {
+  const matches = []
+  for (const idChunk of chunks(recordIds)) {
+    const data =
+      (await requireData(() =>
+        admin
+          .from("resource_map_import_record_matches")
+          .select("import_record_id")
+          .in("import_record_id", idChunk)
+          .eq("match_status", "accepted")
+      )) ?? []
+    matches.push(...data)
+  }
+  return new Set(matches.map((match) => match.import_record_id))
+}
+
+function titleForRecord(record) {
+  const fields = record.extracted_fields ?? {}
+  return fields.serviceTitle ?? fields.title ?? record.source_record_id
+}
+
+function localSourceId(record) {
+  return record.sourceId ?? record.source_id ?? null
+}
+
+function localRecordId(record) {
+  return record.sourceRecordId ?? record.source_record_id ?? null
+}
+
+export function summarizeLocalDelta(localRecords, stagedRecords, sourceSlug) {
+  const sourceRecords = localRecords.filter(
+    (record) => localSourceId(record) === sourceSlug
+  )
+  const publishableRecords = sourceRecords.filter(
+    (record) => analyzeResourceEnrichmentReadiness(record).publishable
+  )
+  const stagedIds = new Set(
+    stagedRecords.map((record) => record.source_record_id)
+  )
+  const matched = publishableRecords.filter((record) =>
+    stagedIds.has(localRecordId(record))
+  )
+  const missing = publishableRecords.filter(
+    (record) => !stagedIds.has(localRecordId(record))
+  )
   return {
-    ...verifiedRecord,
-    promotion_status: "ready",
-    review_status: "approved",
-    reviewed_at: record.reviewed_at ?? verifiedAt,
-    reviewed_by: actorId,
+    held: sourceRecords.length - publishableRecords.length,
+    matched,
+    missing,
+    publishable: publishableRecords.length,
+    total: sourceRecords.length,
   }
 }
 
@@ -222,64 +177,33 @@ async function promoteRecord(admin, record) {
   return result
 }
 
-async function exposeVerifiedContactAndLinks(admin, promotionResults) {
-  const organizationIds = promotionResults
-    .map((result) => result.organization_id)
-    .filter(Boolean)
-  const serviceIds = promotionResults
-    .map((result) => result.service_id)
-    .filter(Boolean)
-  if (organizationIds.length === 0) return
-
-  for (let index = 0; index < organizationIds.length; index += 100) {
-    const organizationChunk = organizationIds.slice(index, index + 100)
-    await requireData(() =>
-      admin
-        .from("resource_map_contacts")
-        .update({ is_public: true })
-        .in("organization_id", organizationChunk)
-    )
-    await requireData(() =>
-      admin
-        .from("resource_map_links")
-        .update({ is_public: true })
-        .in("organization_id", organizationChunk)
-        .in("link_type", ["website", "intake", "apply", "referral"])
-    )
-  }
-  for (let index = 0; index < serviceIds.length; index += 100) {
-    const serviceChunk = serviceIds.slice(index, index + 100)
-    await requireData(() =>
-      admin
-        .from("resource_map_contacts")
-        .update({ is_public: true })
-        .in("service_id", serviceChunk)
-    )
-    await requireData(() =>
-      admin
-        .from("resource_map_links")
-        .update({ is_public: true })
-        .in("service_id", serviceChunk)
-        .in("link_type", ["website", "intake", "apply", "referral"])
-    )
-  }
-}
-
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   const sourceSlug = String(args.get("source-slug") ?? "").trim()
-  const actorId = String(args.get("actor-id") ?? "").trim()
+  const input = String(args.get("input") ?? "").trim()
+  const requestedIds = normalizeIds(args.get("id") ?? args.get("ids"))
+  const limit = normalizeLimit(args.get("limit"))
   const apply = Boolean(args.get("apply"))
-  const concurrency = Math.max(
-    1,
-    Number.parseInt(String(args.get("concurrency") ?? CONCURRENCY), 10)
-  )
-  const reason = String(
-    args.get("reason") ??
-      "Approved after deterministic comparison of official source records."
-  ).slice(0, 1000)
-  if (!sourceSlug || !actorId) {
-    throw new Error("--source-slug and --actor-id are required.")
+  const publish = Boolean(args.get("publish"))
+  const confirmedSource = String(args.get("confirm-source") ?? "").trim()
+
+  if (!sourceSlug) throw new Error("--source-slug is required.")
+  if (apply) {
+    if (!publish) throw new Error("--publish is required with --apply.")
+    if (confirmedSource !== sourceSlug) {
+      throw new Error("--confirm-source must exactly match --source-slug.")
+    }
+    if (requestedIds.length === 0) {
+      throw new Error("Explicit --id values are required with --apply.")
+    }
+    if (requestedIds.length > MAX_CANARY_SIZE) {
+      throw new Error(
+        `A canary may contain at most ${MAX_CANARY_SIZE} records.`
+      )
+    }
+    if (input) {
+      throw new Error("--input is read-only and cannot be used with --apply.")
+    }
   }
 
   const admin = createResourceMapAdminClient()
@@ -294,57 +218,112 @@ async function main() {
   if (source.trust_level !== "official") {
     throw new Error(`${sourceSlug} is not marked as an official source.`)
   }
-  const actor = await requireData(() =>
-    admin.from("profiles").select("id,role").eq("id", actorId).maybeSingle()
-  )
-  if (!actor || actor.role !== "admin") {
-    throw new Error("The review actor must be an existing administrator.")
+
+  let query = admin
+    .from("resource_map_import_records")
+    .select("*")
+    .eq("source_id", source.id)
+    .neq("promotion_status", "promoted")
+    .order("created_at", { ascending: true })
+    .limit(1000)
+  if (requestedIds.length > 0) query = query.in("id", requestedIds)
+  const records = (await requireData(() => query)) ?? []
+  if (apply && records.length !== requestedIds.length) {
+    throw new Error(
+      `Expected ${requestedIds.length} requested unpromoted records; found ${records.length}.`
+    )
   }
 
-  const records =
-    (await requireData(() =>
-      admin
-        .from("resource_map_import_records")
-        .select("*")
-        .eq("source_id", source.id)
-        .neq("promotion_status", "promoted")
-        .order("created_at", { ascending: true })
-        .limit(1000)
-    )) ?? []
-  const verifiedAt = new Date().toISOString()
-  const eligible = records
-    .map((record) => buildVerifiedRecord(record, verifiedAt))
-    .filter((record) => analyzeResourceEnrichmentReadiness(record).publishable)
+  if (input) {
+    const local = summarizeLocalDelta(
+      readResourceMapRecords(input),
+      records,
+      sourceSlug
+    )
+    console.log(
+      `Local delta: ${local.publishable}/${local.total} ${sourceSlug} records pass the local publication contract; held ${local.held}; matched staged rows ${local.matched.length}; missing staged rows ${local.missing.length}.`
+    )
+    for (const record of local.matched.slice(0, limit)) {
+      const staged = records.find(
+        (item) => item.source_record_id === localRecordId(record)
+      )
+      console.log(
+        `- refresh ${staged?.id} - ${record.extractedFields?.serviceTitle ?? record.extractedFields?.title ?? localRecordId(record)}`
+      )
+    }
+  }
+
+  const runs = await loadVerificationRuns(
+    admin,
+    records.map((record) => record.id)
+  )
+  const runsByRecord = new Map()
+  for (const run of runs) {
+    const values = runsByRecord.get(run.import_record_id) ?? []
+    values.push(run)
+    runsByRecord.set(run.import_record_id, values)
+  }
+  const evaluated = records.map((record) => ({
+    gaps: storedApprovalGaps(record, runsByRecord.get(record.id) ?? []),
+    record,
+  }))
+  const eligible = evaluated.filter((item) => item.gaps.length === 0)
+  const selected = eligible.slice(
+    0,
+    requestedIds.length > 0 ? requestedIds.length : limit
+  )
+  const acceptedMatches = await loadAcceptedMatches(
+    admin,
+    selected.map((item) => item.record.id)
+  )
+
+  console.log(
+    `Canary plan: ${eligible.length}/${records.length} unpromoted ${sourceSlug} records retain complete admin review and verification evidence; selected ${selected.length}; accepted duplicate matches ${acceptedMatches.size}.`
+  )
+  for (const item of selected) {
+    const duplicate = acceptedMatches.has(item.record.id)
+      ? " [accepted duplicate: promotion will block]"
+      : ""
+    console.log(
+      `- ${item.record.id} - ${titleForRecord(item.record)}${duplicate}`
+    )
+  }
+  const blockedCounts = {}
+  for (const item of evaluated.filter((item) => item.gaps.length > 0)) {
+    for (const gap of item.gaps)
+      blockedCounts[gap] = (blockedCounts[gap] ?? 0) + 1
+  }
+  if (Object.keys(blockedCounts).length > 0) {
+    console.log(
+      `Held: ${Object.entries(blockedCounts)
+        .map(([gap, count]) => `${gap}=${count}`)
+        .join(", ")}.`
+    )
+  }
 
   if (!apply) {
     console.log(
-      `Dry run: ${eligible.length} of ${records.length} unpromoted ${sourceSlug} records pass every publication gate after identified deterministic verification.`
+      "Dry run only; no review, verification, visibility, or publication state changed."
     )
     return
   }
+  if (selected.length !== records.length) {
+    throw new Error(
+      "Every explicitly requested record must pass the stored publication gates."
+    )
+  }
 
-  const verifiedRecords = await mapConcurrent(
-    eligible,
-    (record) => verifyRecord(admin, record, actorId, reason, verifiedAt),
-    concurrency
-  )
-  const promotionResults = await mapConcurrent(
-    verifiedRecords,
-    (record) => promoteRecord(admin, record),
-    concurrency
-  )
-  await exposeVerifiedContactAndLinks(admin, promotionResults)
-  const promoted = promotionResults.filter(
-    (result) => result.promotion_result === "promoted"
-  ).length
-  const alreadyPromoted = promotionResults.filter(
-    (result) => result.promotion_result === "already_promoted"
-  ).length
-  const blocked = promotionResults.filter(
-    (result) => result.promotion_result === "blocked"
-  ).length
+  const results = []
+  for (const item of selected)
+    results.push(await promoteRecord(admin, item.record))
+  const counts = {}
+  for (const result of results) {
+    counts[result.promotion_result] = (counts[result.promotion_result] ?? 0) + 1
+  }
   console.log(
-    `Verified and published ${promoted} ${sourceSlug} records; ${alreadyPromoted} were already promoted and ${blocked} were blocked as accepted duplicates.`
+    `Canary result: ${Object.entries(counts)
+      .map(([status, count]) => `${status}=${count}`)
+      .join(", ")}. Contacts and links retain their stored private visibility.`
   )
 }
 

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -288,8 +288,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "The guarded Cook County cooling-center dry run found 34/35 current local records passing the publication contract, including 25 matching unapproved staged rows, but selected zero publication candidates until refreshed fields, independent verification, and identified administrator review exist",
+        ],
+        state: "in_progress",
         title:
           "Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1182,8 +1182,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 21,
-      inProgress: 6,
-      notStarted: 8,
+      inProgress: 7,
+      notStarted: 7,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(60)

--- a/tests/acceptance/resource-map-import-records.test.ts
+++ b/tests/acceptance/resource-map-import-records.test.ts
@@ -402,33 +402,77 @@ describe("resource map import records", () => {
     expect(source).toContain("insertRowsInChunks")
   })
 
-  it("keeps official-source publication gated and auditable", async () => {
+  it("keeps official-source canaries behind stored review evidence", async () => {
     const source = readFileSync(VERIFY_AND_PUBLISH_SOURCE, "utf8")
-    const { buildVerifiedRecord } = await import(
-      pathToFileURL(VERIFY_AND_PUBLISH_SOURCE).href
-    )
-    const verified = buildVerifiedRecord(
+    const {
+      hasApprovedVerificationLedger,
+      storedApprovalGaps,
+      summarizeLocalDelta,
+    } = await import(pathToFileURL(VERIFY_AND_PUBLISH_SOURCE).href)
+    const ledger = [
       {
-        extracted_fields: {
-          enrichment: {
-            sourceComparisonCount: 2,
-            verification: { status: "needs_review" },
-          },
+        issues: [],
+        status: "completed",
+        structured_result: {
+          contradictions: [],
+          status: "approved",
+          unsupportedClaims: [],
         },
       },
-      "2026-07-15T15:00:00.000Z"
-    )
+    ]
 
-    expect(verified.extracted_fields.enrichment.verification.status).toBe(
-      "approved"
+    expect(hasApprovedVerificationLedger(ledger)).toBe(true)
+    expect(
+      summarizeLocalDelta(
+        [
+          {
+            extractedFields: {},
+            sourceId: "official-source",
+            sourceRecordId: "held-1",
+          },
+        ],
+        [{ source_record_id: "held-1" }],
+        "official-source"
+      )
+    ).toMatchObject({
+      held: 1,
+      matched: [],
+      missing: [],
+      publishable: 0,
+      total: 1,
+    })
+    expect(
+      storedApprovalGaps(
+        {
+          extracted_fields: {
+            enrichment: {
+              sourceComparisonCount: 2,
+              verification: { status: "needs_review" },
+            },
+          },
+          review_status: "needs_review",
+        },
+        ledger
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        "not_admin_approved",
+        "missing_identified_reviewer",
+        "missing_verification_time",
+        "enrichment_not_verified",
+      ])
     )
-    expect(verified.last_verified_at).toBe("2026-07-15T15:00:00.000Z")
     expect(source).toContain('source.trust_level !== "official"')
-    expect(source).toContain('actor.role !== "admin"')
     expect(source).toContain("analyzeResourceEnrichmentReadiness")
     expect(source).toContain("promote_resource_map_import_record")
-    expect(source).toContain('pass_type: "verification"')
-    expect(source).toContain("resource_map_curation_events")
+    expect(source).toContain("--confirm-source")
+    expect(source).toContain("Explicit --id values are required")
+    expect(source).not.toContain('resource_map_import_records")\n      .update')
+    expect(source).not.toContain("exposeVerifiedContactAndLinks")
+
+    const reviewSource = readFileSync(REVIEW_IMPORTS, "utf8")
+    expect(reviewSource).toContain("--actor-id is required with --apply")
+    expect(reviewSource).toContain('data.role !== "admin"')
   })
 
   it("links staged imports to raw ingestion records in the DB write path", () => {


### PR DESCRIPTION
## Summary

- Separate provider review and verification from publication.
- Publish only records with stored admin approval and a clean verification ledger.
- Cap canaries at five exact IDs with exact source confirmation.
- Keep contacts and intake links private.
- Add a read-only Cook County cooling-center comparison: 34 of 35 local records are publishable, 25 match staged records, 9 are not staged, and 0 currently pass the stored production review gate.

## Why

The existing command could create approval evidence and publish in one operation. Publication must consume prior human review and stored verification instead.

## Scope

No database or production data was changed.

## Verification

- Pre-push: 406 test files passed, 1 skipped.
- Acceptance: 2,112 tests passed, 1 skipped.
- Snapshots match.
- Structure, routes, features, thresholds, boundaries, workspace, interaction, React Grab, surface, and raw-button checks passed.
- Connected Cook County dry run selected zero records and made no state change.