### PR TITLE
[STEP S84] Record Wave 6 release safety proof

### DIFF
--- a/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
+++ b/docs/plans/2026-08-04-finance-fundraising-find-release-design.md
@@ -134,8 +134,8 @@ wave, but unrelated scope does not accumulate in one PR.
 
 Only checked criteria count toward the percentage. Criterion IDs and the
 35-item denominator are stable; changing either requires an explicit PRD
-revision. Current progress: **23/35 complete (66%)**, **6 in progress**, and
-**6 not started**.
+revision. Current progress: **24/35 complete (69%)**, **6 in progress**, and
+**5 not started**.
 
 **Wave 1 — Live stability and existing work close**
 
@@ -183,7 +183,7 @@ revision. Current progress: **23/35 complete (66%)**, **6 in progress**, and
 - [x] `wave-6-criterion-2` **Complete:** Fix resource listings missing provider proof, eligibility, a clear summary, access steps, contact details, or a second source — Evidence: PRs #167-#171 repaired the selected housing, food, and immigrant/refugee cohorts; #171 hosted quality and both deployments passed. Housing two-source coverage increased from `92/106` to `99/106`; food contact or intake coverage increased from `644/752` to `748/752` and access-plus-comparison coverage from `615/752` to `647/752`; immigrant/refugee two-source identity coverage increased from `68/84` to `79/84`, including `74/79` service-eligible listings. Records blocked by real provider evidence failures remain explicitly held. Nothing was approved or published.
 - [x] `wave-6-criterion-3` **Complete:** Publish toward 5,000 useful resources without raw intake, synthetic seeds, or unverified discovery records — Evidence: PRs #174-#175 refreshed existing staging and stored bounded live verification without importing, reviewing, or publishing unverified records. On 2026-08-13, the product owner reviewed and approved only Bremen Township, Brookfield Library, and Calumet Township; all three still matched the current 33-row official Cook County source. The guarded production canary selected exactly those three with zero accepted duplicate matches and promoted them atomically. Anonymous public parity increased only from 853 to 856, all three exact detail routes returned the intended records, and their three contacts plus six links remained private. Removed Markham and Maywood courthouse rows remain held. PR #177 and production CI also closed the obsolete bulk-detail endpoint before publication.
 - [x] `wave-6-criterion-4` **Complete:** Publish current location-connected guides across multiple service categories — Evidence: PR #179 merged as `729ec3f5`; quality and both production deployments passed, and the custom domain serves the released guide bundle. The canonical paginated public API returned all 856 resources and exact live Chicago guide counts for food (201), housing (69), legal (31), libraries/community centers (103), family (23), and health (7). One exact item-detail route per guide returned `200`. The six guides derive only from current public location and category fields, require at least five matches, preserve cooling-center guides, and change no resource data.
-- [ ] `wave-6-criterion-5` **Not started:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof.
+- [x] `wave-6-criterion-5` **Complete:** Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof — Evidence: the approved Bremen, Brookfield, and Calumet canary records remained present in the complete 856-row anonymous catalog, and all three exact detail routes plus the shared official Cook County source returned `200`. A bounded production rehearsal hid only the approved Bremen service, verified the canonical public projection changed from 856 to 855 with that service absent, then restored it in `finally` and verified exact recovery to 856 with the service present. The final service is published with no hidden, suppressed, or deleted marker; audited `hide` and `restore` events preserve both states. `/find`, quality, and both production deployments are healthy.
 
 **Wave 7 — Integrated production release**
 

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3430,3 +3430,19 @@
   unresponsive, so no extended visual test loop was attempted.
 - Marked Wave 6 criterion 4 complete. Overall completion is now `23/35` (`66%`),
   with `6` in progress and `6` not started. No resource or database data changed.
+
+2026-08-13 23:31 EDT - completed Wave 6 release safety and rollback proof.
+
+- Rechecked the three approved Cook County canaries in production. The complete
+  anonymous catalog loaded `856/856` unique records; Bremen, Brookfield, and
+  Calumet were present, their exact detail routes returned `200`, and their
+  shared official Cook County source returned `200`.
+- Rehearsed reversible unpublishing against only the approved Bremen service.
+  The canonical public projection changed from `856` to `855` with Bremen
+  absent, then a `finally` restoration returned it exactly to `856` and present.
+- Final state is published with no hidden, suppressed, or deleted marker.
+  Identified-administrator `hide` and `restore` curation events preserve the
+  before and after states. No record was deleted and no other record changed.
+- Production `/find` returned `200`; PR #180 quality and both production
+  deployments passed. Marked Wave 6 criterion 5 and Wave 6 complete. Overall
+  completion is now `24/35` (`69%`), with `6` in progress and `5` not started.

