### PR TITLE
[STEP S82] Add varied Chicago resource guides

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **22/35 complete (63%)**, **6 in progress**, and
-**7 not started**.
+revision. Current progress: **22/35 complete (63%)**, **7 in progress**, and
+**6 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -182,7 +182,7 @@ revision. Current progress: **22/35 complete (63%)**, **6 in progress**, and
 - [x] `wave-6-criterion-1` **Complete:** Report exact candidate, complete, verified, publishable, promoted, and public counts — Evidence: the 2026-08-13 read-only count refresh reports the expanded local curated snapshot separately at `5,046` candidates and `741` complete/verified/publishable records. Exact production aggregates report `2,184` staged and parity at `853` verified, administrator-approved, publishable, promoted, and anonymous public rows; artifact hashes and reproduction steps are recorded.
 - [x] `wave-6-criterion-2` **Complete:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: PRs #167-#171 repaired the selected housing, food, and immigrant/refugee cohorts; #171 hosted quality and both deployments passed. Housing two-source coverage increased from `92/106` to `99/106`; food contact or intake coverage increased from `644/752` to `748/752` and access-plus-comparison coverage from `615/752` to `647/752`; immigrant/refugee two-source identity coverage increased from `68/84` to `79/84`, including `74/79` service-eligible listings. Records blocked by real provider evidence failures remain explicitly held. Nothing was approved or published.
 - [x] `wave-6-criterion-3` **Complete:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records — Evidence: PRs #174-#175 refreshed existing staging and stored bounded live verification without importing, reviewing, or publishing unverified records. On 2026-08-13, the product owner reviewed and approved only Bremen Township, Brookfield Library, and Calumet Township; all three still matched the current 33-row official Cook County source. The guarded production canary selected exactly those three with zero accepted duplicate matches and promoted them atomically. Anonymous public parity increased only from 853 to 856, all three exact detail routes returned the intended records, and their three contacts plus six links remained private. Removed Markham and Maywood courthouse rows remain held. PR #177 and production CI also closed the obsolete bulk-detail endpoint before publication.
