### PR TITLE
[STEP S87] Preserve workspace legacy deep links

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3869,6 +3869,7 @@
   system contention made the result non-representative. Clean hosted lanes are
   the remaining merge gate. No application, database, or production behavior
   changed.
+
 2026-08-18 14:36 EDT - retired the completed workspace foundation rollout gate.
 
 - Removed the fail-closed `WORKSPACE_FOUNDATION_ROLLOUT_ENABLED` configuration
@@ -3886,3 +3887,15 @@
   creating new user`; no migration or policy changed. No remote, production,
   customer-data, or existing dirty-worktree change occurred. Continue from
   `fix/remove-workspace-foundation-flag-20260818` for review and release.
+
+2026-08-18 15:44 EDT - preserved legacy workspace drawer deep links.
+
+- Updated the authenticated legacy `tab=documents` and `tab=roadmap`
+  redirects to retain their `focus` and `section` parameters when building the
+  canonical workspace drawer URL. Unrelated legacy tabs remain untouched.
+- Added exact regression cases for the Documents W-9 focus, Origin Story
+  roadmap section, and non-redirecting tabs. Focused tests passed `22/22`; the
+  full acceptance suite passed `2,155` tests with one intentional skip; targeted
+  ESLint, all pre-push guardrails, snapshots, and the 112-route production build
+  passed. No data, migration, authorization, or production configuration
+  changed. Continue from `fix/workspace-legacy-deeplink-params-20260818`.

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-content.tsx
@@ -79,7 +79,11 @@ export default async function MyOrganizationPage({
     tabParam: searchState.tabParam,
     viewParam: searchState.viewParam,
   })
-  redirectLegacyMyOrganizationTab(searchState.tabParam)
+  redirectLegacyMyOrganizationTab({
+    tabParam: searchState.tabParam,
+    focusParam: searchState.focusParam,
+    roadmapSectionParam: searchState.roadmapSectionParam,
+  })
   const acceleratorViewRequested = searchState.viewParam === "accelerator"
   const presentationMode =
     searchState.modeParam === "present" ||

--- a/src/app/(dashboard)/my-organization/_lib/my-organization-page-search.ts
+++ b/src/app/(dashboard)/my-organization/_lib/my-organization-page-search.ts
@@ -71,11 +71,32 @@ export async function resolveMyOrganizationPageSearchState(
   }
 }
 
-export function redirectLegacyMyOrganizationTab(tabParam: string) {
+type LegacyMyOrganizationTabRequest = {
+  tabParam: string
+  focusParam: string
+  roadmapSectionParam: string | null
+}
+
+export function getLegacyMyOrganizationTabDestination({
+  tabParam,
+  focusParam,
+  roadmapSectionParam,
+}: LegacyMyOrganizationTabRequest) {
   if (tabParam === "roadmap") {
-    redirect(getWorkspaceDrawerPath({ tab: "roadmap" }))
+    return getWorkspaceDrawerPath({
+      tab: "roadmap",
+      section: roadmapSectionParam,
+    })
   }
   if (tabParam === "documents") {
-    redirect(getWorkspaceDrawerPath({ tab: "documents" }))
+    return getWorkspaceDrawerPath({ tab: "documents", focus: focusParam })
   }
+  return null
+}
+
+export function redirectLegacyMyOrganizationTab(
+  request: LegacyMyOrganizationTabRequest
+) {
+  const destination = getLegacyMyOrganizationTabDestination(request)
+  if (destination) redirect(destination)
 }

--- a/tests/acceptance/workspace-routes.test.ts
+++ b/tests/acceptance/workspace-routes.test.ts
@@ -16,6 +16,7 @@ import {
   getWorkspaceRoadmapSectionPath,
   normalizeWorkspaceDrawerTab,
 } from "@/lib/workspace/routes"
+import { getLegacyMyOrganizationTabDestination } from "@/app/(dashboard)/my-organization/_lib/my-organization-page-search"
 
 const ROOT = process.cwd()
 
@@ -77,6 +78,30 @@ describe("workspace routes", () => {
     expect(getWorkspaceRoadmapDrawerPath("origin-story")).toBe(
       "/workspace?drawer=roadmap&section=origin-story"
     )
+  })
+
+  it("preserves legacy document and roadmap deep-link parameters", () => {
+    expect(
+      getLegacyMyOrganizationTabDestination({
+        tabParam: "documents",
+        focusParam: "w9",
+        roadmapSectionParam: null,
+      })
+    ).toBe("/workspace?drawer=documents&focus=w9")
+    expect(
+      getLegacyMyOrganizationTabDestination({
+        tabParam: "roadmap",
+        focusParam: "",
+        roadmapSectionParam: "origin-story",
+      })
+    ).toBe("/workspace?drawer=roadmap&section=origin-story")
+    expect(
+      getLegacyMyOrganizationTabDestination({
+        tabParam: "company",
+        focusParam: "mission",
+        roadmapSectionParam: null,
+      })
+    ).toBeNull()
   })
 
   it("builds the accelerator paywall link with a source", () => {


### PR DESCRIPTION
## Summary
- preserve `focus` when redirecting legacy Documents links
- preserve `section` when redirecting legacy Roadmap links
- add exact redirect regression coverage and leave unrelated tabs unchanged

## Validation
- focused workspace tests: 22/22
- acceptance: 2,155 passed, 1 skipped
- pre-push guardrails and snapshots passed
- targeted ESLint passed
- 112-route production build passed

## Risk and rollback
- navigation-only change
- no authorization, migration, data, or configuration change
- revert this commit to restore the prior redirect behavior