### PR TITLE
[STEP S78] Defer mobile Find map startup

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3694,3 +3694,23 @@
 - The focused tracker contract passed `37/37`. Full local quality passed with
   `2,136` acceptance tests, focused RLS, the 112-route build, 30 visual tests,
   and performance budgets.
+
+2026-08-14 17:35 EDT - prepared mobile Find interaction-only map startup.
+
+- Measured the current production `/find` mobile baseline with Lighthouse
+  12.8.2: performance `35`, FCP `1.60s`, LCP `10.36s`, TTI `47.87s`, TBT
+  `44.77s`, CLS `0.0004`, and `2.91MB` transferred.
+- Prevented coarse-pointer clients from automatically loading Mapbox after the
+  existing eight-second delay. Mobile now loads it only when the user touches
+  or keyboard-activates the map; fine-pointer clients keep delayed startup.
+- Added a keyboard-focusable map region and extended the focused performance
+  contract. A mobile production-build browser check found zero Mapbox canvases
+  and requests after nine idle seconds, then one canvas and four requests after
+  a touch activation. Local Vercel scripts returned their expected `404`s and
+  domain-restricted Mapbox tiles returned `403`s, so hosted visual proof remains.
+- Full isolated quality passed: lint and all guardrails, snapshots, `2,136`
+  acceptance tests, focused signup/fiscal/Finance/page-health RLS, the 112-route
+  build, `30/30` visuals, and performance budgets. The optional generic
+  connected RLS fixture skipped without credentials. Hosted preview, merge,
+  deployment, and production after-measurement remain pending. The fixed
+  checklist remains `27/35` (`77%`).

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -267,6 +267,8 @@ export function PublicMapSurface({
               ref={containerRef}
               className="h-full w-full [&_.mapboxgl-ctrl-logo]:!hidden"
               aria-label="Public organization map"
+              role="region"
+              tabIndex={0}
             />
           </div>
           <div className="pointer-events-none absolute inset-0 hidden dark:block dark:bg-[linear-gradient(180deg,rgba(250,250,250,0.08),rgba(250,250,250,0.025)_28%,rgba(24,24,27,0.015)_58%,rgba(9,9,11,0.06))]" />

--- a/src/components/public/public-map-index/public-map-index-runtime.ts
+++ b/src/components/public/public-map-index/public-map-index-runtime.ts
@@ -28,6 +28,7 @@ export type PublicMapMapboxApi = (typeof import("mapbox-gl"))["default"]
 export { isRecoverablePublicMapTileError } from "./public-map-runtime-errors"
 
 const PUBLIC_MAP_INTERACTION_READY_DELAY_MS = 8_000
+const PUBLIC_MAP_COARSE_POINTER_MEDIA_QUERY = "(pointer: coarse)"
 
 function applyPublicMapGlobePresentation(map: mapboxgl.Map) {
   map.setProjection("globe")
@@ -336,6 +337,7 @@ export function useInitializePublicMap({
 
     let initializationStarted = false
     let initializeTimeoutId: number | null = null
+    let initializeFrameId: number | null = null
     const mapContainer = containerRef.current
     const startMap = () => {
       if (cancelled || initializationStarted) return
@@ -346,21 +348,36 @@ export function useInitializePublicMap({
       }
       void initializeMap()
     }
+    const startMapFromKeyboard = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" && event.key !== " ") return
+      event.preventDefault()
+      startMap()
+    }
     mapContainer.addEventListener("pointerdown", startMap, {
       once: true,
       passive: true,
     })
-    const initializeFrameId = window.requestAnimationFrame(() => {
-      if (cancelled || initializationStarted) return
-      initializeTimeoutId = window.setTimeout(() => {
-        startMap()
-      }, PUBLIC_MAP_INTERACTION_READY_DELAY_MS)
-    })
+    mapContainer.addEventListener("keydown", startMapFromKeyboard)
+
+    const hasCoarsePointer = window.matchMedia(
+      PUBLIC_MAP_COARSE_POINTER_MEDIA_QUERY
+    ).matches
+    if (!hasCoarsePointer) {
+      initializeFrameId = window.requestAnimationFrame(() => {
+        if (cancelled || initializationStarted) return
+        initializeTimeoutId = window.setTimeout(() => {
+          startMap()
+        }, PUBLIC_MAP_INTERACTION_READY_DELAY_MS)
+      })
+    }
 
     return () => {
       cancelled = true
       mapContainer.removeEventListener("pointerdown", startMap)
-      window.cancelAnimationFrame(initializeFrameId)
+      mapContainer.removeEventListener("keydown", startMapFromKeyboard)
+      if (initializeFrameId !== null) {
+        window.cancelAnimationFrame(initializeFrameId)
+      }
       if (initializeTimeoutId !== null) {
         window.clearTimeout(initializeTimeoutId)
       }

--- a/tests/acceptance/public-find-performance-contract.test.ts
+++ b/tests/acceptance/public-find-performance-contract.test.ts
@@ -43,13 +43,16 @@ describe("public Find performance contract", () => {
     )
   })
 
-  it("keeps the shell interactive before automatic Mapbox startup", () => {
+  it("keeps the shell interactive before intentional Mapbox startup", () => {
     const source = readSource(
       "src/components/public/public-map-index/public-map-index-runtime.ts"
     )
+    const surfaceSource = readSource(
+      "src/components/public/public-map-index/map-surface.tsx"
+    )
 
     expect(source).toContain(
-      "const initializeFrameId = window.requestAnimationFrame"
+      "initializeFrameId = window.requestAnimationFrame"
     )
     expect(source).toContain(
       "PUBLIC_MAP_INTERACTION_READY_DELAY_MS = 8_000"
@@ -58,12 +61,24 @@ describe("public Find performance contract", () => {
     expect(source).toContain(
       'mapContainer.addEventListener("pointerdown", startMap'
     )
+    expect(source).toContain(
+      'PUBLIC_MAP_COARSE_POINTER_MEDIA_QUERY = "(pointer: coarse)"'
+    )
+    expect(source).toContain("if (!hasCoarsePointer)")
+    expect(source).toContain(
+      'mapContainer.addEventListener("keydown", startMapFromKeyboard)'
+    )
     expect(source).toContain("if (cancelled || initializationStarted) return")
     expect(source).toContain(
       'mapContainer.removeEventListener("pointerdown", startMap)'
     )
+    expect(source).toContain(
+      'mapContainer.removeEventListener("keydown", startMapFromKeyboard)'
+    )
     expect(source).toContain("window.cancelAnimationFrame(initializeFrameId)")
     expect(source).toContain("window.clearTimeout(initializeTimeoutId)")
+    expect(surfaceSource).toContain('role="region"')
+    expect(surfaceSource).toContain("tabIndex={0}")
   })
 
   it("renders the intended location consent state in the initial shell", () => {


### PR DESCRIPTION
## Summary

- keep coarse-pointer `/find` clients interactive without automatic Mapbox startup
- load Mapbox on touch or keyboard activation; preserve delayed desktop startup
- record measured production baseline and local browser proof

## Validation

- `pnpm check:quality`
- 2,136 acceptance tests; 1 intentional skip
- focused signup, fiscal, Finance, and page-health RLS suites
- 112-route production build
- 30/30 visual tests
- performance budgets
- mobile production-build browser: 0 Mapbox requests after 9 idle seconds; map loads after touch

## Remaining proof

- hosted preview interaction and console check
- production Lighthouse after merge
- final production smoke and monitoring window

The optional generic connected RLS fixture skipped without isolated credentials. Local Vercel telemetry scripts returned expected 404s and domain-restricted Mapbox tiles returned expected 403s.