### PR TITLE
[STEP S88] Protect Find interaction readiness

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3481,3 +3481,14 @@
 - Confirmed PR #183 merged as `5e694663` after quality, Supabase Preview, and
   both Vercel previews passed. Marked Wave 2 criterion 2 complete. Overall PRD
   completion is now `25/35` (`71%`), with `5` in progress and `5` not started.
+
+2026-08-14 00:32 EDT - protected Find interaction readiness from Mapbox startup.
+
+- Used the latest bounded production baseline: FCP `1.7s`, LCP `4.7s`, and TTI
+  `35.0s`, with Mapbox evaluation dominating the throttled main thread.
+- Extended automatic Mapbox startup to an `8s` interaction-ready boundary so
+  the shell can establish a five-second quiet window. A pointer action on the
+  map still starts Mapbox immediately, preserving explicit user intent.
+- No payload, map behavior after startup, signup, account, or production data
+  changed. Wave 3 criterion 5 remains in progress pending preview and production
+  mobile performance measurements.

--- a/src/components/public/public-map-index/public-map-index-runtime.ts
+++ b/src/components/public/public-map-index/public-map-index-runtime.ts
@@ -27,7 +27,7 @@ import {
 export type PublicMapMapboxApi = (typeof import("mapbox-gl"))["default"]
 export { isRecoverablePublicMapTileError } from "./public-map-runtime-errors"
 
-const PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 2_500
+const PUBLIC_MAP_INTERACTION_READY_DELAY_MS = 8_000
 
 function applyPublicMapGlobePresentation(map: mapboxgl.Map) {
   map.setProjection("globe")
@@ -334,15 +334,32 @@ export function useInitializePublicMap({
       }
     }
 
+    let initializationStarted = false
     let initializeTimeoutId: number | null = null
+    const mapContainer = containerRef.current
+    const startMap = () => {
+      if (cancelled || initializationStarted) return
+      initializationStarted = true
+      if (initializeTimeoutId !== null) {
+        window.clearTimeout(initializeTimeoutId)
+        initializeTimeoutId = null
+      }
+      void initializeMap()
+    }
+    mapContainer.addEventListener("pointerdown", startMap, {
+      once: true,
+      passive: true,
+    })
     const initializeFrameId = window.requestAnimationFrame(() => {
+      if (cancelled || initializationStarted) return
       initializeTimeoutId = window.setTimeout(() => {
-        void initializeMap()
-      }, PUBLIC_MAP_INITIAL_PAINT_DELAY_MS)
+        startMap()
+      }, PUBLIC_MAP_INTERACTION_READY_DELAY_MS)
     })
 
     return () => {
       cancelled = true
+      mapContainer.removeEventListener("pointerdown", startMap)
       window.cancelAnimationFrame(initializeFrameId)
       if (initializeTimeoutId !== null) {
         window.clearTimeout(initializeTimeoutId)

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -43,7 +43,7 @@ describe("public Find performance contract", () => {
     )
   })
 
-  it("lets the initial shell paint before starting Mapbox", () => {
+  it("keeps the shell interactive before automatic Mapbox startup", () => {
     const source = readSource(
       "src/components/public/public-map-index/public-map-index-runtime.ts"
     )
@@ -51,8 +51,17 @@ describe("public Find performance contract", () => {
     expect(source).toContain(
       "const initializeFrameId = window.requestAnimationFrame"
     )
-    expect(source).toContain("PUBLIC_MAP_INITIAL_PAINT_DELAY_MS = 2_500")
+    expect(source).toContain(
+      "PUBLIC_MAP_INTERACTION_READY_DELAY_MS = 8_000"
+    )
     expect(source).toContain("initializeTimeoutId = window.setTimeout")
+    expect(source).toContain(
+      'mapContainer.addEventListener("pointerdown", startMap'
+    )
+    expect(source).toContain("if (cancelled || initializationStarted) return")
+    expect(source).toContain(
+      'mapContainer.removeEventListener("pointerdown", startMap)'
+    )
     expect(source).toContain("window.cancelAnimationFrame(initializeFrameId)")
     expect(source).toContain("window.clearTimeout(initializeTimeoutId)")
   })


### PR DESCRIPTION
## Summary

- reserve an 8-second automatic Mapbox startup boundary for the initial interaction window
- start Mapbox immediately when the user presses the map
- preserve all map behavior after startup

## Baseline

- production mobile FCP: 1.7s
- production mobile LCP: 4.7s
- production mobile TTI: 35.0s
- Mapbox evaluation dominated the throttled main thread

## Validation

- focused Find performance and route coverage: 23/23
- pre-push: 406 files passed, 1 skipped; 2,118 tests passed, 1 skipped

## Remaining release proof

Preview and production mobile measurements are required before Wave 3 criterion 5 is complete.