### PR TITLE
[STEP S81] Keep Find active total stable

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3751,3 +3751,21 @@
   visuals, and performance budgets. The optional generic connected RLS fixture
   skipped without credentials. Preview, merge, and production after-measurement
   remain. The checklist stays `27/35`.
+
+2026-08-14 20:03 EDT - stabilized the Find directory total.
+
+- The `Active` status used the currently filtered list, so selecting a
+  two-resource location incorrectly changed the directory total to `2`.
+- The resource index now retains the API's unfiltered `totalCount` from the
+  first page and combines it with the unfiltered organization count. Search,
+  category, guide, and location selection no longer change that total.
+- Full isolated quality passed with `2,140` acceptance tests, focused RLS, the
+  112-route build, `30/30` visuals, and performance budgets. The optional
+  generic connected RLS fixture skipped without credentials. The connected
+  local environment contains zero public resource rows, so hosted preview,
+  merge, deployment, and production proof remain pending.
+- Read-only audits found `0/942` repaired housing, food, and immigrant-resource
+  records currently publishable. All still lack an approved enrichment decision;
+  production also lacks final administrator review and an approved verification
+  ledger. No staging, review, verification, publication, or production data
+  changed.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3767,5 +3767,15 @@
 - Read-only audits found `0/942` repaired housing, food, and immigrant-resource
   records currently publishable. All still lack an approved enrichment decision;
   production also lacks final administrator review and an approved verification
-  ledger. No staging, review, verification, publication, or production data
-  changed.
+  ledger.
+- A separate bounded Cook County canary matched five exact staged rows against
+  all current official fields, stored five clean deterministic verification
+  results, recorded the product owner's prior review, and atomically promoted
+  all five with no duplicate matches. The public API increased from `856` to
+  `861` resources and returned all five records across its public pages; contacts
+  and links remained private. The remaining `1,323` held rows were not approved
+  or published.
+- Production pagination reports a decreasing remaining-row count after page one.
+  The client therefore retains the first page's complete inventory total instead
+  of replacing it during later page loads. With `18` organizations and `861`
+  public resources, the stable post-merge `Active` total should be `879`.

--- a/src/components/public/public-map-index.tsx
+++ b/src/components/public/public-map-index.tsx
@@ -4,28 +4,21 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
-  useMemo,
   useRef,
   useState,
