### PR TITLE
[STEP S84] Fix assignment autosave recovery

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3794,3 +3794,25 @@
   connected RLS fixture skipped without credentials. No production data changed;
   preview, merge, deployment, and visual production proof for this plan refresh
   remain pending.
+
+2026-08-17 21:28 EDT - prepared assignment-save recovery hotfix.
+
+- Read-only production diagnostics identified Demitrius “Dee” Haywood as the
+  likely report and confirmed all 12 Origin Story answers remain stored. Repeated
+  submissions and a prior `Load failed` event matched an ambiguous-save path;
+  no customer data changed.
+- Corrected five related failures: Workspace hid autosave feedback, unsuccessful
+  autosaves were marked submitted, committed saves were not reconciled after a
+  lost response, secondary organization-profile sync errors were reported as
+  homework failures, and unverifiable legacy drafts could outrank newer server
+  answers. Added an authenticated submission readback, visible saved/error state,
+  retry control, and server-authoritative draft versioning.
+- Focused resilience and MVV tests passed `26/26`. Full isolated quality passed:
+  lint and every guardrail, snapshots, `2,152` acceptance tests, focused RLS,
+  the 112-route production build, `30/30` visuals, and performance budgets. A
+  production-build browser test committed a save, deliberately aborted its POST
+  response, verified recovery feedback, reloaded the saved answer, and restored
+  the internal QA submission exactly afterward.
+- The optional connected generic RLS fixture reached the existing production
+  Auth `Database error creating new user`; all focused RLS suites passed. PR,
+  hosted checks, merge, deployment, and production proof remain pending.

--- a/src/app/api/modules/[id]/assignment-submission/route.ts
+++ b/src/app/api/modules/[id]/assignment-submission/route.ts
@@ -19,6 +19,46 @@ import { syncMappedAnswersToOrganizationProfile } from "./_lib/profile-sync"
 import { extractOrgKeyMappings, sanitizeAnswers } from "./_lib/sanitize"
 import type { AnswersPayload, ModuleMeta, SubmissionStatus } from "./_lib/types"
 
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id: moduleId } = await context.params
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError) {
+    return NextResponse.json({ error: userError.message }, { status: 500 })
+  }
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { data: submission, error } = await supabase
+    .from("assignment_submissions" satisfies keyof Database["public"]["Tables"])
+    .select("answers, status, updated_at")
+    .eq("module_id", moduleId)
+    .eq("user_id", user.id)
+    .maybeSingle<{
+      answers: Record<string, unknown>
+      status: SubmissionStatus
+      updated_at: string | null
+    }>()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    answers: submission?.answers ?? null,
+    status: submission?.status ?? null,
+    updatedAt: submission?.updated_at ?? null,
+  })
+}
+
 export async function POST(
   request: Request,
   context: { params: Promise<{ id: string }> }
@@ -133,31 +173,25 @@ export async function POST(
     return NextResponse.json({ error: upsertError.message }, { status: 500 })
   }
 
-  if (Object.keys(orgKeyMapping).length > 0 && !canEditOrganization(role)) {
-    return NextResponse.json(
-      {
-        error: "Homework saved, but you cannot update this organization.",
-        submissionSaved: true,
-      },
-      { status: 403 }
-    )
-  }
-
-  const profileSync = await syncMappedAnswersToOrganizationProfile({
-    supabase,
-    organizationId: orgId,
-    sanitizedAnswers,
-    orgKeyMapping,
-  })
-  if ("error" in profileSync) {
-    return NextResponse.json(
-      {
-        error: "Homework saved, but organization details did not update.",
-        details: profileSync.error,
-        submissionSaved: true,
-      },
-      { status: 500 }
-    )
+  let warning: string | null = null
+  if (Object.keys(orgKeyMapping).length > 0) {
+    if (!canEditOrganization(role)) {
+      warning = "Saved. You cannot update this organization's shared details."
+    } else {
+      const profileSync = await syncMappedAnswersToOrganizationProfile({
+        supabase,
+        organizationId: orgId,
+        sanitizedAnswers,
+        orgKeyMapping,
+      })
+      if ("error" in profileSync) {
+        console.error(
+          "Homework saved but organization profile sync failed",
+          profileSync.error
+        )
+        warning = "Saved. Organization details could not update."
+      }
+    }
   }
 
   const completionMode = parseAssignmentCompletionMode(assignmentRow.schema)
@@ -205,9 +239,11 @@ export async function POST(
   })
 
   return NextResponse.json({
+    submissionSaved: true,
     status: submissionRows?.status ?? desiredStatus,
     answers: submissionRows?.answers ?? sanitizedAnswers,
     updatedAt: submissionRows?.updated_at ?? null,
     completeOnSubmit: completedOnSubmit,
+    warning,
   })
 }

--- a/src/components/training/module-detail/assignment-form.tsx
+++ b/src/components/training/module-detail/assignment-form.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from "react"
 import { usePathname } from "next/navigation"
 
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 
 import type { ModuleAssignmentField, ModuleResource } from "../types"