-- [ ] `wave-6-criterion-4` **Not started:** Publish current location-connected guides across multiple service categories.
+- [ ] `wave-6-criterion-4` **In progress:** Publish current location-connected guides across multiple service categories — Evidence: the current production catalog has 394 Chicago resources spanning food (201), community (114), housing (69), legal (31), family (23), and health (7). A focused implementation derives six Chicago guides from those public location and category fields, requires at least five current matching records per guide, preserves cooling-center guides, and changes no resource data. Merge, deployment, live guide counts, link checks, and production browser proof remain.
 - [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
 
 **Wave 7 — Integrated production release**

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3400,3 +3400,20 @@
   seed, unverified discovery record, deletion, or unrelated production state
   changed. Reversible hide controls remain available for the three canonical
   services and organizations.
+
+2026-08-13 22:42 EDT - added data-backed Chicago resource guides.
+
+- Measured the current 856-row production catalog read-only. Chicago has 394
+  public resources across food (`201`), community (`114`), housing (`69`),
+  legal (`31`), family (`23`), and health (`7`).
+- Added six derived Chicago guides for food access, housing and shelter,
+  immigration and legal help, libraries and community centers, youth and family
+  support, and health care. Each guide requires at least five current matching
+  records and disappears safely below that threshold.
+- Preserved existing cooling-center guides and the current guide-selection/map
+  behavior. Updated the Guides description so it no longer implies that every
+  guide is heat-related. No resource, review, contact, link, or production data
+  changed.
+- Wave 6 criterion 4 is in progress. Overall completion remains `22/35` (`63%`),
+  with `7` in progress and `6` not started. Continue with focused tests, browser
+  proof, hosted deployment, live guide counts, and link checks.

--- a/src/components/public/public-map-index/resource-guide-model.ts
+++ b/src/components/public/public-map-index/resource-guide-model.ts
@@ -94,6 +94,22 @@ function itemStateMatches(item: PublicMapItem, states: readonly string[]) {
   return states.some((candidate) => state === candidate.toLowerCase())
 }
 
+function itemHasResourceCategory(
+  item: PublicMapItem,
+  categories: readonly PublicMapResourceCategoryKey[]
+) {
+  return categories.some((category) =>
+    item.resourceCategories.some(
+      (itemCategory) =>
+        itemCategory === category || itemCategory.startsWith(`${category}_`)
+    )
+  )
+}
+
+function isChicagoGuideItem(item: PublicMapItem) {
+  return itemCityMatches(item, ["Chicago"]) && itemStateMatches(item, ["IL"])
+}
+
 function isCoolingCenterGuideItem(item: PublicMapItem) {
   const cached = coolingCenterGuideMatchByItem.get(item)
   if (cached !== undefined) return cached
@@ -129,6 +145,77 @@ function isNycCoolingCenterItem(item: PublicMapItem) {
 }
 
 const PUBLIC_MAP_RESOURCE_GUIDE_DEFINITIONS = [
+  {
+    id: "chicago-food-access",
+    title: "Chicago Food Access",
+    subtitle: "Food pantries, meals, and grocery support in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "food",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) && itemHasResourceCategory(item, ["food"]),
+  },
+  {
+    id: "chicago-housing-shelter",
+    title: "Chicago Housing and Shelter",
+    subtitle: "Shelter and housing-stability services in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "housing",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) && itemHasResourceCategory(item, ["housing"]),
+  },
+  {
+    id: "chicago-legal-help",
+    title: "Chicago Immigration and Legal Help",
+    subtitle: "Immigration and legal-aid services in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "legal",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) && itemHasResourceCategory(item, ["legal"]),
+  },
+  {
+    id: "chicago-libraries-community-centers",
+    title: "Chicago Libraries and Community Centers",
+    subtitle:
+      "Libraries and community centers with public services in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "community",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) &&
+      itemHasResourceCategory(item, [
+        "community_libraries",
+        "community_community_centers",
+      ]),
+  },
+  {
+    id: "chicago-family-support",
+    title: "Chicago Youth and Family Support",
+    subtitle: "Youth, caregiver, and family-support services in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "family",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) && itemHasResourceCategory(item, ["family"]),
+  },
+  {
+    id: "chicago-health-care",
+    title: "Chicago Health Care",
+    subtitle: "Health and mental-health services in Chicago.",
+    kicker: "Chicago guide",
+    minItems: 5,
+    primaryResourceCategory: "health",
+    visualVariant: "city",
+    matches: (item) =>
+      isChicagoGuideItem(item) && itemHasResourceCategory(item, ["health"]),
+  },
   {
     id: "nyc-cooling-centers",
     title: "NYC Cooling Centers",
@@ -345,16 +432,18 @@ export function buildPublicMapResourceGuides(
     const minItems = definition.minItems ?? 1
     if (guideItems.length < minItems) return []
 
-    return [{
-      id: definition.id,
-      title: definition.title,
-      subtitle: definition.subtitle,
-      kicker: definition.kicker,
-      itemCount: guideItems.length,
-      items: guideItems,
-      primaryResourceCategory:
-        definition.primaryResourceCategory ?? "emergency_cooling_centers",
-      visualVariant: definition.visualVariant,
-    } satisfies PublicMapResourceGuide]
+    return [
+      {
+        id: definition.id,
+        title: definition.title,
+        subtitle: definition.subtitle,
+        kicker: definition.kicker,
+        itemCount: guideItems.length,
+        items: guideItems,
+        primaryResourceCategory:
+          definition.primaryResourceCategory ?? "emergency_cooling_centers",
+        visualVariant: definition.visualVariant,
+      } satisfies PublicMapResourceGuide,
+    ]
   })
 }

--- a/src/components/public/public-map-index/resource-guides.tsx
+++ b/src/components/public/public-map-index/resource-guides.tsx
@@ -143,7 +143,7 @@ function PublicMapResourceGuidesHeader({ guideCount }: { guideCount: number }) {
           Guides
         </p>
         <p className="text-muted-foreground mt-1 text-sm text-pretty">
-          Cooling centers and heat relief groups
+          Current resources grouped by place and service
         </p>
       </div>
       <p className="text-muted-foreground shrink-0 text-xs tabular-nums">

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -296,8 +296,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "The current production catalog has 394 Chicago resources spanning food (201), community (114), housing (69), legal (31), family (23), and health (7); a focused implementation derives six Chicago guides from current public location and category fields with a minimum of five records per guide, while merge, deployment, live counts, link checks, and production browser proof remain",
+        ],
+        state: "in_progress",
         title:
           "Publish current location-connected guides across multiple service categories",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1182,8 +1182,8 @@ describe("finance release planning graph", () => {
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
       complete: 22,
-      inProgress: 6,
-      notStarted: 7,
+      inProgress: 7,
+      notStarted: 6,
       total: 35,
     })
     expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(63)

--- a/tests/acceptance/public-map-resource-map-items.test.ts
+++ b/tests/acceptance/public-map-resource-map-items.test.ts
@@ -938,6 +938,59 @@ describe("public map resource map items", () => {
     expect(guideById.get("senior-cooling-centers")?.itemCount).toBe(3)
   })
 
+  it("builds current Chicago guides across verified service categories", () => {
+    const guideCategories = [
+      ["food", "chicago-food-access", "food"],
+      ["housing", "chicago-housing-shelter", "housing"],
+      ["legal", "chicago-legal-help", "legal"],
+      [
+        "community_libraries",
+        "chicago-libraries-community-centers",
+        "community",
+      ],
+      ["family", "chicago-family-support", "family"],
+      ["health", "chicago-health-care", "health"],
+    ] as const
+    const resources = guideCategories.flatMap(
+      ([category, , primaryCategory], categoryIndex) =>
+        Array.from({ length: category === "health" ? 5 : 6 }, (_, itemIndex) =>
+          buildGuideResourceItem(
+            `resource_map:chicago-${categoryIndex}-${itemIndex}`,
+            {
+              city: "Chicago",
+              state: "IL",
+              title: `Chicago ${category} resource ${itemIndex + 1}`,
+              resourceCategories: [category],
+              primaryResourceCategory: primaryCategory,
+            }
+          )
+        )
+    )
+    resources.push(
+      ...Array.from({ length: 4 }, (_, index) =>
+        buildGuideResourceItem(`resource_map:gary-food-${index}`, {
+          city: "Gary",
+          state: "IN",
+          title: `Gary food resource ${index + 1}`,
+          resourceCategories: ["food"],
+          primaryResourceCategory: "food",
+        })
+      )
+    )
+
+    const guideById = new Map(
+      buildPublicMapResourceGuides(resources).map((guide) => [guide.id, guide])
+    )
+
+    for (const [category, guideId, primaryCategory] of guideCategories) {
+      expect(guideById.get(guideId)).toMatchObject({
+        itemCount: category === "health" ? 5 : 6,
+        primaryResourceCategory: primaryCategory,
+      })
+    }
+    expect(guideById.has("gary-food-access")).toBe(false)
+  })
+
   it("builds marker features with resource colors and legacy org selection ids", () => {
     const organization = buildOrganization()
     const items = buildPublicMapItems({


### PR DESCRIPTION
## Summary
- add six live-data-derived Chicago guides across food, housing, legal, community, family, and health
- require at least five matching current records so sparse guides disappear safely
- preserve existing cooling-center guides and guide selection behavior
- mark Wave 6 criterion 4 in progress

## Source of truth
Read-only production catalog counts: 394 Chicago records; food 201, community 114, housing 69, legal 31, family 23, health 7. Guides match current public city, state, and category fields only.

## Verification
- focused guide and PRD parity tests: 64/64
- pre-push: 406 files passed, 1 skipped; 2,116 tests passed, 1 skipped
- structure, boundaries, snapshots, React Grab, and raw-button gates passed

## Limitations
- local visual preview was stopped after the isolated-worktree dependency symlink caused a slow webpack compile
- hosted preview and production counts remain before criterion completion
- no resource, review, contact, link, or database state changed