--- a/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
+++ b/src/features/prototype-lab/components/finance/finance-plan-wave-progress.ts
@@ -268,7 +268,7 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
   {
     id: "wave-6-resources-guides",
     sequence: 6,
-    status: "active",
+    status: "production_verified",
     title: "Qualified resources and varied guides",
     criteria: defineCriteria(6, [
       {
@@ -304,8 +304,10 @@ export const FINANCE_PLAN_WAVES: readonly FinancePlanWave[] = [
           "Publish current location-connected guides across multiple service categories",
       },
       {
-        evidence: [],
-        state: "not_started",
+        evidence: [
+          "The approved Bremen, Brookfield, and Calumet canaries remained present in the complete 856-row anonymous catalog, and their three exact detail routes plus the shared official Cook County source returned 200; a bounded production rehearsal hid only the approved Bremen service, verified the canonical public projection changed from 856 to 855 with that service absent, restored it in finally, and verified exact recovery to 856; the final service is published with no hidden, suppressed, or deleted marker, audited hide and restore events preserve both states, and /find, quality, and both production deployments are healthy",
+        ],
+        state: "complete",
         title:
           "Complete cohort canary, count parity, broken-link checks, production monitoring, and reversible unpublish proof",
       },

--- a/tests/acceptance/prototype-finance-release-plan.test.ts
+++ b/tests/acceptance/prototype-finance-release-plan.test.ts
@@ -1169,24 +1169,25 @@ describe("finance release planning graph", () => {
     )
     expect(FINANCE_PLAN_WAVES.map((wave) => wave.status)).toEqual([
       "production_verified",
-      ...Array(5).fill("active"),
+      ...Array(4).fill("active"),
+      "production_verified",
       "queued",
     ])
     expect(FINANCE_PLAN_WAVE_STATUS_COUNTS).toEqual({
-      active: 5,
+      active: 4,
       codeComplete: 0,
       previewVerified: 0,
-      productionVerified: 1,
+      productionVerified: 2,
       queued: 1,
       total: 7,
     })
     expect(FINANCE_PLAN_WAVE_COUNTS).toEqual({
-      complete: 23,
+      complete: 24,
       inProgress: 6,
-      notStarted: 6,
+      notStarted: 5,
       total: 35,
     })
-    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(66)
+    expect(FINANCE_PLAN_COMPLETION_PERCENTAGE).toBe(69)
     expect(sourceCriteria).toHaveLength(35)
     expect(sourceCriteria.map((criterion) => criterion.id)).toEqual(
       trackedCriteria.map((criterion) => criterion.id)
@@ -1275,9 +1276,9 @@ describe("finance release planning graph", () => {
       roadmapNodes.find((node) => node.id === nodeId)?.data
 
     expect(FINANCE_PLAN_CURRENT_FOCUS).toMatchObject({
-      complete: 23,
-      percentage: 66,
-      remaining: 12,
+      complete: 24,
+      percentage: 69,
+      remaining: 11,
       total: 35,
       waveId: "wave-2-signup-legal",
       waveLabel: "Wave 2: Signup, recovery, and legal",


### PR DESCRIPTION
## Summary
- complete Wave 6 count, canary, link, monitoring, and rollback evidence
- mark Wave 6 production-verified
- advance the fixed PRD tracker to 24/35 (69%)

## Production evidence
- complete anonymous catalog: 856/856 unique records
- Bremen, Brookfield, and Calumet present; three detail routes returned 200
- shared official Cook County source returned 200
- bounded Bremen rehearsal: 856 public -> 855 hidden -> 856 restored
- final state is published with no hidden, suppressed, or deleted marker
- audited hide and restore events preserve both states
- `/find`, quality, and both production deployments passed
- no deletion or unrelated record change

## Verification
- `pnpm exec vitest tests/acceptance/prototype-finance-release-plan.test.ts --run` (37/37)
- `pnpm check:structure`
- pre-push gate (406 files passed, 1 skipped; 2,116 tests passed, 1 skipped)
- `git diff --check`