### PR TITLE
[STEP S80] Close obsolete bulk contact endpoint

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3367,3 +3367,17 @@
 - The administrator review dry run matched only the three current records.
   Wave 6 criterion 3 remains in progress and overall completion remains
   `21/35` (`60%`). No record was reviewed, promoted, or made public.
+
+2026-08-13 22:28 EDT - closed the obsolete public resource bulk-detail path.
+
+- Production inspection found the released compact index contains no contact,
+  source, street-address, or detail fields, while the obsolete bare
+  `/api/public/resource-map/items` route still returned all `853` detailed
+  records, including `700` records with public contacts.
+- Replaced only that unused bare route with a temporary redirect to the bounded
+  200-record compact index. The existing per-record detail route and its
+  user-initiated phone and email actions remain unchanged.
+- Added a focused regression that locks the redirect and cache contract. No
+  CAPTCHA, contact relay, consent redesign, database write, review, promotion,
+  or publication change occurred. Overall PRD completion remains `21/35`
+  (`60%`).

--- a/src/app/api/public/resource-map/items/route.ts
+++ b/src/app/api/public/resource-map/items/route.ts
@@ -1,24 +1,10 @@
 import { NextResponse } from "next/server"
 
-import { serializeFindResourceDetailItem } from "@/features/find-resource-index"
-import { fetchPublicResourceMapItems } from "@/lib/queries/resource-map-public-items"
+const BOUNDED_RESOURCE_INDEX_PATH = "/api/public/resource-map/index?limit=200"
 
-export const revalidate = 300
-
-const PUBLIC_RESOURCE_MAP_ITEMS_CACHE_CONTROL =
-  "public, s-maxage=300, stale-while-revalidate=600"
-
-export async function GET() {
-  const resourceItems = await fetchPublicResourceMapItems()
-
-  return NextResponse.json(
-    {
-      resourceItems: resourceItems.map(serializeFindResourceDetailItem),
-    },
-    {
-      headers: {
-        "Cache-Control": PUBLIC_RESOURCE_MAP_ITEMS_CACHE_CONTROL,
-      },
-    }
-  )
+export function GET(request: Request) {
+  const destination = new URL(BOUNDED_RESOURCE_INDEX_PATH, request.url)
+  const response = NextResponse.redirect(destination, 307)
+  response.headers.set("Cache-Control", "public, max-age=300")
+  return response
 }

--- a/tests/acceptance/find-resource-index.test.ts
+++ b/tests/acceptance/find-resource-index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { GET as getLegacyResourceMapItems } from "@/app/api/public/resource-map/items/route"
 import {
   FIND_RESOURCE_INDEX_DEFAULT_PAGE_LIMIT,
   FIND_RESOURCE_INDEX_MAX_PAGE_LIMIT,
@@ -82,6 +83,18 @@ function buildResourceItem(): ExternalResourceMapItem {
 }
 
 describe("find resource index feature contract", () => {
+  it("redirects the obsolete bulk-detail endpoint to the bounded index", () => {
+    const response = getLegacyResourceMapItems(
+      new Request("https://coachhouse.app/api/public/resource-map/items")
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe(
+      "https://coachhouse.app/api/public/resource-map/index?limit=200"
+    )
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300")
+  })
+
   it("serializes only fields needed to place, filter, and identify resources", () => {
     const serialized = serializeFindResourceIndexItem(buildResourceItem())
 


### PR DESCRIPTION
## Summary
- redirect the obsolete bare bulk-detail endpoint to the bounded compact index
- preserve individual resource detail and user-initiated Call/Email actions
- add regression coverage and document the change

## Scope
- no database or publication changes
- no CAPTCHA, relay, or contact-consent redesign

## Verification
- focused resource-index suite: 34/34 passed
- pre-push gate: 406 files passed, 1 skipped; 2,115 tests passed, 1 skipped