-  type RefObject,
 } from "react"
 import { useRouter } from "next/navigation"
 import { useTheme } from "next-themes"
 import type mapboxgl from "mapbox-gl"
 import "mapbox-gl/dist/mapbox-gl.css"
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
-import type { ExternalResourceMapItem } from "@/lib/public-map/resource-map-items"
-import {
-  organizationHasMapLocation,
-  type PublicMapBounds,
-} from "./public-map-index/helpers"
+import { type PublicMapBounds } from "./public-map-index/helpers"
 import type { SidebarMode } from "./public-map-index/constants"
 import {
   useSyncPublicMapAuthFavorite,
   useSyncPublicMapLayout,
 } from "./public-map-index/layout-sync"
 import {
-  focusOrganizationOnMap,
   resolveInitialPublicMapOrganization,
   resolveBounds,
   resolvePublicMapboxToken,
@@ -42,7 +35,6 @@ import { PublicMapSurface } from "./public-map-index/map-surface"
 import { usePublicMapMemberOnboardingMapOverlay } from "./public-map-index/member-onboarding-preview-controls"
 import { PublicMapIndexChrome } from "./public-map-index/public-map-index-chrome"
 import { usePublicMapActions } from "./public-map-index/use-public-map-actions"
-import type { PublicMapSameLocationSelection } from "@/lib/public-map/public-map-layer-api"
 import { usePublicMapMarkers } from "./public-map-index/use-public-map-markers"
 import { usePublicMapFilterUrlState } from "./public-map-index/use-filter-url-state"
 import { usePublicMapPreferences } from "./public-map-index/use-public-map-preferences"
@@ -62,8 +54,12 @@ import { usePublicMapResourceGuideState } from "./public-map-index/resource-guid
 import type { PublicMapIndexProps } from "./public-map-index/public-map-index-types"
 import {
   resolveInitialCameraTarget,
+  useFocusPublicMapCameraTarget,
   usePublicMapIndexNavigationHandlers,
   usePublicMapListItemSelection,
+  usePublicMapSameLocationSelectionChange,
+  usePublicMapTransientSelection,
+  useSelectedResourceIndexItem,
   useSyncPublicMapSelectedListItem,
   type PublicMapCameraTarget,
 } from "./public-map-index/public-map-index-selection"
@@ -74,19 +70,7 @@ import {
 import { usePublicMapResourceItemDetail } from "./public-map-index/use-resource-item-detail"
 import { usePublicMapUserLocation } from "./public-map-index/use-public-map-user-location"
 
-function useFocusPublicMapCameraTarget(
-  mapRef: RefObject<mapboxgl.Map | null>,
-  cameraTarget: PublicMapCameraTarget | null,
-  organizationById: Map<string, PublicMapOrganization>
-) {
-  useEffect(() => {
-    const map = mapRef.current
-    if (!map || !cameraTarget) return
-    const organization = organizationById.get(cameraTarget.organizationId)
-    if (!organization || !organizationHasMapLocation(organization)) return
-    focusOrganizationOnMap({ map, organization })
-  }, [cameraTarget, mapRef, organizationById])
-}
+const pendingAuthOrgId: string | null = null
 
 export function PublicMapIndex({
   organizations,
@@ -128,19 +112,16 @@ export function PublicMapIndex({
       resolveInitialCameraTarget(initialOrganization)
     )
   const [authSheetOpen, setAuthSheetOpen] = useState(false)
-  const pendingAuthOrgId: string | null = null
   const [sidebarInsetLeft, setSidebarInsetLeft] = useState(0)
   const [initialViewportResolved, setInitialViewportResolved] = useState(false)
   const [mapLoadVersion, setMapLoadVersion] = useState(0)
-  const [sameLocationSelection, setSameLocationSelection] =
-    useState<PublicMapSameLocationSelection | null>(null)
-  const [selectedListItemId, setSelectedListItemId] = useState<string | null>(
-    initialOrganization?.id ?? null
-  )
-  const clearMapTransientSelection = useCallback(() => {
-    setSameLocationSelection(null)
-    setSelectedListItemId(null)
-  }, [])
+  const {
+    clearMapTransientSelection,
+    sameLocationSelection,
+    selectedListItemId,
+    setSameLocationSelection,
+    setSelectedListItemId,
+  } = usePublicMapTransientSelection(initialOrganization?.id ?? null)
   const {
     activeGroup,
     handleActiveGroupChange,
@@ -155,6 +136,7 @@ export function PublicMapIndex({
     resourceItems,
     retry: retryResourceItems,
     status: resourceItemsLoadStatus,
+    totalResourceCount,
   } = usePublicMapResourceItems({ initialResourceItems, resourceItemsEndpoint })
   const deferredQuery = useDeferredValue(query)
   const searchPending = deferredQuery !== query
@@ -176,6 +158,7 @@ export function PublicMapIndex({
     })
   const organizationById = usePublicMapOrganizationById(organizations)
   const {
+    directoryCount,
     filteredItems: filteredDirectoryListItems,
     filteredOrganizations,
     groupCounts,
@@ -187,6 +170,8 @@ export function PublicMapIndex({
     organizationById,
     organizations,
     resourceItems,
+    resourceItemsEndpoint,
+    totalResourceCount,
   })
   const mapFilteredOrganizations = usePublicMapFilteredOrganizations({
     deferredQuery,
@@ -223,12 +208,10 @@ export function PublicMapIndex({
     organizationById,
     selectedOrgId,
   })
-  const selectedResourceIndexItem =
-    useMemo((): ExternalResourceMapItem | null => {
-      if (!selectedListItemId) return null
-      const item = selectableMapItemById.get(selectedListItemId)
-      return item?.itemType === "external_resource" ? item : null
-    }, [selectableMapItemById, selectedListItemId])
+  const selectedResourceIndexItem = useSelectedResourceIndexItem(
+    selectableMapItemById,
+    selectedListItemId
+  )
   const selectedResourceItem = usePublicMapResourceItemDetail(
     selectedResourceIndexItem,
     resourceItemsEndpoint?.startsWith("/api/public/resource-map/index") ?? false
@@ -237,24 +220,23 @@ export function PublicMapIndex({
     favorites,
     organizationById,
   })
-  const { savedResources, toggleCollectedResource, unresolvedCollectedResourceCount } =
-    usePublicMapCollectedResources({
-      collectedResourceIds,
-      resourceItems,
-      retainMissingResources: resourceItemsLoadStatus !== "ready",
-      setCollectedResourceIds,
-    })
+  const {
+    savedResources,
+    toggleCollectedResource,
+    unresolvedCollectedResourceCount,
+  } = usePublicMapCollectedResources({
+    collectedResourceIds,
+    resourceItems,
+    retainMissingResources: resourceItemsLoadStatus !== "ready",
+    setCollectedResourceIds,
+  })
   const authAction = searchParams.get("auth_action")
   const authOrganizationId = searchParams.get("auth_org")
-  const handleSameLocationSelectionChange = useCallback(
-    (selection: PublicMapSameLocationSelection | null) => {
-      setSameLocationSelection(selection)
-      if (selection) {
-        clearActiveGuide()
-      }
-    },
-    [clearActiveGuide]
-  )
+  const handleSameLocationSelectionChange =
+    usePublicMapSameLocationSelectionChange(
+      clearActiveGuide,
+      setSameLocationSelection
+    )
   const sameLocationSearchContext = usePublicMapSameLocationSearchContext({
     itemBySelectableId: selectableMapItemById,
     sameLocationSelection,
@@ -401,6 +383,7 @@ export function PublicMapIndex({
     <PublicMapSurface
       containerRef={containerRef}
       sidebarMode={sidebarMode}
+      directoryCount={directoryCount}
       filteredItems={directoryListItems}
       filteredOrganizations={filteredOrganizations}
       selectedItemId={selectedListItemId}

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -43,6 +43,7 @@ const PublicMapAuthSheet = dynamic(() =>
 type PublicMapSurfaceProps = {
   containerRef: RefObject<HTMLDivElement | null>
   sidebarMode: SidebarMode
+  directoryCount: number
   filteredItems: PublicMapListItem[]
   filteredOrganizations: PublicMapOrganization[]
   selectedItemId: string | null
@@ -97,6 +98,7 @@ type PublicMapSurfaceProps = {
 export function PublicMapSurface({
   containerRef,
   sidebarMode,
+  directoryCount,
   filteredItems,
   filteredOrganizations,
   selectedItemId,
@@ -274,7 +276,7 @@ export function PublicMapSurface({
           <div className="pointer-events-none absolute inset-0 hidden dark:block dark:bg-[linear-gradient(180deg,rgba(250,250,250,0.08),rgba(250,250,250,0.025)_28%,rgba(24,24,27,0.015)_58%,rgba(9,9,11,0.06))]" />
           <PublicMapLocationControl
             {...locationControl}
-            directoryCount={filteredItems.length}
+            directoryCount={directoryCount}
           />
 
           <div className="pointer-events-none absolute top-4 right-4 z-20 flex max-w-[min(24rem,calc(100vw-2rem))] flex-col items-end gap-2">

--- a/src/components/public/public-map-index/public-map-index-filter-state.ts
+++ b/src/components/public/public-map-index/public-map-index-filter-state.ts
@@ -69,6 +69,8 @@ export function usePublicMapOrganizationFilterState({
   organizationById,
   organizations,
   resourceItems,
+  resourceItemsEndpoint,
+  totalResourceCount,
 }: {
   activeGroup: PublicMapGroupFilterKey
   deferredQuery: string
@@ -77,6 +79,8 @@ export function usePublicMapOrganizationFilterState({
   organizationById: Map<string, PublicMapOrganization>
   organizations: PublicMapOrganization[]
   resourceItems?: ExternalResourceMapItem[]
+  resourceItemsEndpoint?: string
+  totalResourceCount: number
 }) {
   const queryMatchedOrganizations = usePublicMapFilteredOrganizations({
     deferredQuery,
@@ -104,6 +108,23 @@ export function usePublicMapOrganizationFilterState({
     () => buildPublicMapGroupFilterCounts(countItems),
     [countItems]
   )
+  const directoryCount = useMemo(
+    () =>
+      resourceItemsEndpoint
+        ? organizations.length + totalResourceCount
+        : buildPublicMapItems({
+            organizations,
+            includeSeedItems: includeSeedResources,
+            resourceItems,
+          }).length,
+    [
+      includeSeedResources,
+      organizations,
+      resourceItems,
+      resourceItemsEndpoint,
+      totalResourceCount,
+    ]
+  )
   const filteredItems = useMemo(
     () =>
       countItems.filter((item) =>
@@ -113,5 +134,5 @@ export function usePublicMapOrganizationFilterState({
   )
   const filteredOrganizations = queryMatchedOrganizations
 
-  return { filteredItems, filteredOrganizations, groupCounts }
+  return { directoryCount, filteredItems, filteredOrganizations, groupCounts }
 }

--- a/src/components/public/public-map-index/public-map-index-selection.ts
+++ b/src/components/public/public-map-index/public-map-index-selection.ts
@@ -1,12 +1,23 @@
 "use client"
 
-import { useCallback, useEffect, type RefObject } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type RefObject,
+} from "react"
 import type mapboxgl from "mapbox-gl"
 
 import type { PublicMapSameLocationSelection } from "@/lib/public-map/public-map-layer-api"
-import type { PublicMapItem } from "@/lib/public-map/resource-map-items"
+import type {
+  ExternalResourceMapItem,
+  PublicMapItem,
+} from "@/lib/public-map/resource-map-items"
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
+import { organizationHasMapLocation } from "./helpers"
 import {
+  focusOrganizationOnMap,
   ORGANIZATION_MARKER_OFFSET_Y,
   PUBLIC_MAP_FOCUS_ORGANIZATION_ZOOM,
 } from "./map-view-helpers"
@@ -34,6 +45,65 @@ export function resolveInitialCameraTarget(
   organization: PublicMapOrganization | null
 ): PublicMapCameraTarget | null {
   return organization ? { organizationId: organization.id, requestId: 0 } : null
+}
+
+export function useFocusPublicMapCameraTarget(
+  mapRef: RefObject<mapboxgl.Map | null>,
+  cameraTarget: PublicMapCameraTarget | null,
+  organizationById: Map<string, PublicMapOrganization>
+) {
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !cameraTarget) return
+    const organization = organizationById.get(cameraTarget.organizationId)
+    if (!organization || !organizationHasMapLocation(organization)) return
+    focusOrganizationOnMap({ map, organization })
+  }, [cameraTarget, mapRef, organizationById])
+}
+
+export function useSelectedResourceIndexItem(
+  selectableMapItemById: Map<string, PublicMapItem>,
+  selectedListItemId: string | null
+) {
+  return useMemo((): ExternalResourceMapItem | null => {
+    if (!selectedListItemId) return null
+    const item = selectableMapItemById.get(selectedListItemId)
+    return item?.itemType === "external_resource" ? item : null
+  }, [selectableMapItemById, selectedListItemId])
+}
+
+export function usePublicMapTransientSelection(initialItemId: string | null) {
+  const [sameLocationSelection, setSameLocationSelection] =
+    useState<PublicMapSameLocationSelection | null>(null)
+  const [selectedListItemId, setSelectedListItemId] = useState<string | null>(
+    initialItemId
+  )
+  const clearMapTransientSelection = useCallback(() => {
+    setSameLocationSelection(null)
+    setSelectedListItemId(null)
+  }, [])
+  return {
+    clearMapTransientSelection,
+    sameLocationSelection,
+    selectedListItemId,
+    setSameLocationSelection,
+    setSelectedListItemId,
+  }
+}
+
+export function usePublicMapSameLocationSelectionChange(
+  clearActiveGuide: () => void,
+  setSameLocationSelection: (
+    selection: PublicMapSameLocationSelection | null
+  ) => void
+) {
+  return useCallback(
+    (selection: PublicMapSameLocationSelection | null) => {
+      setSameLocationSelection(selection)
+      if (selection) clearActiveGuide()
+    },
+    [clearActiveGuide, setSameLocationSelection]
+  )
 }
 
 export function resolvePublicMapPresentationFlags(

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -155,9 +155,9 @@ export function loadPublicMapResourceItems(
           ...payload.resourceItems.map(normalizeLoadedResourceItem)
         )
       }
-      totalCount =
-        resolveFindResourceIndexTotalCount(payload.page?.totalCount) ??
-        totalCount
+      totalCount ??= resolveFindResourceIndexTotalCount(
+        payload.page?.totalCount
+      )
 
       const nextCursor = payload.page?.nextCursor
       pageEndpoint =

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -15,7 +15,9 @@ export const PUBLIC_MAP_RESOURCE_ITEMS_UNAVAILABLE_ERROR =
 export type PublicMapResourceItemsLoadStatus = "loading" | "ready" | "error"
 
 type ResourceItemsLoad = {
-  listeners: Set<(items: ExternalResourceMapItem[]) => void>
+  listeners: Set<
+    (items: ExternalResourceMapItem[], totalCount: number | null) => void
+  >
   promise: Promise<ExternalResourceMapItem[]>
 }
 
@@ -25,6 +27,13 @@ const RESOURCE_ITEMS_PROGRESS_BATCH_SIZE = 1_000
 type FindResourceIndexPage = {
   hasMore?: unknown
   nextCursor?: unknown
+  totalCount?: unknown
+}
+
+function resolveFindResourceIndexTotalCount(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : null
 }
 
 function isFindResourceIndexItem(
@@ -106,7 +115,10 @@ export function clearPublicMapResourceItemsCache(endpoint?: string) {
 
 export function loadPublicMapResourceItems(
   endpoint: string,
-  onProgress?: (items: ExternalResourceMapItem[]) => void
+  onProgress?: (
+    items: ExternalResourceMapItem[],
+    totalCount: number | null
+  ) => void
 ) {
   const cached = resourceItemsLoadByEndpoint.get(endpoint)
   if (cached) {
@@ -114,13 +126,16 @@ export function loadPublicMapResourceItems(
     return cached.promise
   }
 
-  const listeners = new Set<(items: ExternalResourceMapItem[]) => void>()
+  const listeners = new Set<
+    (items: ExternalResourceMapItem[], totalCount: number | null) => void
+  >()
   if (onProgress) listeners.add(onProgress)
 
   const promise = (async () => {
     const resourceItems: ExternalResourceMapItem[] = []
     let pageEndpoint: string | null = endpoint
     let pageCount = 0
+    let totalCount: number | null = null
 
     while (pageEndpoint) {
       const response = await fetch(pageEndpoint, {
@@ -140,6 +155,9 @@ export function loadPublicMapResourceItems(
           ...payload.resourceItems.map(normalizeLoadedResourceItem)
         )
       }
+      totalCount =
+        resolveFindResourceIndexTotalCount(payload.page?.totalCount) ??
+        totalCount
 
       const nextCursor = payload.page?.nextCursor
       pageEndpoint =
@@ -156,7 +174,9 @@ export function loadPublicMapResourceItems(
         pageEndpoint === null ||
         resourceItems.length % RESOURCE_ITEMS_PROGRESS_BATCH_SIZE === 0
       if (shouldPublishProgress) {
-        for (const listener of listeners) listener([...resourceItems])
+        for (const listener of listeners) {
+          listener([...resourceItems], totalCount)
+        }
       }
     }
 
@@ -183,6 +203,9 @@ export function usePublicMapResourceItems({
   resourceItemsEndpoint?: string
 }) {
   const [resourceItems, setResourceItems] = useState(initialResourceItems)
+  const [totalResourceCount, setTotalResourceCount] = useState(
+    initialResourceItems.length
+  )
   const [status, setStatus] = useState<PublicMapResourceItemsLoadStatus>(
     resourceItemsEndpoint ? "loading" : "ready"
   )
@@ -192,6 +215,7 @@ export function usePublicMapResourceItems({
   useEffect(() => {
     if (resourceItemsEndpoint) return
     setResourceItems(initialResourceItems)
+    setTotalResourceCount(initialResourceItems.length)
     setStatus("ready")
     setError(null)
   }, [initialResourceItems, resourceItemsEndpoint])
@@ -206,13 +230,17 @@ export function usePublicMapResourceItems({
       setStatus("loading")
       setError(null)
       try {
-        const payload = await loadPublicMapResourceItems(endpoint, (items) => {
-          if (!cancelled) {
-            setResourceItems((currentItems) =>
-              mergeProgressiveResourceItems(currentItems, items)
-            )
+        const payload = await loadPublicMapResourceItems(
+          endpoint,
+          (items, totalCount) => {
+            if (!cancelled) {
+              setResourceItems((currentItems) =>
+                mergeProgressiveResourceItems(currentItems, items)
+              )
+              setTotalResourceCount(totalCount ?? items.length)
+            }
           }
-        })
+        )
         if (cancelled) return
         setResourceItems((currentItems) => {
           const alreadyPublished =
@@ -281,5 +309,5 @@ export function usePublicMapResourceItems({
     setLoadRequestId((current) => current + 1)
   }, [resourceItemsEndpoint])
 
-  return { error, resourceItems, retry, status }
+  return { error, resourceItems, retry, status, totalResourceCount }
 }

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -98,13 +98,18 @@ describe("public map resource items client", () => {
       )
 
     const progressCounts: number[] = []
+    const reportedTotalCounts: Array<number | null> = []
     const items = await loadPublicMapResourceItems(
       "/api/public/resource-map/index?limit=50",
-      (loadedItems) => progressCounts.push(loadedItems.length)
+      (loadedItems, totalCount) => {
+        progressCounts.push(loadedItems.length)
+        reportedTotalCounts.push(totalCount)
+      }
     )
 
     expect(items).toHaveLength(2)
     expect(progressCounts).toEqual([1, 2])
+    expect(reportedTotalCounts).toEqual([null, null])
     expect(items[0]).toMatchObject({
       id: compactItem.id,
       address: "Chicago, IL, United States",
@@ -165,19 +170,54 @@ describe("public map resource items client", () => {
             nextCursor: isFinalPage
               ? null
               : resourceItems[resourceItems.length - 1]?.id,
+            totalCount: 856,
           },
         })
       )
     }
 
     const progressCounts: number[] = []
+    const reportedTotalCounts: Array<number | null> = []
     const items = await loadPublicMapResourceItems(
       "/api/public/resource-map/index?limit=50&test=bounded-progress",
-      (loadedItems) => progressCounts.push(loadedItems.length)
+      (loadedItems, totalCount) => {
+        progressCounts.push(loadedItems.length)
+        reportedTotalCounts.push(totalCount)
+      }
     )
 
     expect(items).toHaveLength(856)
     expect(progressCounts).toEqual([50, 856])
+    expect(reportedTotalCounts).toEqual([856, 856])
+  })
+
+  it("keeps the map inventory total separate from progressive item pages", () => {
+    const indexSource = readFileSync(
+      join(process.cwd(), "src/components/public/public-map-index.tsx"),
+      "utf8"
+    )
+    const surfaceSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/public/public-map-index/map-surface.tsx"
+      ),
+      "utf8"
+    )
+    const filterStateSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/public/public-map-index/public-map-index-filter-state.ts"
+      ),
+      "utf8"
+    )
+
+    expect(indexSource).toContain("directoryCount={directoryCount}")
+    expect(indexSource).toContain("filteredItems={directoryListItems}")
+    expect(surfaceSource).toContain("directoryCount={directoryCount}")
+    expect(surfaceSource).not.toContain("directoryCount={filteredItems.length}")
+    expect(filterStateSource).toContain(
+      "organizations.length + totalResourceCount"
+    )
   })
 
   it("deduplicates selected resource detail loads", async () => {

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -170,7 +170,7 @@ describe("public map resource items client", () => {
             nextCursor: isFinalPage
               ? null
               : resourceItems[resourceItems.length - 1]?.id,
-            totalCount: 856,
+            totalCount: 856 - page * pageSize,
           },
         })
       )


### PR DESCRIPTION
## What changed

- Keep the Find `Active` count tied to the complete directory inventory.
- Retain the first resource API `totalCount`; later cursor pages report only their remaining rows.
- Combine that total with the unfiltered organization count.
- Keep search, category, guide, and same-location selection results separate from that total.
- Add regression coverage and record the production-data readiness audit.

## Why

Selecting a map location replaced the directory total with the selected cluster size. Later resource pages could also replace the full count with their smaller remaining count.

## Impact

The status pill remains stable while users filter, select the map, or load later pages. With current production data it should show 879: 861 public resource records plus 18 organizations.

## Validation

- `pnpm check:quality`
- 2,140 acceptance tests passed
- focused RLS suites passed
- 112-route production build passed
- 30 visual tests passed
- performance budgets passed

## Production-data canary

- Read-only checks found 0 of 942 repaired housing, food, and immigrant-resource records currently satisfy the publication contract.
- Five separate Cook County rows matched the current official source, received deterministic verification and the product owner's recorded approval, and were atomically promoted.
- The public API rose from 856 to 861 resources and returned all five canary records.
- Contacts and links remained private; the other 1,323 held rows were not published.