### PR TITLE
[STEP S80] Bound progressive Find renders

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3732,3 +3732,22 @@
   visuals, and performance budgets. The optional generic connected RLS fixture
   skipped without credentials. Preview, merge, and production proof remain.
   The fixed checklist remains `27/35` (`77%`).
+
+2026-08-14 18:40 EDT - reduced progressive Find catalog renders.
+
+- PR #197 merged as `22940002`; main CI and both production deployments passed.
+  Production mobile loaded all seven visible avatars through bounded transforms,
+  retained interaction-only Mapbox startup, and reported no HTTP, console, or
+  page errors.
+- The production Lighthouse rerun reduced initial transfer from `2.91MB` to
+  `895KB` and improved FCP from `1.60s` to `1.39s`, but repeated progressive
+  catalog renders still held TTI at `38.84s` and TBT at `35.87s`.
+- Kept the first 50-item page immediate while collapsing the remaining 17 page
+  drains into one final publication, and avoided the duplicate final state
+  update when that payload is already current. A realistic 856-item regression
+  proves only the 50-item and final states publish.
+- Full isolated quality passed with `2,139` acceptance tests, focused
+  signup/fiscal/Finance/page-health RLS suites, the 112-route build, `30/30`
+  visuals, and performance budgets. The optional generic connected RLS fixture
+  skipped without credentials. Preview, merge, and production after-measurement
+  remain. The checklist stays `27/35`.

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -20,7 +20,7 @@ type ResourceItemsLoad = {
 }
 
 const resourceItemsLoadByEndpoint = new Map<string, ResourceItemsLoad>()
-const RESOURCE_ITEMS_PROGRESS_BATCH_SIZE = 200
+const RESOURCE_ITEMS_PROGRESS_BATCH_SIZE = 1_000
 
 type FindResourceIndexPage = {
   hasMore?: unknown
@@ -214,7 +214,12 @@ export function usePublicMapResourceItems({
           }
         })
         if (cancelled) return
-        setResourceItems(payload)
+        setResourceItems((currentItems) => {
+          const alreadyPublished =
+            currentItems.length === payload.length &&
+            currentItems.every((item, index) => item === payload[index])
+          return alreadyPublished ? currentItems : payload
+        })
         setStatus("ready")
       } catch (error) {
         if (cancelled) return

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -146,6 +146,40 @@ describe("public map resource items client", () => {
     expect(progressCounts).toEqual([1, 5])
   })
 
+  it("avoids repeated renders while draining the production-sized catalog", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+    const totalPages = 18
+    const pageSize = 50
+
+    for (let page = 0; page < totalPages; page += 1) {
+      const isFinalPage = page === totalPages - 1
+      const itemCount = isFinalPage ? 6 : pageSize
+      const resourceItems = Array.from({ length: itemCount }, (_, index) => ({
+        id: `resource_map:${page * pageSize + index}`,
+      }))
+      fetchSpy.mockResolvedValueOnce(
+        buildJsonResponse({
+          resourceItems,
+          page: {
+            hasMore: !isFinalPage,
+            nextCursor: isFinalPage
+              ? null
+              : resourceItems[resourceItems.length - 1]?.id,
+          },
+        })
+      )
+    }
+
+    const progressCounts: number[] = []
+    const items = await loadPublicMapResourceItems(
+      "/api/public/resource-map/index?limit=50&test=bounded-progress",
+      (loadedItems) => progressCounts.push(loadedItems.length)
+    )
+
+    expect(items).toHaveLength(856)
+    expect(progressCounts).toEqual([50, 856])
+  })
+
   it("deduplicates selected resource detail loads", async () => {
     const resourceItem = {
       id: "resource_map:detail-client-test",


### PR DESCRIPTION
## Summary

- keep the first 50-item Find page immediate
- publish the remaining production-sized catalog once instead of every 200 items
- avoid the duplicate final state update when the final payload is already current

## Validation

- `pnpm check:quality`
- 2,139 acceptance tests; 1 intentional skip
- realistic 856-item regression publishes only 50-item and final states
- focused signup, fiscal, Finance, and page-health RLS suites
- 112-route production build
- 30/30 visual tests
- performance budgets

## Remaining proof

- hosted deployment
- standardized production performance rerun
- final monitoring window

The optional generic connected RLS fixture skipped without isolated credentials.