@@ -21,7 +26,10 @@ type AssignmentFormProps = {
   fields: ModuleAssignmentField[]
   initialValues: AssignmentValues
   pending: boolean
-  onSubmit: (values: AssignmentValues, options?: { silent?: boolean }) => void | Promise<unknown>
+  onSubmit: (
+    values: AssignmentValues,
+    options?: { silent?: boolean }
+  ) => void | Promise<unknown>
   roadmapStatusBySectionId?: Record<string, RoadmapSectionStatus>
   mode?: "standard" | "stepper"
   activeSectionId?: string
@@ -53,7 +61,9 @@ export function AssignmentForm(props: AssignmentFormProps) {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Homework</CardTitle>
-          <CardDescription>No assignment data yet — check back soon.</CardDescription>
+          <CardDescription>
+            No assignment data yet — check back soon.
+          </CardDescription>
         </CardHeader>
       </Card>
     )
@@ -96,9 +106,14 @@ function AssignmentFormInner({
     moduleId,
     onSubmit,
   })
-  const hasMeta = Boolean(showStatusBadge || helperText || errorMessage || statusNote || autoSaving)
+  const hasMeta = Boolean(
+    showStatusBadge || helperText || errorMessage || statusNote || autoSaving
+  )
 
-  const { baseSections, tabSections } = useMemo(() => buildAssignmentSections(fields), [fields])
+  const { baseSections, tabSections } = useMemo(
+    () => buildAssignmentSections(fields),
+    [fields]
+  )
   const {
     shouldUseTabs,
     useInlineTabs,
@@ -115,12 +130,17 @@ function AssignmentFormInner({
   })
   const { fieldAnswered, overall } = useAssignmentProgress(tabSections, values)
   const showProgressPanel = !isStepper && overall.total > 1
-  const activeSectionIndex = tabSections.findIndex((section) => section.id === activeSectionKey)
-  const activeSectionForNavigation = activeSectionIndex >= 0 ? tabSections[activeSectionIndex] : null
+  const activeSectionIndex = tabSections.findIndex(
+    (section) => section.id === activeSectionKey
+  )
+  const activeSectionForNavigation =
+    activeSectionIndex >= 0 ? tabSections[activeSectionIndex] : null
   const nextSectionForNavigation =
     activeSectionIndex >= 0 ? tabSections[activeSectionIndex + 1] : null
   const canGoPreviousStep =
-    typeof currentStep === "number" && currentStep > 1 && Boolean(onStepPrevious)
+    typeof currentStep === "number" &&
+    currentStep > 1 &&
+    Boolean(onStepPrevious)
   const canGoNextStep =
     typeof currentStep === "number" &&
     typeof totalSteps === "number" &&
@@ -147,7 +167,7 @@ function AssignmentFormInner({
       isAcceleratorShell,
       richTextMinHeight,
       updateValue,
-    ],
+    ]
   )
 
   const progressPanel = (
@@ -178,16 +198,18 @@ function AssignmentFormInner({
               "grid items-start gap-6",
               headerSlot && showProgressPanel
                 ? "md:grid-cols-[minmax(240px,_360px)_minmax(0,_1fr)] xl:grid-cols-[minmax(260px,_420px)_minmax(0,_1fr)]"
-                : "",
+                : ""
             )}
           >
             {headerSlot ? (
-              <div className="min-w-0 w-full md:justify-self-start md:max-w-[320px]">
+              <div className="w-full min-w-0 md:max-w-[320px] md:justify-self-start">
                 {headerSlot}
               </div>
             ) : null}
             {showProgressPanel ? (
-              <div className={`min-w-0 ${headerSlot ? "" : "md:col-span-2"}`}>{progressPanel}</div>
+              <div className={`min-w-0 ${headerSlot ? "" : "md:col-span-2"}`}>
+                {progressPanel}
+              </div>
             ) : null}
           </div>
         ) : null
@@ -200,14 +222,30 @@ function AssignmentFormInner({
           "self-start",
           isStepper
             ? "flex min-h-0 flex-1 flex-col self-stretch overflow-hidden"
-            : "space-y-3",
+            : "space-y-3"
         )}
       >
         <div
           className={cn(
-            isStepper && "min-h-0 flex-1 overflow-y-auto overscroll-contain pb-5 pr-1",
+            isStepper &&
+              "min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1 pb-5"
           )}
         >
+          {isStepper ? (
+            <AssignmentFormSubmitRow
+              isStepper
+              hasMeta={hasMeta}
+              helperText={helperText}
+              errorMessage={errorMessage}
+              statusNote={statusNote}
+              autoSaving={autoSaving}
+              nextHref={null}
+              currentStep={currentStep}
+              totalSteps={totalSteps}
+              pending={pending}
+              onRetry={() => onSubmit(values)}
+            />
+          ) : null}
           <AssignmentFieldsContent
             isStepper={isStepper}
             shouldUseTabs={shouldUseTabs}
@@ -236,6 +274,8 @@ function AssignmentFormInner({
             nextHref={nextHref}
             currentStep={currentStep}
             totalSteps={totalSteps}
+            pending={pending}
+            onRetry={() => onSubmit(values)}
           />
         ) : showStepNavigation ? (
           <AssignmentStepNavigation

--- a/src/components/training/module-detail/assignment-form/assignment-draft.ts
+++ b/src/components/training/module-detail/assignment-form/assignment-draft.ts
@@ -1,0 +1,79 @@
+import type { AssignmentValues } from "../utils"
+
+type StoredAssignmentDraft = {
+  baseSignature?: string
+  updatedAt?: string
+  values?: AssignmentValues
+}
+
+export function getAssignmentDraftStorageKey(moduleId: string) {
+  return `assignment-autosave-${moduleId}`
+}
+
+export function serializeAssignmentValues(values: AssignmentValues) {
+  return JSON.stringify(values)
+}
+
+export function normalizeValuesToInitialSchema({
+  values,
+  initialValues,
+}: {
+  values: AssignmentValues
+  initialValues: AssignmentValues
+}): AssignmentValues {
+  const normalized: AssignmentValues = {}
+  for (const key of Object.keys(initialValues)) {
+    normalized[key] = key in values ? values[key] : initialValues[key]
+  }
+  return normalized
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0
+  if (typeof value === "number") return Number.isFinite(value)
+  if (Array.isArray(value)) return value.some(hasMeaningfulValue)
+  if (!value || typeof value !== "object") return false
+  return Object.values(value).some(hasMeaningfulValue)
+}
+
+export function readAssignmentDraft({
+  initialValues,
+  raw,
+}: {
+  initialValues: AssignmentValues
+  raw: string
+}): AssignmentValues | null {
+  try {
+    const parsed = JSON.parse(raw) as StoredAssignmentDraft
+    if (!parsed?.values || typeof parsed.values !== "object") return null
+
+    const currentBaseSignature = serializeAssignmentValues(initialValues)
+    if (typeof parsed.baseSignature === "string") {
+      if (parsed.baseSignature !== currentBaseSignature) return null
+    } else if (hasMeaningfulValue(initialValues)) {
+      // Legacy drafts cannot prove they are newer than server data. The server wins.
+      return null
+    }
+
+    return normalizeValuesToInitialSchema({
+      values: parsed.values,
+      initialValues,
+    })
+  } catch {
+    return null
+  }
+}
+
+export function buildAssignmentDraft({
+  initialValues,
+  values,
+}: {
+  initialValues: AssignmentValues
+  values: AssignmentValues
+}) {
+  return JSON.stringify({
+    baseSignature: serializeAssignmentValues(initialValues),
+    updatedAt: new Date().toISOString(),
+    values,
+  } satisfies StoredAssignmentDraft)
+}

--- a/src/components/training/module-detail/assignment-form/assignment-form-submit-row.tsx
+++ b/src/components/training/module-detail/assignment-form/assignment-form-submit-row.tsx
@@ -14,6 +14,8 @@ type AssignmentFormSubmitRowProps = {
   nextHref: string | null
   currentStep: number | undefined
   totalSteps: number | undefined
+  pending: boolean
+  onRetry: () => void | Promise<unknown>
 }
 
 export function AssignmentFormSubmitRow({
@@ -26,23 +28,74 @@ export function AssignmentFormSubmitRow({
   nextHref,
   currentStep,
   totalSteps,
+  pending,
+  onRetry,
 }: AssignmentFormSubmitRowProps) {
   return (
-    <div className={cn("flex flex-wrap items-start gap-3 pt-2", isStepper && "justify-center")}>
-      <div className={cn("flex flex-wrap items-center gap-3 text-xs text-muted-foreground", !isStepper && "ml-auto")}>
-        <div className={cn("flex flex-col gap-1", isStepper ? "text-center" : "text-right")}>
-          <div className={cn("min-h-[14px] flex flex-wrap justify-end gap-2", !hasMeta && "opacity-0")}>
-            {helperText ? <p className="text-emerald-600">{helperText}</p> : null}
-            {errorMessage ? <p className="text-rose-500">{errorMessage}</p> : null}
+    <div
+      className={cn(
+        "flex flex-wrap items-start gap-3 pt-2",
+        isStepper && "justify-center"
+      )}
+    >
+      <div
+        className={cn(
+          "text-muted-foreground flex flex-wrap items-center gap-3 text-xs",
+          !isStepper && "ml-auto"
+        )}
+      >
+        <div
+          className={cn(
+            "flex flex-col gap-1",
+            isStepper ? "text-center" : "text-right"
+          )}
+        >
+          <div
+            className={cn(
+              "flex min-h-[14px] flex-wrap items-center justify-end gap-2",
+              !hasMeta && "opacity-0"
+            )}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {helperText ? (
+              <p className="text-emerald-600">{helperText}</p>
+            ) : null}
+            {errorMessage ? (
+              <>
+                <p className="text-rose-500">{errorMessage}</p>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-11 px-3 text-xs sm:h-7 sm:px-2"
+                  disabled={pending || autoSaving}
+                  onClick={() => void onRetry()}
+                >
+                  Retry save
+                </Button>
+              </>
+            ) : null}
             {statusNote ? <p className="text-amber-600">{statusNote}</p> : null}
             {autoSaving ? <p>Saving…</p> : null}
           </div>
         </div>
         {!isStepper && nextHref ? (
-          <Button asChild size="default" variant="outline" title="Next module" className="relative min-w-[92px] px-2.5">
-            <Link href={nextHref} aria-label="Next module" className="inline-flex h-9 items-center justify-center gap-2 px-1">
-              {typeof currentStep === "number" && typeof totalSteps === "number" ? (
-                <span className="inline-flex items-center justify-center rounded-full bg-card px-1 text-[10px] font-semibold text-muted-foreground">
+          <Button
+            asChild
+            size="default"
+            variant="outline"
+            title="Next module"
+            className="relative min-w-[92px] px-2.5"
+          >
+            <Link
+              href={nextHref}
+              aria-label="Next module"
+              className="inline-flex h-9 items-center justify-center gap-2 px-1"
+            >
+              {typeof currentStep === "number" &&
+              typeof totalSteps === "number" ? (
+                <span className="bg-card text-muted-foreground inline-flex items-center justify-center rounded-full px-1 text-[10px] font-semibold">
                   {currentStep + 1} of {totalSteps}
                 </span>
               ) : null}

--- a/src/components/training/module-detail/assignment-form/hooks/use-assignment-form-values.ts
+++ b/src/components/training/module-detail/assignment-form/hooks/use-assignment-form-values.ts
@@ -1,40 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { assignmentValuesEqual, type AssignmentValues } from "../../utils"
+import {
+  buildAssignmentDraft,
+  getAssignmentDraftStorageKey,
+  normalizeValuesToInitialSchema,
+  readAssignmentDraft,
+  serializeAssignmentValues,
+} from "../assignment-draft"
 
 type UseAssignmentFormValuesParams = {
   initialValues: AssignmentValues
   moduleId: string
-  onSubmit: (values: AssignmentValues, options?: { silent?: boolean }) => void | Promise<unknown>
+  onSubmit: (
+    values: AssignmentValues,
+    options?: { silent?: boolean }
+  ) => void | Promise<unknown>
 }
 
 type UseAssignmentFormValuesResult = {
   values: AssignmentValues
   autoSaving: boolean
   updateValue: (name: string, value: AssignmentValues[string]) => void
-}
-
-function getAutoSaveStorageKey(moduleId: string) {
-  return `assignment-autosave-${moduleId}`
-}
-
-function serializeAssignmentValues(values: AssignmentValues) {
-  return JSON.stringify(values)
-}
-
-function normalizeValuesToInitialSchema({
-  values,
-  initialValues,
-}: {
-  values: AssignmentValues
-  initialValues: AssignmentValues
-}): AssignmentValues {
-  const normalized: AssignmentValues = {}
-  for (const key of Object.keys(initialValues)) {
-    normalized[key] =
-      key in values ? values[key] : initialValues[key]
-  }
-  return normalized
 }
 
 export function useAssignmentFormValues({
@@ -60,7 +47,8 @@ export function useAssignmentFormValues({
     if (moduleChanged) {
       moduleIdRef.current = moduleId
       initialValuesRef.current = initialValues
-      lastSubmittedSignatureRef.current = serializeAssignmentValues(initialValues)
+      lastSubmittedSignatureRef.current =
+        serializeAssignmentValues(initialValues)
       inFlightSubmitSignatureRef.current = null
       setValues(initialValues)
       return
@@ -70,7 +58,10 @@ export function useAssignmentFormValues({
       return
     }
 
-    const canReplace = assignmentValuesEqual(valuesRef.current, initialValuesRef.current)
+    const canReplace = assignmentValuesEqual(
+      valuesRef.current,
+      initialValuesRef.current
+    )
     initialValuesRef.current = initialValues
     lastSubmittedSignatureRef.current = serializeAssignmentValues(initialValues)
     if (canReplace) {
@@ -80,32 +71,35 @@ export function useAssignmentFormValues({
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    const storageKey = getAutoSaveStorageKey(moduleId)
+    const storageKey = getAssignmentDraftStorageKey(moduleId)
 
     try {
       const raw = window.localStorage.getItem(storageKey)
       if (!raw) return
 
-      const parsed = JSON.parse(raw) as { values?: AssignmentValues }
-      if (!parsed?.values) return
-
-      const nextValues = normalizeValuesToInitialSchema({
-        values: parsed.values as AssignmentValues,
+      const nextValues = readAssignmentDraft({
+        raw,
         initialValues: initialValuesRef.current,
       })
-      setValues((prev) => (assignmentValuesEqual(nextValues, prev) ? prev : nextValues))
+      if (!nextValues) return
+      setValues((prev) =>
+        assignmentValuesEqual(nextValues, prev) ? prev : nextValues
+      )
     } catch {
       // ignore storage errors
     }
   }, [moduleId])
 
-  const updateValue = useCallback((name: string, value: AssignmentValues[string]) => {
-    setValues((prev) => ({ ...prev, [name]: value }))
-  }, [])
+  const updateValue = useCallback(
+    (name: string, value: AssignmentValues[string]) => {
+      setValues((prev) => ({ ...prev, [name]: value }))
+    },
+    []
+  )
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    const storageKey = getAutoSaveStorageKey(moduleId)
+    const storageKey = getAssignmentDraftStorageKey(moduleId)
     const normalizedValues = normalizeValuesToInitialSchema({
       values,
       initialValues,
@@ -116,14 +110,13 @@ export function useAssignmentFormValues({
       return
     }
 
-    try {
-      window.localStorage.setItem(storageKey, JSON.stringify({ values: normalizedValues }))
-    } catch {
-      // ignore storage errors
-    }
-
     if (assignmentValuesEqual(normalizedValues, initialValues)) {
       if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current)
+      try {
+        window.localStorage.removeItem(storageKey)
+      } catch {
+        // ignore storage errors
+      }
       const initialSignature = serializeAssignmentValues(initialValues)
       lastSubmittedSignatureRef.current = initialSignature
       if (inFlightSubmitSignatureRef.current === initialSignature) {
@@ -131,6 +124,15 @@ export function useAssignmentFormValues({
       }
       setAutoSaving(false)
       return
+    }
+
+    try {
+      window.localStorage.setItem(
+        storageKey,
+        buildAssignmentDraft({ initialValues, values: normalizedValues })
+      )
+    } catch {
+      // ignore storage errors
     }
 
     const nextSignature = serializeAssignmentValues(normalizedValues)
@@ -148,8 +150,10 @@ export function useAssignmentFormValues({
       inFlightSubmitSignatureRef.current = nextSignature
       setAutoSaving(true)
       Promise.resolve(onSubmit(normalizedValues, { silent: true }))
-        .then(() => {
-          lastSubmittedSignatureRef.current = nextSignature
+        .then((saved) => {
+          if (saved !== false) {
+            lastSubmittedSignatureRef.current = nextSignature
+          }
         })
         .catch((error) => {
           console.error("Autosave failed", error)

--- a/src/components/training/module-detail/assignment-submission-request.ts
+++ b/src/components/training/module-detail/assignment-submission-request.ts
@@ -1,0 +1,231 @@
+import type { ModuleAssignmentField } from "@/lib/modules"
+
+import {
+  assignmentValuesEqual,
+  buildAssignmentValues,
+  type AssignmentValues,
+} from "./utils"
+
+type AssignmentSubmissionPayload = {
+  answers?: Record<string, unknown> | null
+  status?: string | null
+  updatedAt?: string | null
+  completeOnSubmit?: boolean
+  submissionSaved?: boolean
+  warning?: string | null
+  error?: string | null
+  missing?: unknown
+}
+
+export type AssignmentSubmissionResult =
+  | {
+      saved: true
+      answers: Record<string, unknown>
+      status: string
+      updatedAt: string | null
+      completeOnSubmit: boolean
+      message: string
+    }
+  | {
+      saved: false
+      error: string
+    }
+
+type SubmitAssignmentParams = {
+  assignmentFields: ModuleAssignmentField[]
+  fetcher?: typeof fetch
+  moduleId: string
+  values: AssignmentValues
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+async function readPayload(
+  response: Response
+): Promise<AssignmentSubmissionPayload | null> {
+  try {
+    const payload: unknown = await response.json()
+    return isRecord(payload) ? (payload as AssignmentSubmissionPayload) : null
+  } catch {
+    return null
+  }
+}
+
+function normalizeForComparison(value: unknown): unknown {
+  if (typeof value === "string") return value.trim()
+  if (Array.isArray(value)) return value.map(normalizeForComparison)
+  if (!isRecord(value)) return value
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      normalizeForComparison(entry),
+    ])
+  )
+}
+
+function persistedAnswersMatch({
+  assignmentFields,
+  attemptedValues,
+  persistedAnswers,
+}: {
+  assignmentFields: ModuleAssignmentField[]
+  attemptedValues: AssignmentValues
+  persistedAnswers: Record<string, unknown>
+}) {
+  const attempted = normalizeForComparison(
+    buildAssignmentValues(assignmentFields, attemptedValues)
+  ) as AssignmentValues
+  const persisted = normalizeForComparison(
+    buildAssignmentValues(assignmentFields, persistedAnswers)
+  ) as AssignmentValues
+  return assignmentValuesEqual(attempted, persisted)
+}
+
+function savedResult({
+  payload,
+  values,
+  message,
+}: {
+  payload: AssignmentSubmissionPayload | null
+  values: AssignmentValues
+  message?: string
+}): AssignmentSubmissionResult {
+  return {
+    saved: true,
+    answers:
+      payload?.answers && isRecord(payload.answers) ? payload.answers : values,
+    status: typeof payload?.status === "string" ? payload.status : "submitted",
+    updatedAt:
+      typeof payload?.updatedAt === "string" ? payload.updatedAt : null,
+    completeOnSubmit: Boolean(payload?.completeOnSubmit),
+    message:
+      message ??
+      (typeof payload?.warning === "string" && payload.warning.trim()
+        ? payload.warning
+        : "Saved."),
+  }
+}
+
+function responseError(payload: AssignmentSubmissionPayload | null) {
+  if (Array.isArray(payload?.missing) && payload.missing.length > 0) {
+    return `Please complete: ${payload.missing.join(", ")}`
+  }
+  if (typeof payload?.error === "string" && payload.error.trim()) {
+    return payload.error
+  }
+  return "Unable to save. Your answers remain on this device; try again."
+}
+
+async function recoverPersistedSubmission({
+  assignmentFields,
+  fetcher,
+  moduleId,
+  values,
+}: Required<
+  Pick<SubmitAssignmentParams, "assignmentFields" | "moduleId" | "values">
+> & {
+  fetcher: typeof fetch
+}): Promise<AssignmentSubmissionResult | null> {
+  try {
+    const response = await fetcher(
+      `/api/modules/${moduleId}/assignment-submission`,
+      {
+        method: "GET",
+        cache: "no-store",
+      }
+    )
+    if (!response.ok) return null
+
+    const payload = await readPayload(response)
+    if (
+      !payload?.answers ||
+      !isRecord(payload.answers) ||
+      !persistedAnswersMatch({
+        assignmentFields,
+        attemptedValues: values,
+        persistedAnswers: payload.answers,
+      })
+    ) {
+      return null
+    }
+
+    return savedResult({
+      payload,
+      values,
+      message: "Saved. Verified after a connection interruption.",
+    })
+  } catch {
+    return null
+  }
+}
+
+export async function submitAssignmentWithRecovery({
+  assignmentFields,
+  fetcher = fetch,
+  moduleId,
+  values,
+}: SubmitAssignmentParams): Promise<AssignmentSubmissionResult> {
+  let response: Response
+  try {
+    response = await fetcher(`/api/modules/${moduleId}/assignment-submission`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answers: values }),
+    })
+  } catch {
+    return (
+      (await recoverPersistedSubmission({
+        assignmentFields,
+        fetcher,
+        moduleId,
+        values,
+      })) ?? {
+        saved: false,
+        error: "Unable to save. Your answers remain on this device; try again.",
+      }
+    )
+  }
+
+  const payload = await readPayload(response)
+  if (response.ok) {
+    if (payload) return savedResult({ payload, values })
+    return (
+      (await recoverPersistedSubmission({
+        assignmentFields,
+        fetcher,
+        moduleId,
+        values,
+      })) ?? {
+        saved: false,
+        error:
+          "Unable to verify the save. Your answers remain on this device; try again.",
+      }
+    )
+  }
+
+  if (payload?.submissionSaved) {
+    return savedResult({
+      payload,
+      values,
+      message:
+        typeof payload.error === "string" && payload.error.trim()
+          ? payload.error
+          : "Saved. Organization details could not update.",
+    })
+  }
+
+  if (response.status >= 500) {
+    const recovered = await recoverPersistedSubmission({
+      assignmentFields,
+      fetcher,
+      moduleId,
+      values,
+    })
+    if (recovered) return recovered
+  }
+
+  return { saved: false, error: responseError(payload) }
+}

--- a/src/components/training/module-detail/use-assignment-submission.ts
+++ b/src/components/training/module-detail/use-assignment-submission.ts
@@ -9,7 +9,11 @@ import {
   buildAssignmentValues,
   type AssignmentValues,
 } from "./utils"
-import type { ModuleAssignmentField, ModuleAssignmentSubmission } from "@/lib/modules"
+import type {
+  ModuleAssignmentField,
+  ModuleAssignmentSubmission,
+} from "@/lib/modules"
+import { submitAssignmentWithRecovery } from "./assignment-submission-request"
 
 interface UseAssignmentSubmissionProps {
   assignmentFields: ModuleAssignmentField[]
@@ -30,14 +34,16 @@ export function useAssignmentSubmission({
   const [formSeed, setFormSeed] = useState<AssignmentValues>(initialFormValues)
   useEffect(() => {
     setFormSeed((prev) =>
-      assignmentValuesEqual(prev, initialFormValues) ? prev : initialFormValues,
+      assignmentValuesEqual(prev, initialFormValues) ? prev : initialFormValues
     )
   }, [initialFormValues])
 
   const [submissionStatus, setSubmissionStatus] = useState<string | null>(
-    submission?.status ?? null,
+    submission?.status ?? null
   )
-  const [lastSavedAt, setLastSavedAt] = useState<string | null>(submission?.updatedAt ?? null)
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(
+    submission?.updatedAt ?? null
+  )
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -58,73 +64,60 @@ export function useAssignmentSubmission({
       setIsSubmitting(true)
 
       try {
-        const response = await fetch(`/api/modules/${moduleId}/assignment-submission`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ answers: values }),
+        const result = await submitAssignmentWithRecovery({
+          assignmentFields: fieldsSnapshot,
+          moduleId,
+          values,
         })
 
-        if (!response.ok) {
-          let friendly = "Failed to submit assignment."
-          try {
-            const payload = await response.json()
-            if (Array.isArray(payload?.missing) && payload.missing.length > 0) {
-              friendly = `Please complete: ${payload.missing.join(", ")}`
-            } else if (typeof payload?.error === "string") {
-              friendly = payload.error
-            }
-          } catch {
-            // ignore parse errors
-          }
-          setError(friendly)
-          return
-        }
-
-        const data = (await response.json()) as {
-          answers?: Record<string, unknown>
-          status?: string | null
-          updatedAt?: string | null
-          completeOnSubmit?: boolean
+        if (!result.saved) {
+          setError(result.error)
+          return false
         }
 
         const normalizedAnswers = buildAssignmentValues(
           fieldsSnapshot,
-          data.answers ?? null,
+          result.answers
         )
         setFormSeed(normalizedAnswers)
 
-        const nextStatus = (data.status ?? "submitted") as string
+        const nextStatus = result.status
         setSubmissionStatus(nextStatus)
 
-        const savedAt = data.updatedAt ?? new Date().toISOString()
+        const savedAt = result.updatedAt ?? new Date().toISOString()
         setLastSavedAt(savedAt)
 
-        const autoComplete = Boolean(data.completeOnSubmit)
-        if (!options?.silent) {
+        const autoComplete = result.completeOnSubmit
+        if (result.message !== "Saved.") {
+          setMessage(result.message)
+        } else if (!options?.silent) {
           setMessage(
             autoComplete
               ? "Submission saved — this module is now marked complete."
-              : "Submission saved.",
+              : "Submission saved."
           )
         } else {
-          setMessage(null)
+          setMessage("Saved.")
         }
         setError(null)
 
         const shouldRefresh =
-          autoComplete ||
-          (!options?.silent && submissionStatus !== nextStatus)
+          autoComplete || (!options?.silent && submissionStatus !== nextStatus)
         if (shouldRefresh) {
           router.refresh()
         }
+        return true
       } catch (err) {
         console.error("Assignment submission failed", err)
-        setError("Unable to submit assignment. Please try again.")
+        setError(
+          "Unable to save. Your answers remain on this device; try again."
+        )
+        return false
       } finally {
         setIsSubmitting(false)
       }
     },
-    [assignmentFields, moduleId, router, submissionStatus],
+    [assignmentFields, moduleId, router, submissionStatus]
   )
 
   const statusMeta = useMemo(() => {

--- a/tests/acceptance/assignment-submission-resilience.test.ts
+++ b/tests/acceptance/assignment-submission-resilience.test.ts
@@ -1,0 +1,307 @@
+import { readFileSync } from "node:fs"
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AssignmentFormSubmitRow } from "@/components/training/module-detail/assignment-form/assignment-form-submit-row"
+import {
+  buildAssignmentDraft,
+  readAssignmentDraft,
+} from "@/components/training/module-detail/assignment-form/assignment-draft"
+import { submitAssignmentWithRecovery } from "@/components/training/module-detail/assignment-submission-request"
+import type { ModuleAssignmentField } from "@/lib/modules"
+import { createSupabaseServerClientServerMock } from "./test-utils"
+
+const fields: ModuleAssignmentField[] = [
+  {
+    name: "why",
+    label: "Why?",
+    type: "long_text",
+    required: false,
+  },
+]
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("assignment submission resilience", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("verifies a committed save after the POST response is lost", async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          answers: { why: "Start Dee's Resource Center" },
+          status: "submitted",
+          updatedAt: "2026-08-17T19:15:00.000Z",
+        })
+      )
+
+    const result = await submitAssignmentWithRecovery({
+      assignmentFields: fields,
+      fetcher: fetcher as typeof fetch,
+      moduleId: "module-1",
+      values: { why: "  Start Dee's Resource Center  " },
+    })
+
+    expect(result).toMatchObject({
+      saved: true,
+      message: "Saved. Verified after a connection interruption.",
+      status: "submitted",
+    })
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "/api/modules/module-1/assignment-submission",
+      { method: "GET", cache: "no-store" }
+    )
+  })
+
+  it("does not claim recovery when the persisted answers differ", async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Load failed"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          answers: { why: "Older answer" },
+          status: "submitted",
+        })
+      )
+
+    const result = await submitAssignmentWithRecovery({
+      assignmentFields: fields,
+      fetcher: fetcher as typeof fetch,
+      moduleId: "module-1",
+      values: { why: "New answer" },
+    })
+
+    expect(result).toEqual({
+      saved: false,
+      error: "Unable to save. Your answers remain on this device; try again.",
+    })
+  })
+
+  it("honors the legacy submissionSaved contract", async () => {
+    const result = await submitAssignmentWithRecovery({
+      assignmentFields: fields,
+      fetcher: vi.fn().mockResolvedValue(
+        jsonResponse(
+          {
+            error: "Homework saved, but organization details did not update.",
+            submissionSaved: true,
+          },
+          500
+        )
+      ) as typeof fetch,
+      moduleId: "module-1",
+      values: { why: "Safe answer" },
+    })
+
+    expect(result).toMatchObject({
+      saved: true,
+      answers: { why: "Safe answer" },
+      message: "Homework saved, but organization details did not update.",
+    })
+  })
+
+  it("recovers a committed save after a generic server error", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: "Internal error" }, 500))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          answers: { why: "Safe answer" },
+          status: "submitted",
+          updatedAt: "2026-08-17T19:15:00.000Z",
+        })
+      )
+
+    const result = await submitAssignmentWithRecovery({
+      assignmentFields: fields,
+      fetcher: fetcher as typeof fetch,
+      moduleId: "module-1",
+      values: { why: "Safe answer" },
+    })
+
+    expect(result).toMatchObject({
+      saved: true,
+      message: "Saved. Verified after a connection interruption.",
+    })
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps validation errors as failures without a recovery read", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(
+          { error: "Missing required answers", missing: ["Why?"] },
+          400
+        )
+      )
+
+    const result = await submitAssignmentWithRecovery({
+      assignmentFields: fields,
+      fetcher: fetcher as typeof fetch,
+      moduleId: "module-1",
+      values: { why: "" },
+    })
+
+    expect(result).toEqual({ saved: false, error: "Please complete: Why?" })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets current server answers outrank an unverifiable legacy draft", () => {
+    expect(
+      readAssignmentDraft({
+        initialValues: { why: "Saved server answer" },
+        raw: JSON.stringify({ values: { why: "Stale local answer" } }),
+      })
+    ).toBeNull()
+  })
+
+  it("restores a versioned draft only against the server state it started from", () => {
+    const raw = buildAssignmentDraft({
+      initialValues: { why: "Saved server answer" },
+      values: { why: "New unsaved draft" },
+    })
+
+    expect(
+      readAssignmentDraft({
+        initialValues: { why: "Saved server answer" },
+        raw,
+      })
+    ).toEqual({ why: "New unsaved draft" })
+    expect(
+      readAssignmentDraft({
+        initialValues: { why: "Newer server answer" },
+        raw,
+      })
+    ).toBeNull()
+  })
+
+  it("renders accessible save feedback and a retry action", () => {
+    const savedMarkup = renderToStaticMarkup(
+      React.createElement(AssignmentFormSubmitRow, {
+        isStepper: true,
+        hasMeta: true,
+        helperText: "Saved.",
+        errorMessage: null,
+        statusNote: null,
+        autoSaving: false,
+        nextHref: null,
+        currentStep: 1,
+        totalSteps: 2,
+        pending: false,
+        onRetry: () => undefined,
+      })
+    )
+    const errorMarkup = renderToStaticMarkup(
+      React.createElement(AssignmentFormSubmitRow, {
+        isStepper: true,
+        hasMeta: true,
+        helperText: null,
+        errorMessage: "Unable to save.",
+        statusNote: null,
+        autoSaving: false,
+        nextHref: null,
+        currentStep: 1,
+        totalSteps: 2,
+        pending: false,
+        onRetry: () => undefined,
+      })
+    )
+
+    expect(savedMarkup).toContain('aria-live="polite"')
+    expect(savedMarkup).toContain("Saved.")
+    expect(errorMarkup).toContain("Retry save")
+  })
+
+  it("keeps save feedback visible in the Workspace stepper", () => {
+    const formSource = readFileSync(
+      "src/components/training/module-detail/assignment-form.tsx",
+      "utf8"
+    )
+    const workspaceSource = readFileSync(
+      "src/features/workspace-accelerator-card/components/workspace-accelerator-step-node-card-body.tsx",
+      "utf8"
+    )
+
+    expect(workspaceSource).toContain("showStepNavigation={false}")
+    expect(formSource.match(/<AssignmentFormSubmitRow/g)).toHaveLength(2)
+    expect(formSource).toContain("onRetry={() => onSubmit(values)}")
+
+    const valuesHookSource = readFileSync(
+      "src/components/training/module-detail/assignment-form/hooks/use-assignment-form-values.ts",
+      "utf8"
+    )
+    expect(valuesHookSource).toContain("if (saved !== false)")
+  })
+
+  it("returns the authenticated user's persisted submission for reconciliation", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        answers: { why: "Saved server answer" },
+        status: "submitted",
+        updated_at: "2026-08-17T19:15:00.000Z",
+      },
+      error: null,
+    })
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle,
+    }
+    createSupabaseServerClientServerMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockReturnValue(chain),
+    })
+    const { GET } =
+      await import("@/app/api/modules/[id]/assignment-submission/route")
+
+    const response = await GET(new Request("https://example.test"), {
+      params: Promise.resolve({ id: "module-1" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      answers: { why: "Saved server answer" },
+      status: "submitted",
+      updatedAt: "2026-08-17T19:15:00.000Z",
+    })
+    expect(chain.eq).toHaveBeenNthCalledWith(1, "module_id", "module-1")
+    expect(chain.eq).toHaveBeenNthCalledWith(2, "user_id", "user-1")
+  })
+
+  it("rejects unauthenticated recovery reads", async () => {
+    createSupabaseServerClientServerMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+    })
+    const { GET } =
+      await import("@/app/api/modules/[id]/assignment-submission/route")
+
+    const response = await GET(new Request("https://example.test"), {
+      params: Promise.resolve({ id: "module-1" }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "Unauthorized" })
+  })
+})


### PR DESCRIPTION
## Summary

- reconcile assignment saves when the POST committed but its response was lost
- treat organization-profile sync as a secondary warning after homework is saved
- keep newer server answers above unverifiable legacy browser drafts
- show accessible save/error feedback and a retry control above stepper assignments
- avoid marking failed autosaves as submitted

## Root cause

The assignment upsert happens before secondary organization sync and before the browser receives a response. A connection interruption or secondary sync error could therefore persist the answers while the client reported failure. Workspace stepper feedback was below the fixed shell on mobile, failed autosaves were recorded as completed, and legacy local drafts could outrank hydrated server answers.

Read-only production diagnostics confirmed the likely customer still has all 12 Origin Story answers stored. No customer data changed.

## Validation

- `pnpm check:quality`
  - lint and all structural guardrails
  - snapshots
  - 2,152 acceptance tests passed; 1 skipped
  - focused signup, fiscal, Finance, and page-health RLS passed
  - 112-route production build and application TypeScript passed
  - 30 visual tests passed
  - performance budgets passed
- focused assignment resilience and MVV tests: 26/26 passed
- production-build browser fault injection:
  - committed POST response deliberately aborted
  - recovery GET verified the persisted answer
  - confirmation visible at y=197 on a 390x844 dark mobile viewport
  - reload hydrated the saved answer
  - internal QA submission restored exactly afterward

The optional connected generic RLS fixture is independently blocked in production Auth with `Database error creating new user`; all focused RLS suites passed.

## Risk and rollback

- no migration, Stripe change, subscription change, or customer-data mutation
- self-only recovery read remains protected by authentication and existing RLS
- rollback: revert this commit
