### PR TITLE
[STEP S79] Bound public Find logo downloads

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3714,3 +3714,21 @@
   connected RLS fixture skipped without credentials. Hosted preview, merge,
   deployment, and production after-measurement remain pending. The fixed
   checklist remains `27/35` (`77%`).
+
+2026-08-14 18:15 EDT - bounded initial Find logo downloads.
+
+- PR #196 merged as `b65cb50a`; both production deployments completed. A
+  production mobile browser check made zero Mapbox requests after nine idle
+  seconds, then loaded the map on touch with no HTTP, console, or page errors.
+- The first production after-run improved Lighthouse performance from `35` to
+  `46` and LCP from `10.36s` to `4.84s`, but still downloaded `2.45MB`. Two
+  original Supabase-hosted logos accounted for about `1.46MB`.
+- Added bounded `144x144`, quality-75 Supabase image transforms for public Find
+  list avatars while preserving external URLs and logo/header crop behavior.
+  A mobile production-build browser check found all seven rendered list avatars
+  using the bounded transform path and none using original public-object URLs.
+- Full isolated quality passed with `2,138` acceptance tests, focused
+  signup/fiscal/Finance/page-health RLS suites, the 112-route build, `30/30`
+  visuals, and performance budgets. The optional generic connected RLS fixture
+  skipped without credentials. Preview, merge, and production proof remain.
+  The fixed checklist remains `27/35` (`77%`).

--- a/src/components/public/public-map-index/organization-list-platform-card.tsx
+++ b/src/components/public/public-map-index/organization-list-platform-card.tsx
@@ -3,6 +3,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { formatCompactOrganizationLocation } from "@/lib/location/organization-location"
 import type { PlatformOrganizationMapItem } from "@/lib/public-map/resource-map-items"
+import { buildPublicImageTransformUrl } from "@/lib/storage/public-url"
 import { cn } from "@/lib/utils"
 import { OrganizationListActivityPreview } from "./organization-list-activity-preview"
 import {
@@ -49,8 +50,15 @@ export function PublicMapPlatformOrganizationListCard({
     ? previewPrograms.slice(0, 2)
     : previewPrograms
   const fallbackInitials = buildInitials(org.name)
-  const avatarImageSrc = org.logoUrl ?? org.headerUrl ?? undefined
   const hasLogoImage = Boolean(org.logoUrl && org.logoUrl.trim().length > 0)
+  const avatarImageSrc = buildPublicImageTransformUrl(
+    org.logoUrl ?? org.headerUrl ?? undefined,
+    {
+      width: 144,
+      height: 144,
+      resize: hasLogoImage ? "contain" : "cover",
+    }
+  )
   const ownerId = buildPublicMapOrganizationListCardOwnerId(org.id)
   const openDetails = () =>
     onOpenDetails ? onOpenDetails(org.id) : onSelectOrg(org.id)

--- a/src/lib/storage/public-url.ts
+++ b/src/lib/storage/public-url.ts
@@ -1,6 +1,45 @@
 const PUBLIC_OBJECT_PREFIX = "/storage/v1/object/public/"
+const PUBLIC_IMAGE_RENDER_PREFIX = "/storage/v1/render/image/public/"
 
-export function extractPublicObjectPath(url: string, bucket: string): string | null {
+export function buildPublicImageTransformUrl(
+  url: string | undefined,
+  {
+    height,
+    quality = 75,
+    resize = "contain",
+    width,
+  }: {
+    height: number
+    quality?: number
+    resize?: "contain" | "cover"
+    width: number
+  }
+): string | undefined {
+  if (!url) return url
+
+  try {
+    const parsed = new URL(url)
+    if (!parsed.hostname.endsWith(".supabase.co")) return url
+    if (!parsed.pathname.includes(PUBLIC_OBJECT_PREFIX)) return url
+
+    parsed.pathname = parsed.pathname.replace(
+      PUBLIC_OBJECT_PREFIX,
+      PUBLIC_IMAGE_RENDER_PREFIX
+    )
+    parsed.searchParams.set("width", String(width))
+    parsed.searchParams.set("height", String(height))
+    parsed.searchParams.set("resize", resize)
+    parsed.searchParams.set("quality", String(quality))
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+export function extractPublicObjectPath(
+  url: string,
+  bucket: string
+): string | null {
   if (!url) return null
   try {
     const parsed = new URL(url)

--- a/tests/acceptance/public-storage-image-transform.test.ts
+++ b/tests/acceptance/public-storage-image-transform.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { buildPublicImageTransformUrl } from "@/lib/storage/public-url"
+
+describe("public storage image transforms", () => {
+  it("requests bounded Supabase public images", () => {
+    expect(
+      buildPublicImageTransformUrl(
+        "https://project.supabase.co/storage/v1/object/public/org-media/org/logo.png",
+        { width: 144, height: 144, resize: "contain" }
+      )
+    ).toBe(
+      "https://project.supabase.co/storage/v1/render/image/public/org-media/org/logo.png?width=144&height=144&resize=contain&quality=75"
+    )
+  })
+
+  it("leaves non-Supabase and invalid URLs unchanged", () => {
+    expect(
+      buildPublicImageTransformUrl("https://example.org/logo.png", {
+        width: 144,
+        height: 144,
+      })
+    ).toBe("https://example.org/logo.png")
+    expect(
+      buildPublicImageTransformUrl("not a URL", {
+        width: 144,
+        height: 144,
+      })
+    ).toBe("not a URL")
+  })
+})


### PR DESCRIPTION
## Summary

- serve public Find list avatars through bounded Supabase image transforms
- preserve external URLs and existing logo/header crop behavior
- cut two observed original logo downloads totaling about 1.46 MB

## Validation

- `pnpm check:quality`
- 2,138 acceptance tests; 1 intentional skip
- focused signup, fiscal, Finance, and page-health RLS suites
- 112-route production build
- 30/30 visual tests
- performance budgets
- mobile production-build browser: 7/7 rendered avatars transformed; 0 original public-object URLs

## Remaining proof

- hosted deployment
- production Lighthouse and route/browser smoke
- final monitoring window

The optional generic connected RLS fixture skipped without isolated credentials.