### PR TITLE
[STEP S85] Verify immutable signup consent RLS

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3430,3 +3430,16 @@
   unresponsive, so no extended visual test loop was attempted.
 - Marked Wave 6 criterion 4 complete. Overall completion is now `23/35` (`66%`),
   with `6` in progress and `6` not started. No resource or database data changed.
+
+2026-08-13 23:40 EDT - proved signup legal acceptance through connected RLS.
+
+- Added the current legal version and content hashes to the existing ephemeral
+  RLS member fixture so the real `auth.users` trigger records consent.
+- Connected production RLS verified the user-linked version, both hashes,
+  server UTC acceptance time, and `signup` source; the user could read only
+  their row, another authenticated user and anonymous caller could not read it,
+  and authenticated insert, update, and delete attempts were denied.
+- The existing user cleanup cascaded the acceptance row. Production acceptance
+  count was `0` before and `0` after, so no account or consent record remains.
+- Focused legal acceptance passed `5/5`; Fiscal, Finance, and the full connected
+  RLS matrix passed. No email was sent and no lasting production data changed.

--- a/supabase/tests/rls.test.mjs
+++ b/supabase/tests/rls.test.mjs
@@ -71,6 +71,14 @@ const orgAdminEmail = `org-admin-${suffix}@example.com`
 const coachEmail = `coach-${suffix}@example.com`
 const secondCoachEmail = `coach-2-${suffix}@example.com`
 const password = `TempPass!${suffix}`
+const signupLegalConsent = {
+  version: "2026-08-12.1",
+  termsSha256:
+    "405e53cfa64e4dba9ecb4e04289d82ed0b8f20b70a233a4b310996d63493e5a2",
+  privacySha256:
+    "c4ff2282fa5033042d4bcee3ed26ac4b1a5863b4cabd1346084c3d6097853d92",
+  acceptedAt: new Date().toISOString(),
+}
 
 async function ensureProfile(id, role, fullName) {
   const { error } = await adminClient.from("profiles").upsert(
@@ -92,6 +100,7 @@ async function createUsers() {
     email: memberEmail,
     password,
     email_confirm: true,
+    user_metadata: { legal_consent: signupLegalConsent },
   })
   if (memberError) throw memberError
 
@@ -298,6 +307,81 @@ async function run() {
   })
 
   const results = []
+
+  if (await tableExists("platform_legal_acceptances")) {
+    const { data: ownAcceptance, error: ownAcceptanceError } =
+      await memberClient
+        .from("platform_legal_acceptances")
+        .select(
+          "id,user_id,document_version,terms_sha256,privacy_sha256,accepted_at,source"
+        )
+        .eq("user_id", member.id)
+        .eq("document_version", signupLegalConsent.version)
+        .maybeSingle()
+    results.push({
+      name: "signup trigger records the current immutable legal acceptance",
+      passed:
+        !ownAcceptanceError &&
+        ownAcceptance?.user_id === member.id &&
+        ownAcceptance?.document_version === signupLegalConsent.version &&
+        ownAcceptance?.terms_sha256 === signupLegalConsent.termsSha256 &&
+        ownAcceptance?.privacy_sha256 === signupLegalConsent.privacySha256 &&
+        ownAcceptance?.source === "signup" &&
+        typeof ownAcceptance?.accepted_at === "string" &&
+        new Date(ownAcceptance?.accepted_at).toISOString() ===
+          new Date(member.created_at).toISOString(),
+    })
+
+    const { data: otherAcceptance, error: otherAcceptanceError } =
+      await adminSessionClient
+        .from("platform_legal_acceptances")
+        .select("id")
+        .eq("user_id", member.id)
+        .maybeSingle()
+    results.push({
+      name: "authenticated users cannot read another legal acceptance",
+      passed: !otherAcceptanceError && !otherAcceptance,
+    })
+
+    const { data: anonAcceptance, error: anonAcceptanceError } =
+      await anonClient
+        .from("platform_legal_acceptances")
+        .select("id")
+        .eq("user_id", member.id)
+    results.push({
+      name: "anonymous users cannot read legal acceptances",
+      passed:
+        !!anonAcceptanceError ||
+        (Array.isArray(anonAcceptance) && anonAcceptance.length === 0),
+    })
+
+    const acceptanceId = ownAcceptance?.id ?? -1
+    const { error: acceptanceInsertError } = await memberClient
+      .from("platform_legal_acceptances")
+      .insert({
+        user_id: member.id,
+        document_version: "rls-write-probe",
+        terms_sha256: "a".repeat(64),
+        privacy_sha256: "b".repeat(64),
+        accepted_at: new Date().toISOString(),
+        source: "signup",
+      })
+    const { error: acceptanceUpdateError } = await memberClient
+      .from("platform_legal_acceptances")
+      .update({ accepted_at: new Date().toISOString() })
+      .eq("id", acceptanceId)
+    const { error: acceptanceDeleteError } = await memberClient
+      .from("platform_legal_acceptances")
+      .delete()
+      .eq("id", acceptanceId)
+    results.push({
+      name: "authenticated users cannot mutate immutable legal acceptances",
+      passed:
+        !!acceptanceInsertError &&
+        !!acceptanceUpdateError &&
+        !!acceptanceDeleteError,
+    })
+  }
 
   if (await tableExists("platform_staff_members")) {
     const [

--- a/tests/acceptance/legal-consent.test.ts
+++ b/tests/acceptance/legal-consent.test.ts
@@ -148,6 +148,15 @@ describe("legal consent", () => {
       `consent ->> 'privacySha256' = '${PRIVACY_DOCUMENT.sha256}'`
     )
 
+    const rlsSuite = readFileSync("supabase/tests/rls.test.mjs", "utf8")
+    expect(rlsSuite).toContain(
+      "signup trigger records the current immutable legal acceptance"
+    )
+    expect(rlsSuite).toContain(
+      "authenticated users cannot mutate immutable legal acceptances"
+    )
+    expect(rlsSuite).toContain("anonymous users cannot read legal acceptances")
+
     const testerAction = readFileSync(
       "src/app/(auth)/tester/sign-up/actions.ts",
       "utf8"


### PR DESCRIPTION
## Summary
- add an ephemeral legal-consent fixture to the connected RLS suite
- prove the live auth trigger records the current version, both content hashes, user, server UTC time, and signup source
- prove own-row reads and deny cross-user, anonymous, insert, update, and delete access
- retain automatic auth-user cleanup and consent cascade

## Production evidence
- connected Fiscal, Finance, and full RLS matrices passed
- consent trigger and four consent isolation checks passed
- legal acceptance count was 0 before and 0 after
- no email was sent and no account or consent row remains

## Verification
- focused legal acceptance: 5/5
- connected `pnpm test:rls`
- pre-push gate: 406 files passed, 1 skipped; 2,116 tests passed, 1 skipped
- `git diff --check`

## Tracker note
This adds durable proof coverage. Update the fixed PRD percentage only after this PR and the open Wave 6 proof PR are merged.