### PR TITLE
[STEP S87] Publish Core Documents to Find

### DIFF
--- a/docs/plans/2026-08-18-core-documents-publication-design.md
+++ b/docs/plans/2026-08-18-core-documents-publication-design.md
@@ -1,0 +1,50 @@
+# Core Documents publication design
+
+## Goal
+
+Make the six public-profile Core Documents the source of truth for the
+narrative fields shown on an organization's public `/find` profile. Their
+existing status control becomes an explicit publication control:
+
+- `Not started`: gray and private.
+- `Draft`: amber and private.
+- `Public`: green and visible on the public organization profile.
+
+## Approach
+
+Keep the stored `not_started`, `in_progress`, and `complete` values so existing
+roadmap, readiness, and workspace projections do not require a broad data
+migration. Present those values as `Not started`, `Draft`, and `Public` in Core
+Documents. Treat `complete` as the publication gate for the six public profile
+narratives: Origin Story, Need, Mission, Vision, Values, and Theory of Change.
+Other roadmap sections retain their existing progress labels because `/find`
+does not expose them.
+
+Existing public profile fields remain visible until a user activates the new
+publication control. This avoids a data migration and prevents the release from
+silently removing public content. On the first edit or status change, the
+application records that the Core Document is publication-controlled. Moving a
+public document to `Draft` retains its last public version while keeping the
+replacement private; moving it back to `Public` replaces that version. `Not
+started` unpublishes it.
+
+All six narrative write paths use the same roadmap sections. This includes the
+Core Documents editor, the organization profile editor, and mapped assignment
+answers. Existing root profile values remain as compatibility data but are no
+longer updated by those editors.
+
+## Save and cache flow
+
+Changing status saves the current editor draft and status together so `Public`
+never publishes an older autosaved version. Successful saves and deletes for
+the six public-profile sections invalidate the tagged public-organization cache
+and revalidate `/find`. Failed saves keep the local draft and show the existing
+error feedback.
+
+## Verification
+
+Focused acceptance coverage must prove legacy fallback, draft privacy, public
+projection, the three new labels with existing colors, atomic status saves, and
+public-map cache invalidation, last-public-version preservation, and canonical
+profile/assignment writes. Run focused lint and acceptance tests before the full
+quality gate.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3791,7 +3791,7 @@
   visuals, and performance budgets. The optional connected RLS fixture skipped
   without credentials. No visual, database, or production change occurred;
   preview, merge, deployment, and production device proof remain pending.
-2026-08-14 23:33 EDT - reconciled the visual Finance release plan with production.
+  2026-08-14 23:33 EDT - reconciled the visual Finance release plan with production.
 
 - Confirmed PR #200 merged as `9fda00d2`; main CI and both production
   deployments passed. Its prior live Maricopa dry run matched `3/3` without
@@ -3884,7 +3884,7 @@
   performance budgets passed.
 - Scoped signup, fiscal, Finance, and page-health RLS suites passed. The optional
   generic RLS fixture reached the existing Supabase Auth `Database error
-  creating new user`; no migration or policy changed. No remote, production,
+creating new user`; no migration or policy changed. No remote, production,
   customer-data, or existing dirty-worktree change occurred. Continue from
   `fix/remove-workspace-foundation-flag-20260818` for review and release.
 
@@ -3947,3 +3947,25 @@
 - No application, database, visual, deployment, production, or existing dirty
   checkout state changed. Continue from
   `chore/acceptance-test-projects-20260818` for complete gates and PR review.
+
+2026-08-18 17:35 EDT - preserved rich Core Documents through public profiles.
+
+- Resolved review findings that organization-profile hydration flattened rich
+  Origin Story, Need, and Theory of Change HTML and that publication controls
+  could display derived `Draft` after the user saved `Not started`. The profile
+  editor now keeps canonical rich HTML and existing images, while publication
+  controls display the persisted status.
+- Public `/find` organization stories now retain sanitized headings, emphasis,
+  lists, alignment, tables, links, and images. Image-only public documents remain
+  available; truly empty story fields and the entire empty story section are
+  omitted instead of opening to `Not provided yet.` The shared accordion
+  primitive was not changed, and collapsed images render only after expansion.
+- Bumped the public-organization cache key so deployment cannot reuse the old
+  plain-text projection. Server-side sanitization strips scripts and unsafe image
+  attributes before the lightweight public renderer receives content.
+- Full acceptance passed `2,168` tests with one intentional skip; lint, every
+  structural and React Grab guardrail, snapshots, focused RLS, the 112-route
+  production build, and all `30/30` visuals passed. Two final `/find` viewport
+  checks initially stopped behind the existing location-consent dialog and
+  passed immediately when rerun alone. `/find` measured `1873.3KB` against its
+  `1900KB` budget. No database, customer, or production data changed.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3888,6 +3888,30 @@
   customer-data, or existing dirty-worktree change occurred. Continue from
   `fix/remove-workspace-foundation-flag-20260818` for review and release.
 
+2026-08-18 14:48 EDT - connected Core Documents publication to Find profiles.
+
+- Confirmed roadmap saves wrote edited Core Documents without invalidating the
+  cached public-organization projection, while Origin Story, Need, and Theory of
+  Change still came from legacy profile fields.
+- Changed the six public-profile Core Documents to show `Not started`, `Draft`,
+  and `Public` while retaining their gray, amber, and green status colors. Other
+  roadmap sections retain their progress labels.
+- Public narrative fields now use saved roadmap content only when marked
+  `Public`, keep new drafts private, preserve existing public values without a
+  database migration, retain the last public version while a replacement is in
+  `Draft`, save draft content atomically with status changes, and refresh `/find`
+  after relevant saves or deletes.
+- Routed organization-profile and mapped-homework edits for all six narratives
+  through the same Core Document records so those older paths no longer bypass
+  the publication source of truth.
+- Final rebased pre-push quality passed every structural guardrail, snapshots,
+  and `2,163` acceptance tests with one intentional skip. Full-gate acceptance,
+  focused RLS, the 112-route build, and performance budgets also passed; one
+  unrelated visual stability timeout passed immediately when rerun alone. The
+  optional connected generic RLS suite skipped without isolated credentials.
+  Hosted CI, review, merge, deployment, and production proof remain pending; no
+  account data or production state changed.
+
 2026-08-18 15:44 EDT - preserved legacy workspace drawer deep links.
 
 - Updated the authenticated legacy `tab=documents` and `tab=roadmap`

--- a/src/actions/organization.ts
+++ b/src/actions/organization.ts
@@ -20,11 +20,14 @@ import { normalizeExternalUrl } from "@/lib/organization/urls"
 import {
   findOrganizationNarrativeRevisionConflict,
   normalizeOrganizationNarrativeHtml,
+  resolveOrganizationCoreDocuments,
   type OrganizationNarratives,
+  type OrganizationCoreDocuments,
   type OrganizationNarrativeRevisions,
   resolveOrganizationNarrativeRevisions,
   resolveOrganizationNarratives,
   updateOrganizationNarratives,
+  updateOrganizationCoreDocuments,
 } from "@/lib/roadmap"
 import {
   canEditOrganization,
@@ -161,6 +164,18 @@ export async function updateOrganizationProfileAction(
     if (normalized !== currentNarratives[key])
       narrativeUpdates[key] = normalized
   }
+  const currentCoreDocuments = resolveOrganizationCoreDocuments(current)
+  const coreDocumentUpdates: Partial<OrganizationCoreDocuments> = {}
+  for (const key of ["need", "originStory", "theoryOfChange"] as const) {
+    if (!Object.prototype.hasOwnProperty.call(payload, key)) continue
+    const value = payload[key]
+    const normalized = normalizeOrganizationNarrativeHtml(
+      typeof value === "string" ? value : ""
+    )
+    if (normalized !== currentCoreDocuments[key]) {
+      coreDocumentUpdates[key] = normalized
+    }
+  }
   const narrativeConflict = findOrganizationNarrativeRevisionConflict({
     profile: current,
     updates: narrativeUpdates,
@@ -190,6 +205,7 @@ export async function updateOrganizationProfileAction(
   for (const [k, v] of Object.entries(payload)) {
     if (k === "narrativeRevisions") continue
     if (k === "mission" || k === "vision" || k === "values") continue
+    if (k === "need" || k === "originStory" || k === "theoryOfChange") continue
     // Store EIN in both the column and profile for now (column is canonical)
     if (k === "ein") {
       next[k] = v ?? null
@@ -227,6 +243,7 @@ export async function updateOrganizationProfileAction(
   }
 
   next = updateOrganizationNarratives(next, narrativeUpdates).nextProfile
+  next = updateOrganizationCoreDocuments(next, coreDocumentUpdates).nextProfile
 
   const addressMapping: Array<[keyof OrgProfilePayload, string]> = [
     ["addressStreet", "address_street"],

--- a/src/actions/roadmap.ts
+++ b/src/actions/roadmap.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 
 import { sanitizeHtml } from "@/lib/markdown/sanitize"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
@@ -8,6 +8,7 @@ import type { Json } from "@/lib/supabase"
 import type { BudgetTableRow } from "@/lib/modules"
 import {
   ROADMAP_SECTION_LIMIT,
+  PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS,
   getOrganizationNarrativeKeyForSectionId,
   getRoadmapWorkspaceRevalidationPaths,
   normalizeOrganizationNarrativeHtml,
@@ -62,6 +63,14 @@ function revalidateRoadmapWorkspacePaths({
   })) {
     revalidatePath(path)
   }
+}
+
+function revalidatePublicOrganizationProfile(sectionId: string | null) {
+  if (!sectionId || !PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(sectionId)) {
+    return
+  }
+  revalidateTag("public-map-organizations", "max")
+  revalidatePath("/find")
 }
 
 export async function saveRoadmapSectionAction({
@@ -125,7 +134,8 @@ export async function saveRoadmapSectionAction({
     previousSection.lastUpdated !== expectedLastUpdated
   ) {
     return {
-      error: "This roadmap section was updated elsewhere. Reload before saving.",
+      error:
+        "This roadmap section was updated elsewhere. Reload before saving.",
     }
   }
 
@@ -200,6 +210,7 @@ export async function saveRoadmapSectionAction({
     publicSlug: orgRow?.public_slug,
     sectionSlug: section.slug,
   })
+  revalidatePublicOrganizationProfile(section.id)
 
   if (isNewSection) {
     const notifyResult = await createNotification(supabase, {
@@ -307,6 +318,7 @@ export async function deleteRoadmapSectionAction(
     publicSlug: orgRow?.public_slug,
     sectionSlug: previousSection?.slug,
   })
+  revalidatePublicOrganizationProfile(previousSection?.id ?? null)
 
   return { ok: true }
 }

--- a/src/app/(dashboard)/my-organization/_lib/helpers.ts
+++ b/src/app/(dashboard)/my-organization/_lib/helpers.ts
@@ -1,8 +1,9 @@
 import type { ModuleCardStatus } from "@/lib/accelerator/progress"
 import { normalizeOrganizationLocationFields } from "@/lib/location/organization-location"
 import {
+  organizationNarrativeHtmlToPlainText,
   resolveOrganizationNarrativeRevisions,
-  resolveOrganizationNarratives,
+  resolveOrganizationCoreDocuments,
 } from "@/lib/roadmap"
 import type {
   BrandTypographyConfig,
@@ -181,7 +182,7 @@ export function buildInitialOrganizationProfile({
     postal: profile["address_postal"],
     country: profile["address_country"],
   })
-  const narratives = resolveOrganizationNarratives(profile)
+  const coreDocuments = resolveOrganizationCoreDocuments(profile)
 
   return {
     name: String(profile["name"] ?? ""),
@@ -218,15 +219,15 @@ export function buildInitialOrganizationProfile({
     tiktok: String(profile["tiktok"] ?? ""),
     newsletter: String(profile["newsletter"] ?? ""),
     github: String(profile["github"] ?? ""),
-    vision: narratives.vision,
-    mission: narratives.mission,
-    need: String(profile["need"] ?? ""),
-    values: narratives.values,
-    originStory: String(
-      profile["originStory"] ?? profile["origin_story"] ?? ""
+    vision: coreDocuments.vision,
+    mission: coreDocuments.mission,
+    need: organizationNarrativeHtmlToPlainText(coreDocuments.need),
+    values: coreDocuments.values,
+    originStory: organizationNarrativeHtmlToPlainText(
+      coreDocuments.originStory
     ),
-    theoryOfChange: String(
-      profile["theoryOfChange"] ?? profile["theory_of_change"] ?? ""
+    theoryOfChange: organizationNarrativeHtmlToPlainText(
+      coreDocuments.theoryOfChange
     ),
     programs: String(profile["programs"] ?? ""),
     reports: String(profile["reports"] ?? ""),

--- a/src/app/(dashboard)/my-organization/_lib/helpers.ts
+++ b/src/app/(dashboard)/my-organization/_lib/helpers.ts
@@ -1,7 +1,6 @@
 import type { ModuleCardStatus } from "@/lib/accelerator/progress"
 import { normalizeOrganizationLocationFields } from "@/lib/location/organization-location"
 import {
-  organizationNarrativeHtmlToPlainText,
   resolveOrganizationNarrativeRevisions,
   resolveOrganizationCoreDocuments,
 } from "@/lib/roadmap"
@@ -221,14 +220,10 @@ export function buildInitialOrganizationProfile({
     github: String(profile["github"] ?? ""),
     vision: coreDocuments.vision,
     mission: coreDocuments.mission,
-    need: organizationNarrativeHtmlToPlainText(coreDocuments.need),
+    need: coreDocuments.need,
     values: coreDocuments.values,
-    originStory: organizationNarrativeHtmlToPlainText(
-      coreDocuments.originStory
-    ),
-    theoryOfChange: organizationNarrativeHtmlToPlainText(
-      coreDocuments.theoryOfChange
-    ),
+    originStory: coreDocuments.originStory,
+    theoryOfChange: coreDocuments.theoryOfChange,
     programs: String(profile["programs"] ?? ""),
     reports: String(profile["reports"] ?? ""),
     boilerplate: String(profile["boilerplate"] ?? ""),

--- a/src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts
+++ b/src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts
@@ -4,9 +4,9 @@ import {
   shouldStripOrgProfileHtml,
 } from "@/lib/organization/profile-cleanup"
 import {
-  isOrganizationNarrativeKey,
-  type OrganizationNarratives,
-  updateOrganizationNarratives,
+  getOrganizationCoreDocumentKey,
+  type OrganizationCoreDocuments,
+  updateOrganizationCoreDocuments,
 } from "@/lib/roadmap"
 
 import type { SupabaseServerClient } from "./types"
@@ -48,7 +48,7 @@ export async function syncMappedAnswersToOrganizationProfile({
     unknown
   >
   let nextProfile: Record<string, unknown> = { ...currentProfile }
-  const narrativeUpdates: Partial<OrganizationNarratives> = {}
+  const coreDocumentUpdates: Partial<OrganizationCoreDocuments> = {}
 
   for (const [fieldName, organizationKey] of Object.entries(orgKeyMapping)) {
     const value = sanitizedAnswers[fieldName]
@@ -70,8 +70,9 @@ export async function syncMappedAnswersToOrganizationProfile({
     }
 
     if (normalizedValue === null) continue
-    if (isOrganizationNarrativeKey(organizationKey)) {
-      narrativeUpdates[organizationKey] = Array.isArray(normalizedValue)
+    const coreDocumentKey = getOrganizationCoreDocumentKey(organizationKey)
+    if (coreDocumentKey) {
+      coreDocumentUpdates[coreDocumentKey] = Array.isArray(normalizedValue)
         ? normalizedValue.join("\n")
         : String(normalizedValue)
       continue
@@ -91,9 +92,9 @@ export async function syncMappedAnswersToOrganizationProfile({
     }
   }
 
-  nextProfile = updateOrganizationNarratives(
+  nextProfile = updateOrganizationCoreDocuments(
     nextProfile,
-    narrativeUpdates
+    coreDocumentUpdates
   ).nextProfile
 
   if (!organizationRow) {

--- a/src/app/api/modules/[id]/assignment-submission/route.ts
+++ b/src/app/api/modules/[id]/assignment-submission/route.ts
@@ -19,6 +19,12 @@ import { syncMappedAnswersToOrganizationProfile } from "./_lib/profile-sync"
 import { extractOrgKeyMappings, sanitizeAnswers } from "./_lib/sanitize"
 import type { AnswersPayload, ModuleMeta, SubmissionStatus } from "./_lib/types"
 
+async function revalidatePublicOrganizationProfile() {
+  const { revalidatePath, revalidateTag } = await import("next/cache")
+  revalidateTag("public-map-organizations", "max")
+  revalidatePath("/find")
+}
+
 export async function GET(
   _request: Request,
   context: { params: Promise<{ id: string }> }
@@ -190,6 +196,8 @@ export async function POST(
           profileSync.error
         )
         warning = "Saved. Organization details could not update."
+      } else {
+        await revalidatePublicOrganizationProfile()
       }
     }
   }

--- a/src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx
+++ b/src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx
@@ -1,14 +1,11 @@
 "use client"
 
 import { RichTextEditor } from "@/components/rich-text-editor"
-import { Textarea } from "@/components/ui/textarea"
-import { cn } from "@/lib/utils"
 
 import {
   FormRow,
   ProfileField,
 } from "@/components/organization/org-profile-card/shared"
-import { ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH } from "@/components/organization/org-profile-card/validation"
 import type { CompanyEditProps } from "../types"
 
 const STORY_FIELDS = [
@@ -53,51 +50,36 @@ const NARRATIVE_FIELDS = [
   },
 ] as const
 
-function StoryTextField({
+function StoryCoreDocumentField({
   company,
   errors,
   field,
-  onInputChange,
-}: Pick<CompanyEditProps, "company" | "errors" | "onInputChange"> & {
+  onUpdate,
+  onDirty,
+}: Pick<CompanyEditProps, "company" | "errors" | "onUpdate" | "onDirty"> & {
   field: (typeof STORY_FIELDS)[number] | typeof THEORY_FIELD
 }) {
   const value = company[field.name] ?? ""
   const error = errors[field.name] ?? ""
-  const count = value.length
-  const overLimit = count > ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH
 
   return (
     <ProfileField label={field.label} focusKey={field.name}>
-      <Textarea
-        id={field.name}
-        name={field.name}
+      <RichTextEditor
         value={value}
-        onChange={onInputChange}
-        rows={4}
-        maxLength={ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH}
+        onChange={(nextValue) => {
+          onUpdate({ [field.name]: nextValue })
+          onDirty()
+        }}
+        ariaLabel={field.label}
         placeholder={field.placeholder}
-        aria-invalid={Boolean(error)}
-        aria-describedby={`${field.name}-limit${error ? ` ${field.name}-error` : ""}`}
+        mode="compact"
+        minHeight={160}
+        maxHeight={360}
+        stableScrollbars
+        preserveImages
+        editorClassName="min-h-[160px]"
       />
-      <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
-        {error ? (
-          <p id={`${field.name}-error`} className="text-destructive">
-            {error}
-          </p>
-        ) : (
-          <span aria-hidden />
-        )}
-        <p
-          id={`${field.name}-limit`}
-          className={cn(
-            "text-muted-foreground ml-auto tabular-nums",
-            overLimit && "text-destructive font-medium"
-          )}
-        >
-          {count.toLocaleString()} /{" "}
-          {ORG_PROFILE_ROADMAP_TEXT_MAX_LENGTH.toLocaleString()}
-        </p>
-      </div>
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
     </ProfileField>
   )
 }
@@ -139,7 +121,6 @@ function StoryNarrativeField({
 export function StorySection({
   company,
   errors,
-  onInputChange,
   onUpdate,
   onDirty,
 }: CompanyEditProps) {
@@ -150,12 +131,13 @@ export function StorySection({
     >
       <div className="grid gap-4 md:grid-cols-2">
         {STORY_FIELDS.map((field) => (
-          <StoryTextField
+          <StoryCoreDocumentField
             key={field.name}
             company={company}
             errors={errors}
             field={field}
-            onInputChange={onInputChange}
+            onUpdate={onUpdate}
+            onDirty={onDirty}
           />
         ))}
         {NARRATIVE_FIELDS.map((field) => (
@@ -168,11 +150,12 @@ export function StorySection({
             onDirty={onDirty}
           />
         ))}
-        <StoryTextField
+        <StoryCoreDocumentField
           company={company}
           errors={errors}
           field={THEORY_FIELD}
-          onInputChange={onInputChange}
+          onUpdate={onUpdate}
+          onDirty={onDirty}
         />
       </div>
     </FormRow>

--- a/src/components/public/public-map-index/organization-detail-helpers.ts
+++ b/src/components/public/public-map-index/organization-detail-helpers.ts
@@ -17,6 +17,7 @@ import {
 import type { PublicMapOrganization } from "@/lib/queries/public-map-index"
 import { buildPublicMapResourceLinks } from "@/lib/public-map/resource-links"
 import type { PublicMapOrganizationResourceLink } from "@/lib/public-map/resource-links"
+import { stripHtml } from "@/lib/markdown/convert"
 
 export type PublicMapSocialKey = keyof Pick<
   PublicMapOrganization,
@@ -219,7 +220,13 @@ export function buildStoryFields(
       label: "Theory of change",
       value: normalizeText(organization.theoryOfChange),
     },
-  ]
+  ].filter((field) => hasRenderableNarrativeContent(field.value))
+}
+
+export function hasRenderableNarrativeContent(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  return stripHtml(trimmed).trim().length > 0 || /<img\b/i.test(trimmed)
 }
 
 export function buildContactRows(

--- a/src/components/public/public-map-index/organization-detail-sections.tsx
+++ b/src/components/public/public-map-index/organization-detail-sections.tsx
@@ -18,7 +18,6 @@ import { cn } from "@/lib/utils"
 
 import { PublicMapMediaImage } from "./media-image"
 import {
-  truncateAtWordBoundary,
   type OrganizationDetailContactRow,
   type OrganizationDetailStoryField,
 } from "./organization-detail-helpers"
@@ -38,8 +37,6 @@ type DetailBrandKitProps = {
 
 type DetailOriginProps = {
   storyFields: OrganizationDetailStoryField[]
-  expandedStoryFields: Record<string, boolean>
-  onToggleField: (fieldLabel: string) => void
 }
 
 export function OrganizationDetailBrandKitSection({
@@ -133,23 +130,14 @@ function OrganizationDetailLogoCard({
 
 export function OrganizationDetailOriginSection({
   storyFields,
-  expandedStoryFields,
-  onToggleField,
 }: DetailOriginProps) {
+  if (storyFields.length === 0) return null
+
   return (
     <section className={PUBLIC_MAP_DETAIL_SECTION_CLASSNAME}>
       <h3 className="text-base font-semibold">Organization story</h3>
       <Accordion type="single" collapsible className="mt-1 w-full">
         {storyFields.map((field) => {
-          const hasCopy = field.value.length > 0
-          const expanded = Boolean(expandedStoryFields[field.label])
-          const needsToggle = hasCopy && field.value.length > 260
-          const copy = hasCopy
-            ? expanded
-              ? field.value
-              : truncateAtWordBoundary(field.value, 260)
-            : "Not provided yet."
-
           return (
             <AccordionItem
               key={field.label}
@@ -160,29 +148,27 @@ export function OrganizationDetailOriginSection({
                 {field.label}
               </AccordionTrigger>
               <AccordionContent>
-                <p className="text-foreground text-sm leading-relaxed break-words whitespace-pre-wrap">
-                  {copy}
-                  {needsToggle ? (
-                    <>
-                      {" "}
-                      <Button
-                        type="button"
-                        variant="link"
-                        size="sm"
-                        className="text-primary h-auto px-0 py-0 text-sm"
-                        onClick={() => onToggleField(field.label)}
-                      >
-                        {expanded ? "View less" : "View more"}
-                      </Button>
-                    </>
-                  ) : null}
-                </p>
+                <OrganizationDetailStoryContent value={field.value} />
               </AccordionContent>
             </AccordionItem>
           )
         })}
       </Accordion>
     </section>
+  )
+}
+
+export function OrganizationDetailStoryContent({ value }: { value: string }) {
+  return (
+    <div
+      className={cn(
+        "prose prose-sm dark:prose-invert text-foreground max-w-none overflow-x-auto text-sm leading-relaxed break-words",
+        "prose-p:my-2 prose-ul:list-disc prose-ol:list-decimal prose-ul:pl-5 prose-ol:pl-5",
+        "prose-img:h-auto prose-img:max-w-full prose-img:rounded-xl prose-img:border prose-img:border-border/60"
+      )}
+      // Public narrative HTML is sanitized by resolvePublicOrganizationProfileNarratives.
+      dangerouslySetInnerHTML={{ __html: value }}
+    />
   )
 }
 

--- a/src/components/public/public-map-index/organization-detail.tsx
+++ b/src/components/public/public-map-index/organization-detail.tsx
@@ -61,9 +61,6 @@ export function PublicMapOrganizationDetail({
   compact = false,
 }: PublicMapOrganizationDetailProps) {
   const [aboutExpanded, setAboutExpanded] = useState(false)
-  const [expandedStoryFields, setExpandedStoryFields] = useState<
-    Record<string, boolean>
-  >({})
 
   const profileImageSrc =
     normalizeImageSrc(organization.logoUrl) ??
@@ -135,16 +132,7 @@ export function PublicMapOrganizationDetail({
         brandKitDownloadHref={brandKitDownloadHref}
       />
 
-      <OrganizationDetailOriginSection
-        storyFields={storyFields}
-        expandedStoryFields={expandedStoryFields}
-        onToggleField={(fieldLabel) =>
-          setExpandedStoryFields((previous) => ({
-            ...previous,
-            [fieldLabel]: !previous[fieldLabel],
-          }))
-        }
-      />
+      <OrganizationDetailOriginSection storyFields={storyFields} />
 
       <OrganizationDetailContactSection contactRows={contactRows} />
 

--- a/src/components/roadmap/roadmap-editor/components/roadmap-editor-shell.tsx
+++ b/src/components/roadmap/roadmap-editor/components/roadmap-editor-shell.tsx
@@ -7,6 +7,7 @@ import { RoadmapBudgetTableEditor } from "@/components/roadmap/roadmap-budget-ta
 import { RoadmapCalendar } from "@/components/roadmap/roadmap-calendar"
 import { RoadmapSectionPanel } from "@/components/roadmap/roadmap-section-panel"
 import type { RoadmapSection, RoadmapSectionStatus } from "@/lib/roadmap"
+import { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS } from "@/lib/roadmap/public-organization-profile-sections"
 
 import { DEFAULT_PLACEHOLDER, ROADMAP_TOOLBAR_ID } from "../constants"
 import type { RoadmapDraft } from "../types"
@@ -89,6 +90,7 @@ export function RoadmapEditorShell({
           subtitle={headerSubtitle}
           icon={SectionIcon}
           status={status}
+          controlsPublicProfile={PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(activeSection.id)}
           canEdit={canEdit}
           onStatusChange={onStatusChange}
           statusSelectDisabled={statusSelectDisabled}

--- a/src/components/roadmap/roadmap-editor/components/roadmap-editor-shell.tsx
+++ b/src/components/roadmap/roadmap-editor/components/roadmap-editor-shell.tsx
@@ -71,6 +71,10 @@ export function RoadmapEditorShell({
   savingId,
   sectionIcon: SectionIcon,
 }: RoadmapEditorShellProps) {
+  const controlsPublicProfile = PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(
+    activeSection.id
+  )
+
   return (
     <>
       {showRightRail ? (
@@ -89,8 +93,8 @@ export function RoadmapEditorShell({
           title={headerTitle}
           subtitle={headerSubtitle}
           icon={SectionIcon}
-          status={status}
-          controlsPublicProfile={PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(activeSection.id)}
+          status={controlsPublicProfile ? activeSection.status : status}
+          controlsPublicProfile={controlsPublicProfile}
           canEdit={canEdit}
           onStatusChange={onStatusChange}
           statusSelectDisabled={statusSelectDisabled}

--- a/src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts
+++ b/src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts
@@ -339,26 +339,52 @@ export function useRoadmapEditorState({
       if (!canEdit) return
       if (!activeSection) return
       if (savingId || isPending) return
+      const draft =
+        draftsRef.current[activeSection.id] ?? createDraft(activeSection)
+      const draftIsDirty = isRoadmapDraftDirty(activeSection, draft)
       setSavingId(activeSection.id)
       startTransition(async () => {
-        const result = await saveRoadmapSectionAction({
-          sectionId: activeSection.id,
-          status: nextStatus,
-        })
+        try {
+          const result = await saveRoadmapSectionAction({
+            sectionId: activeSection.id,
+            expectedLastUpdated: activeSection.lastUpdated,
+            status: nextStatus,
+            ...(draftIsDirty
+              ? {
+                  title: draft.title,
+                  subtitle: draft.subtitle,
+                  content: draft.content,
+                  budgetRows:
+                    activeSection.id === "budget"
+                      ? draft.budgetRows
+                      : undefined,
+                  imageUrl: draft.imageUrl,
+                }
+              : {}),
+          })
 
-        if ("error" in result) {
-          setSavingId(null)
-          toast.error(result.error)
-          return
-        }
+          if ("error" in result) {
+            toast.error(result.error)
+            return
+          }
 
-        const nextSection = result.section
-        setSections((prev) =>
-          prev.map((section) =>
-            section.id === nextSection.id ? nextSection : section
+          const nextSection = result.section
+          setSections((prev) =>
+            prev.map((section) =>
+              section.id === nextSection.id ? nextSection : section
+            )
           )
-        )
-        setSavingId(null)
+          setDrafts((prev) => ({
+            ...prev,
+            [nextSection.id]: createDraft(nextSection),
+          }))
+        } catch {
+          toast.error(
+            "The roadmap could not save. Your draft is still available; retry or refresh."
+          )
+        } finally {
+          setSavingId(null)
+        }
       })
     },
     [activeSection, canEdit, isPending, savingId]

--- a/src/components/roadmap/roadmap-section-panel.tsx
+++ b/src/components/roadmap/roadmap-section-panel.tsx
@@ -16,6 +16,7 @@ type RoadmapSectionPanelProps = {
   icon: ComponentType<{ className?: string }>
   headerControlsTop?: ReactNode
   status: RoadmapSectionStatus
+  controlsPublicProfile?: boolean
   canEdit?: boolean
   onStatusChange?: (status: RoadmapSectionStatus) => void
   statusSelectDisabled?: boolean
@@ -37,6 +38,7 @@ export function RoadmapSectionPanel({
   icon: Icon,
   headerControlsTop,
   status,
+  controlsPublicProfile = false,
   canEdit = true,
   onStatusChange,
   statusSelectDisabled = false,
@@ -52,8 +54,19 @@ export function RoadmapSectionPanel({
   editorProps,
 }: RoadmapSectionPanelProps) {
   const statusLabel = useMemo(
-    () => (status === "complete" ? "Complete" : status === "in_progress" ? "In progress" : "Not started"),
-    [status],
+    () =>
+      controlsPublicProfile
+        ? status === "complete"
+          ? "Public"
+          : status === "in_progress"
+            ? "Draft"
+            : "Not started"
+        : status === "complete"
+          ? "Complete"
+          : status === "in_progress"
+            ? "In progress"
+            : "Not started",
+    [controlsPublicProfile, status],
   )
   const statusDotClass = useMemo(
     () => (status === "complete" ? "bg-emerald-500" : status === "in_progress" ? "bg-amber-500" : "bg-border"),
@@ -114,7 +127,7 @@ export function RoadmapSectionPanel({
                 >
                   <SelectTrigger
                     className="h-7 rounded-full border border-border/60 bg-muted/40 px-2.5 text-xs font-medium text-muted-foreground shadow-none"
-                    aria-label="Roadmap section status"
+                    aria-label={controlsPublicProfile ? "Core document publication status" : "Roadmap section status"}
                   >
                     <span className="flex items-center gap-2">
                       <span aria-hidden className={cn("h-1.5 w-1.5 rounded-full", statusDotClass)} />
@@ -123,8 +136,8 @@ export function RoadmapSectionPanel({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="not_started">Not started</SelectItem>
-                    <SelectItem value="in_progress">In progress</SelectItem>
-                    <SelectItem value="complete">Complete</SelectItem>
+                    <SelectItem value="in_progress">{controlsPublicProfile ? "Draft" : "In progress"}</SelectItem>
+                    <SelectItem value="complete">{controlsPublicProfile ? "Public" : "Complete"}</SelectItem>
                   </SelectContent>
                 </Select>
               ) : (

--- a/src/lib/queries/public-map-index.ts
+++ b/src/lib/queries/public-map-index.ts
@@ -17,7 +17,10 @@ import {
   inferPublicMapGroups,
   type PublicMapGroupKey,
 } from "@/lib/public-map/groups"
-import { resolvePublicOrganizationProfileNarratives } from "@/lib/roadmap"
+import {
+  organizationNarrativeHtmlToPlainText,
+  resolvePublicOrganizationProfileNarratives,
+} from "@/lib/roadmap"
 
 export type PublicMapProgramPreview = {
   id: string
@@ -268,6 +271,8 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
       const profile = (row.profile ?? {}) as Record<string, unknown>
       const narratives = resolvePublicOrganizationProfileNarratives(profile)
       const { mission, vision, values } = narratives
+      const missionPlainText =
+        organizationNarrativeHtmlToPlainText(mission).trim()
       const programs = topProgramsByOrgId.get(row.user_id) ?? []
       const activityLinks = activityLinksByOrgId.get(row.user_id) ?? []
       const groups = inferPublicMapGroups({
@@ -280,7 +285,7 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
         description:
           typeof profile["description"] === "string"
             ? profile["description"].trim() || null
-            : mission || null,
+            : missionPlainText || null,
         programs: activityLinks,
       })
 
@@ -299,7 +304,8 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
         name: readProfileString(profile, "name") ?? "Organization",
         tagline: readProfileString(profile, "tagline"),
         description:
-          (readProfileString(profile, "description") ?? mission) || null,
+          (readProfileString(profile, "description") ?? missionPlainText) ||
+          null,
         boilerplate: readProfileString(profile, "boilerplate"),
         vision: vision || null,
         mission: mission || null,
@@ -404,7 +410,7 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
 const fetchPublicMapOrganizationsCached = unstable_cache(
   async (): Promise<PublicMapOrganization[]> =>
     fetchPublicMapOrganizationsUncached(),
-  ["public-map-organizations-v7"],
+  ["public-map-organizations-v8"],
   { revalidate: 300, tags: ["public-map-organizations"] }
 )
 

--- a/src/lib/queries/public-map-index.ts
+++ b/src/lib/queries/public-map-index.ts
@@ -17,7 +17,7 @@ import {
   inferPublicMapGroups,
   type PublicMapGroupKey,
 } from "@/lib/public-map/groups"
-import { resolveOrganizationNarrativePlainText } from "@/lib/roadmap"
+import { resolvePublicOrganizationProfileNarratives } from "@/lib/roadmap"
 
 export type PublicMapProgramPreview = {
   id: string
@@ -266,9 +266,8 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
   return orgRows
     .map((row) => {
       const profile = (row.profile ?? {}) as Record<string, unknown>
-      const mission = resolveOrganizationNarrativePlainText(profile, "mission")
-      const vision = resolveOrganizationNarrativePlainText(profile, "vision")
-      const values = resolveOrganizationNarrativePlainText(profile, "values")
+      const narratives = resolvePublicOrganizationProfileNarratives(profile)
+      const { mission, vision, values } = narratives
       const programs = topProgramsByOrgId.get(row.user_id) ?? []
       const activityLinks = activityLinksByOrgId.get(row.user_id) ?? []
       const groups = inferPublicMapGroups({
@@ -305,18 +304,9 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
         vision: vision || null,
         mission: mission || null,
         values: values || null,
-        needStatement: readProfileString(
-          profile,
-          "need",
-          "needStatement",
-          "need_statement"
-        ),
-        originStory: readProfileString(profile, "origin_story", "originStory"),
-        theoryOfChange: readProfileString(
-          profile,
-          "theory_of_change",
-          "theoryOfChange"
-        ),
+        needStatement: narratives.needStatement || null,
+        originStory: narratives.originStory || null,
+        theoryOfChange: narratives.theoryOfChange || null,
         formationStatus: readProfileFormationStatus(profile),
         contactName: readProfileString(
           profile,
@@ -414,7 +404,7 @@ async function fetchPublicMapOrganizationsUncached(): Promise<
 const fetchPublicMapOrganizationsCached = unstable_cache(
   async (): Promise<PublicMapOrganization[]> =>
     fetchPublicMapOrganizationsUncached(),
-  ["public-map-organizations-v6"],
+  ["public-map-organizations-v7"],
   { revalidate: 300, tags: ["public-map-organizations"] }
 )
 

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -5,6 +5,12 @@ export {
 } from "./roadmap/definitions"
 export { removeRoadmapSection, updateRoadmapSection } from "./roadmap/mutations"
 export {
+  getOrganizationCoreDocumentKey,
+  ORGANIZATION_CORE_DOCUMENT_SECTION_IDS,
+  resolveOrganizationCoreDocuments,
+  updateOrganizationCoreDocuments,
+} from "./roadmap/organization-core-documents"
+export {
   findOrganizationNarrativeRevisionConflict,
   getOrganizationNarrativeKeyForSectionId,
   isOrganizationNarrativeKey,
@@ -31,9 +37,17 @@ export {
   resolveRoadmapSections,
 } from "./roadmap/sections"
 export {
+  resolvePublicOrganizationProfileNarratives,
+} from "./roadmap/public-organization-profile"
+export { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS } from "./roadmap/public-organization-profile-sections"
+export {
   getRoadmapWorkspaceRevalidationPaths,
   resolveRoadmapSectionDerivedStatus,
 } from "./roadmap/helpers"
+export type {
+  OrganizationCoreDocumentKey,
+  OrganizationCoreDocuments,
+} from "./roadmap/organization-core-documents"
 export type {
   RoadmapHomeworkLink,
   RoadmapHomeworkStatus,
@@ -46,6 +60,7 @@ export type {
   OrganizationNarrativeRevisions,
   OrganizationNarratives,
 } from "./roadmap/organization-narratives"
+export type { PublicOrganizationProfileNarratives } from "./roadmap/public-organization-profile"
 export type {
   MvvMigrationAction,
   MvvMigrationPlan,
@@ -54,7 +69,4 @@ export type {
   MvvMigrationOrganizationReport,
   MvvMigrationRun,
 } from "./roadmap/mvv-migration-runner"
-export type {
-  MvvReviewExtract,
-  MvvReviewProposal,
-} from "./roadmap/mvv-review"
+export type { MvvReviewExtract, MvvReviewProposal } from "./roadmap/mvv-review"

--- a/src/lib/roadmap/helpers.ts
+++ b/src/lib/roadmap/helpers.ts
@@ -45,6 +45,8 @@ const STORED_SECTION_KEYS = new Set([
   "subtitle",
   "slug",
   "content",
+  "publishedContent",
+  "publicProfileStatusControlled",
   "budgetRows",
   "imageUrl",
   "lastUpdated",
@@ -138,6 +140,12 @@ export function buildRoadmapSection(
   const subtitleIsTemplate =
     effectiveStoredSubtitle.length === 0 && templateSubtitle.length > 0
   const content = typeof stored?.content === "string" ? stored.content : ""
+  const publishedContent =
+    typeof stored?.publishedContent === "string"
+      ? stored.publishedContent
+      : undefined
+  const publicProfileStatusControlled =
+    stored?.publicProfileStatusControlled === true ? true : undefined
   const budgetRows = normalizeRoadmapBudgetRows(stored?.budgetRows)
   const imageUrlRaw = normalizeText(stored?.imageUrl)
   const imageUrl = imageUrlRaw.length > 0 ? imageUrlRaw : undefined
@@ -196,6 +204,8 @@ export function buildRoadmapSection(
     prompt,
     placeholder,
     content,
+    publishedContent,
+    publicProfileStatusControlled,
     budgetRows,
     storageExtras,
     imageUrl,
@@ -281,6 +291,12 @@ export function serializeRoadmapSections(sections: RoadmapSection[]) {
     subtitle: section.subtitle,
     slug: section.slug,
     content: section.content,
+    ...(section.publishedContent !== undefined
+      ? { publishedContent: section.publishedContent }
+      : {}),
+    ...(section.publicProfileStatusControlled
+      ? { publicProfileStatusControlled: true }
+      : {}),
     ...(section.id === "budget" || (section.budgetRows?.length ?? 0) > 0
       ? { budgetRows: section.budgetRows ?? [] }
       : {}),

--- a/src/lib/roadmap/mutations.ts
+++ b/src/lib/roadmap/mutations.ts
@@ -11,6 +11,8 @@ import {
 import { resolveRoadmapSections } from "./sections"
 import type { RoadmapSection, RoadmapSectionStatus } from "./types"
 import type { BudgetTableRow } from "@/lib/modules"
+import { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS } from "./public-organization-profile-sections"
+import { resolveLegacyPublicProfileSectionContent } from "./public-profile-publication-state"
 
 export function updateRoadmapSection(
   profile: Record<string, unknown> | null | undefined,
@@ -82,6 +84,25 @@ export function updateRoadmapSection(
         : current.isPublic
     const nextLayout = updates.layout ?? current.layout
     const nextStatus = updates.status ?? current.status ?? "not_started"
+    let nextPublishedContent = current.publishedContent
+    let nextPublicProfileStatusControlled =
+      current.publicProfileStatusControlled
+    if (
+      (updates.status !== undefined || updates.content !== undefined) &&
+      PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(current.id)
+    ) {
+      nextPublicProfileStatusControlled = true
+      if (nextStatus === "complete" || nextStatus === "not_started") {
+        nextPublishedContent = undefined
+      } else if (!current.publicProfileStatusControlled) {
+        nextPublishedContent = resolveLegacyPublicProfileSectionContent(
+          nextProfile,
+          current
+        )
+      } else if (current.status === "complete") {
+        nextPublishedContent = current.content
+      }
+    }
     const nextCtaLabel =
       typeof updates.ctaLabel === "string" ? updates.ctaLabel : current.ctaLabel
     const nextCtaUrl =
@@ -96,6 +117,8 @@ export function updateRoadmapSection(
       title: nextTitle,
       subtitle: nextSubtitle,
       content: nextContent,
+      publishedContent: nextPublishedContent,
+      publicProfileStatusControlled: nextPublicProfileStatusControlled,
       budgetRows: nextBudgetRows,
       imageUrl: nextImageUrl,
       isPublic: nextIsPublic,
@@ -140,6 +163,9 @@ export function updateRoadmapSection(
         : nextContent.trim().length > 0
           ? "in_progress"
           : "not_started"
+    const controlsPublicProfile =
+      (updates.status !== undefined || updates.content !== undefined) &&
+      PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS.has(targetId)
     const nextCtaLabel =
       typeof updates.ctaLabel === "string" ? updates.ctaLabel : undefined
     const nextCtaUrl =
@@ -154,6 +180,7 @@ export function updateRoadmapSection(
           subtitle: nextSubtitle,
           slug: nextSlug,
           content: nextContent,
+          publicProfileStatusControlled: controlsPublicProfile || undefined,
           budgetRows: nextBudgetRows,
           imageUrl: nextImageUrl,
           isPublic: nextIsPublic,

--- a/src/lib/roadmap/organization-core-documents.ts
+++ b/src/lib/roadmap/organization-core-documents.ts
@@ -1,0 +1,143 @@
+import { normalizeOrganizationNarrativeHtml } from "./organization-narratives"
+import { updateRoadmapSection } from "./mutations"
+import { resolveRoadmapSections } from "./sections"
+import type { RoadmapSection } from "./types"
+
+export const ORGANIZATION_CORE_DOCUMENT_SECTION_IDS = {
+  originStory: "origin_story",
+  need: "need",
+  mission: "mission_vision_values",
+  vision: "vision",
+  values: "values",
+  theoryOfChange: "theory_of_change",
+} as const
+
+export type OrganizationCoreDocumentKey =
+  keyof typeof ORGANIZATION_CORE_DOCUMENT_SECTION_IDS
+
+export type OrganizationCoreDocuments = Record<
+  OrganizationCoreDocumentKey,
+  string
+>
+
+const CORE_DOCUMENT_KEYS = Object.keys(
+  ORGANIZATION_CORE_DOCUMENT_SECTION_IDS
+) as OrganizationCoreDocumentKey[]
+
+const PROFILE_KEY_TO_CORE_DOCUMENT = new Map<
+  string,
+  OrganizationCoreDocumentKey
+>([
+  ["originStory", "originStory"],
+  ["origin_story", "originStory"],
+  ["need", "need"],
+  ["needStatement", "need"],
+  ["need_statement", "need"],
+  ["mission", "mission"],
+  ["vision", "vision"],
+  ["values", "values"],
+  ["theoryOfChange", "theoryOfChange"],
+  ["theory_of_change", "theoryOfChange"],
+])
+
+function readLegacyValue(
+  profile: Record<string, unknown>,
+  key: OrganizationCoreDocumentKey
+): string {
+  const aliases: Record<OrganizationCoreDocumentKey, string[]> = {
+    originStory: ["originStory", "origin_story"],
+    need: ["need", "needStatement", "need_statement"],
+    mission: ["mission"],
+    vision: ["vision"],
+    values: ["values"],
+    theoryOfChange: ["theoryOfChange", "theory_of_change"],
+  }
+  for (const alias of aliases[key]) {
+    const value = profile[alias]
+    if (typeof value === "string" && value.trim()) return value.trim()
+    if (!Array.isArray(value)) continue
+    const joined = value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)
+      .join("\n")
+    if (joined) return joined
+  }
+  return ""
+}
+
+export function getOrganizationCoreDocumentKey(
+  profileKey: string
+): OrganizationCoreDocumentKey | null {
+  return PROFILE_KEY_TO_CORE_DOCUMENT.get(profileKey.trim()) ?? null
+}
+
+export function resolveOrganizationCoreDocuments(
+  profile: Record<string, unknown> | null | undefined
+): OrganizationCoreDocuments {
+  const normalizedProfile = profile ?? {}
+  const sectionById = new Map(
+    resolveRoadmapSections(normalizedProfile).map((section) => [
+      section.id,
+      section,
+    ])
+  )
+
+  return CORE_DOCUMENT_KEYS.reduce<OrganizationCoreDocuments>(
+    (result, key) => {
+      const section = sectionById.get(
+        ORGANIZATION_CORE_DOCUMENT_SECTION_IDS[key]
+      )
+      result[key] =
+        section &&
+        (section.content.trim().length > 0 || section.lastUpdated !== null)
+          ? section.content
+          : normalizeOrganizationNarrativeHtml(
+              readLegacyValue(normalizedProfile, key)
+            )
+      return result
+    },
+    {
+      originStory: "",
+      need: "",
+      mission: "",
+      vision: "",
+      values: "",
+      theoryOfChange: "",
+    }
+  )
+}
+
+export function updateOrganizationCoreDocuments(
+  profile: Record<string, unknown> | null | undefined,
+  updates: Partial<OrganizationCoreDocuments>
+): {
+  nextProfile: Record<string, unknown>
+  sections: Partial<Record<OrganizationCoreDocumentKey, RoadmapSection>>
+} {
+  let nextProfile = { ...(profile ?? {}) }
+  const sections: Partial<Record<OrganizationCoreDocumentKey, RoadmapSection>> =
+    {}
+
+  for (const key of CORE_DOCUMENT_KEYS) {
+    const content = updates[key]
+    if (typeof content !== "string") continue
+    const currentSection = resolveRoadmapSections(nextProfile).find(
+      (section) => section.id === ORGANIZATION_CORE_DOCUMENT_SECTION_IDS[key]
+    )
+    const result = updateRoadmapSection(
+      nextProfile,
+      ORGANIZATION_CORE_DOCUMENT_SECTION_IDS[key],
+      {
+        content: normalizeOrganizationNarrativeHtml(content),
+        status:
+          currentSection?.status === "not_started" && content.trim()
+            ? "in_progress"
+            : undefined,
+      }
+    )
+    nextProfile = result.nextProfile
+    sections[key] = result.section
+  }
+
+  return { nextProfile, sections }
+}

--- a/src/lib/roadmap/public-organization-profile-sections.ts
+++ b/src/lib/roadmap/public-organization-profile-sections.ts
@@ -1,0 +1,8 @@
+export const PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS = new Set([
+  "origin_story",
+  "need",
+  "mission_vision_values",
+  "vision",
+  "values",
+  "theory_of_change",
+])

--- a/src/lib/roadmap/public-organization-profile.ts
+++ b/src/lib/roadmap/public-organization-profile.ts
@@ -1,0 +1,85 @@
+import {
+  organizationNarrativeHtmlToPlainText,
+  resolveLegacyOrganizationNarratives,
+} from "./organization-narratives"
+import { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS } from "./public-organization-profile-sections"
+import { resolveRoadmapSections } from "./sections"
+import { resolveLegacyPublicProfileSectionContent } from "./public-profile-publication-state"
+
+export { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS }
+
+export type PublicOrganizationProfileNarratives = {
+  originStory: string
+  needStatement: string
+  mission: string
+  vision: string
+  values: string
+  theoryOfChange: string
+}
+
+function readLegacyProfileString(
+  profile: Record<string, unknown>,
+  ...keys: string[]
+) {
+  for (const key of keys) {
+    const value = profile[key]
+    if (typeof value !== "string") continue
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+  return ""
+}
+
+export function resolvePublicOrganizationProfileNarratives(
+  profile: Record<string, unknown> | null | undefined
+): PublicOrganizationProfileNarratives {
+  const normalizedProfile = profile ?? {}
+  const sectionById = new Map(
+    resolveRoadmapSections(normalizedProfile).map((section) => [
+      section.id,
+      section,
+    ])
+  )
+  const legacyNarratives =
+    resolveLegacyOrganizationNarratives(normalizedProfile)
+
+  const resolveSection = (sectionId: string, legacyValue: string) => {
+    const section = sectionById.get(sectionId)
+    if (!section || section.lastUpdated === null) {
+      return legacyValue
+    }
+    const content = section.publicProfileStatusControlled
+      ? section.status === "complete"
+        ? section.content
+        : section.publishedContent ?? ""
+      : resolveLegacyPublicProfileSectionContent(normalizedProfile, section)
+    return organizationNarrativeHtmlToPlainText(content).trim()
+  }
+
+  return {
+    originStory: resolveSection(
+      "origin_story",
+      readLegacyProfileString(normalizedProfile, "origin_story", "originStory")
+    ),
+    needStatement: resolveSection(
+      "need",
+      readLegacyProfileString(
+        normalizedProfile,
+        "need",
+        "needStatement",
+        "need_statement"
+      )
+    ),
+    mission: resolveSection("mission_vision_values", legacyNarratives.mission),
+    vision: resolveSection("vision", legacyNarratives.vision),
+    values: resolveSection("values", legacyNarratives.values),
+    theoryOfChange: resolveSection(
+      "theory_of_change",
+      readLegacyProfileString(
+        normalizedProfile,
+        "theory_of_change",
+        "theoryOfChange"
+      )
+    ),
+  }
+}

--- a/src/lib/roadmap/public-organization-profile.ts
+++ b/src/lib/roadmap/public-organization-profile.ts
@@ -1,5 +1,5 @@
 import {
-  organizationNarrativeHtmlToPlainText,
+  normalizeOrganizationNarrativeHtml,
   resolveLegacyOrganizationNarratives,
 } from "./organization-narratives"
 import { PUBLIC_ORGANIZATION_PROFILE_SECTION_IDS } from "./public-organization-profile-sections"
@@ -46,14 +46,14 @@ export function resolvePublicOrganizationProfileNarratives(
   const resolveSection = (sectionId: string, legacyValue: string) => {
     const section = sectionById.get(sectionId)
     if (!section || section.lastUpdated === null) {
-      return legacyValue
+      return normalizeOrganizationNarrativeHtml(legacyValue)
     }
     const content = section.publicProfileStatusControlled
       ? section.status === "complete"
         ? section.content
-        : section.publishedContent ?? ""
+        : (section.publishedContent ?? "")
       : resolveLegacyPublicProfileSectionContent(normalizedProfile, section)
-    return organizationNarrativeHtmlToPlainText(content).trim()
+    return normalizeOrganizationNarrativeHtml(content)
   }
 
   return {

--- a/src/lib/roadmap/public-profile-publication-state.ts
+++ b/src/lib/roadmap/public-profile-publication-state.ts
@@ -1,0 +1,45 @@
+import type { RoadmapSection } from "./types"
+
+function readProfileValue(
+  profile: Record<string, unknown>,
+  ...keys: string[]
+): string {
+  for (const key of keys) {
+    const value = profile[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+    if (!Array.isArray(value)) continue
+    const joined = value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)
+      .join("\n")
+    if (joined) return joined
+  }
+  return ""
+}
+
+export function resolveLegacyPublicProfileSectionContent(
+  profile: Record<string, unknown>,
+  section: RoadmapSection
+): string {
+  if (
+    section.id === "mission_vision_values" ||
+    section.id === "vision" ||
+    section.id === "values"
+  ) {
+    if (section.lastUpdated !== null) return section.content
+    return readProfileValue(
+      profile,
+      section.id === "mission_vision_values" ? "mission" : section.id
+    )
+  }
+  if (section.id === "origin_story") {
+    return readProfileValue(profile, "origin_story", "originStory")
+  }
+  if (section.id === "need") {
+    return readProfileValue(profile, "need", "needStatement", "need_statement")
+  }
+  if (section.id === "theory_of_change") {
+    return readProfileValue(profile, "theory_of_change", "theoryOfChange")
+  }
+  return ""
+}

--- a/src/lib/roadmap/types.ts
+++ b/src/lib/roadmap/types.ts
@@ -27,6 +27,8 @@ export type RoadmapHomeworkLink = {
 
 export type RoadmapSection = RoadmapSectionDefinition & {
   content: string
+  publishedContent?: string
+  publicProfileStatusControlled?: boolean
   budgetRows?: BudgetTableRow[]
   storageExtras?: Record<string, unknown>
   imageUrl?: string
@@ -49,6 +51,8 @@ export type StoredSection = {
   subtitle?: unknown
   slug?: unknown
   content?: unknown
+  publishedContent?: unknown
+  publicProfileStatusControlled?: unknown
   budgetRows?: unknown
   imageUrl?: unknown
   lastUpdated?: unknown

--- a/tests/acceptance/core-documents-publication.test.ts
+++ b/tests/acceptance/core-documents-publication.test.ts
@@ -1,0 +1,275 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveOrganizationCoreDocuments,
+  resolvePublicOrganizationProfileNarratives,
+  updateOrganizationCoreDocuments,
+  updateRoadmapSection,
+} from "@/lib/roadmap"
+
+const ROOT = process.cwd()
+
+function readSource(relativePath: string) {
+  return readFileSync(join(ROOT, relativePath), "utf8")
+}
+
+describe("Core Documents publication", () => {
+  it("keeps untouched legacy public-profile narratives visible", () => {
+    expect(
+      resolvePublicOrganizationProfileNarratives({
+        origin_story: "Legacy origin",
+        need: "Legacy need",
+        mission: "Legacy mission",
+        vision: "Legacy vision",
+        values: ["Care", "Trust"],
+        theory_of_change: "Legacy theory",
+      })
+    ).toEqual({
+      originStory: "Legacy origin",
+      needStatement: "Legacy need",
+      mission: "Legacy mission",
+      vision: "Legacy vision",
+      values: "Care\nTrust",
+      theoryOfChange: "Legacy theory",
+    })
+  })
+
+  it("keeps saved drafts off the public organization profile", () => {
+    const lastUpdated = "2026-08-18T18:00:00.000Z"
+
+    expect(
+      resolvePublicOrganizationProfileNarratives({
+        origin_story: "Previously public origin",
+        need: "Previously public need",
+        mission: "Previously public mission",
+        vision: "Previously public vision",
+        values: "Previously public values",
+        theory_of_change: "Previously public theory",
+        roadmap: {
+          sections: [
+            {
+              id: "origin_story",
+              content: "<p>Draft origin</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+            {
+              id: "need",
+              content: "<p>Draft need</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+            {
+              id: "mission_vision_values",
+              content: "<p>Draft mission</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+            {
+              id: "vision",
+              content: "<p>Draft vision</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+            {
+              id: "values",
+              content: "<p>Draft values</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+            {
+              id: "theory_of_change",
+              content: "<p>Draft theory</p>",
+              status: "in_progress",
+              lastUpdated,
+              publicProfileStatusControlled: true,
+            },
+          ],
+        },
+      })
+    ).toEqual({
+      originStory: "",
+      needStatement: "",
+      mission: "",
+      vision: "",
+      values: "",
+      theoryOfChange: "",
+    })
+  })
+
+  it("preserves the previous public version while a replacement is drafted", () => {
+    const initiallyPublic = updateRoadmapSection({}, "need", {
+      content: "<p>Current public need</p>",
+      status: "complete",
+    })
+    const drafting = updateRoadmapSection(initiallyPublic.nextProfile, "need", {
+      content: "<p>Private replacement</p>",
+      status: "in_progress",
+    })
+
+    expect(drafting.section.publishedContent).toBe("<p>Current public need</p>")
+    expect(
+      resolvePublicOrganizationProfileNarratives(drafting.nextProfile)
+        .needStatement
+    ).toBe("Current public need")
+
+    const republished = updateRoadmapSection(drafting.nextProfile, "need", {
+      status: "complete",
+    })
+    expect(republished.section.publishedContent).toBeUndefined()
+    expect(
+      resolvePublicOrganizationProfileNarratives(republished.nextProfile)
+        .needStatement
+    ).toBe("Private replacement")
+  })
+
+  it("keeps legacy public content stable when publication controls activate", () => {
+    const drafting = updateRoadmapSection(
+      { need: "Legacy public need" },
+      "need",
+      {
+        content: "<p>Private replacement</p>",
+        status: "in_progress",
+      }
+    )
+
+    expect(drafting.section.publicProfileStatusControlled).toBe(true)
+    expect(drafting.section.publishedContent).toBe("Legacy public need")
+    expect(
+      resolvePublicOrganizationProfileNarratives(drafting.nextProfile)
+        .needStatement
+    ).toBe("Legacy public need")
+  })
+
+  it("activates draft privacy when a legacy document is edited", () => {
+    const edited = updateRoadmapSection(
+      {
+        roadmap: {
+          sections: [
+            {
+              id: "mission_vision_values",
+              content: "<p>Current public mission</p>",
+              status: "in_progress",
+              lastUpdated: "2026-08-17T18:00:00.000Z",
+            },
+          ],
+        },
+      },
+      "mission_vision_values",
+      { content: "<p>Private replacement</p>" }
+    )
+
+    expect(edited.section.publicProfileStatusControlled).toBe(true)
+    expect(edited.section.publishedContent).toBe(
+      "<p>Current public mission</p>"
+    )
+    expect(
+      resolvePublicOrganizationProfileNarratives(edited.nextProfile).mission
+    ).toBe("Current public mission")
+  })
+
+  it("routes all six profile and homework narratives through Core Documents", () => {
+    const updated = updateOrganizationCoreDocuments(
+      { need: "Legacy need" },
+      {
+        originStory: "Origin",
+        need: "Need",
+        mission: "Mission",
+        vision: "Vision",
+        values: "Values",
+        theoryOfChange: "Theory",
+      }
+    )
+
+    expect(resolveOrganizationCoreDocuments(updated.nextProfile)).toEqual({
+      originStory: "<p>Origin</p>",
+      need: "<p>Need</p>",
+      mission: "<p>Mission</p>",
+      vision: "<p>Vision</p>",
+      values: "<p>Values</p>",
+      theoryOfChange: "<p>Theory</p>",
+    })
+
+    const organizationAction = readSource("src/actions/organization.ts")
+    const assignmentSync = readSource(
+      "src/app/api/modules/[id]/assignment-submission/_lib/profile-sync.ts"
+    )
+    const assignmentRoute = readSource(
+      "src/app/api/modules/[id]/assignment-submission/route.ts"
+    )
+    expect(organizationAction).toContain("updateOrganizationCoreDocuments")
+    expect(assignmentSync).toContain("getOrganizationCoreDocumentKey")
+    expect(assignmentSync).toContain("updateOrganizationCoreDocuments")
+    expect(assignmentRoute).toContain(
+      'revalidateTag("public-map-organizations", "max")'
+    )
+  })
+
+  it("projects public Core Documents into the public profile", () => {
+    const lastUpdated = "2026-08-18T18:00:00.000Z"
+    const section = (id: string, content: string) => ({
+      id,
+      content,
+      status: "complete",
+      lastUpdated,
+      publicProfileStatusControlled: true,
+    })
+
+    expect(
+      resolvePublicOrganizationProfileNarratives({
+        roadmap: {
+          sections: [
+            section("origin_story", "<p>Public <strong>origin</strong></p>"),
+            section("need", "<p>Public need</p>"),
+            section("mission_vision_values", "<p>Public mission</p>"),
+            section("vision", "<p>Public vision</p>"),
+            section("values", "<ul><li>Care</li><li>Trust</li></ul>"),
+            section("theory_of_change", "<p>Public theory</p>"),
+          ],
+        },
+      })
+    ).toEqual({
+      originStory: "Public origin",
+      needStatement: "Public need",
+      mission: "Public mission",
+      vision: "Public vision",
+      values: "- Care\n- Trust",
+      theoryOfChange: "Public theory",
+    })
+  })
+
+  it("uses the new labels, keeps colors, and refreshes the public map", () => {
+    const panel = readSource("src/components/roadmap/roadmap-section-panel.tsx")
+    const editor = readSource(
+      "src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts"
+    )
+    const action = readSource("src/actions/roadmap.ts")
+    const publicMapQuery = readSource("src/lib/queries/public-map-index.ts")
+
+    expect(panel).toContain(
+      '<SelectItem value="not_started">Not started</SelectItem>'
+    )
+    expect(panel).toContain('{controlsPublicProfile ? "Draft" : "In progress"}')
+    expect(panel).toContain('{controlsPublicProfile ? "Public" : "Complete"}')
+    expect(panel).toContain('"Core document publication status"')
+    expect(panel).toContain('status === "complete" ? "bg-emerald-500"')
+    expect(panel).toContain(
+      'status === "in_progress" ? "bg-amber-500" : "bg-border"'
+    )
+    expect(editor).toContain("expectedLastUpdated: activeSection.lastUpdated")
+    expect(editor).toContain("content: draft.content")
+    expect(action).toContain('revalidateTag("public-map-organizations", "max")')
+    expect(action).toContain('revalidatePath("/find")')
+    expect(publicMapQuery).toContain(
+      "resolvePublicOrganizationProfileNarratives(profile)"
+    )
+  })
+})

--- a/tests/acceptance/core-documents-publication.test.ts
+++ b/tests/acceptance/core-documents-publication.test.ts
@@ -28,12 +28,12 @@ describe("Core Documents publication", () => {
         theory_of_change: "Legacy theory",
       })
     ).toEqual({
-      originStory: "Legacy origin",
-      needStatement: "Legacy need",
-      mission: "Legacy mission",
-      vision: "Legacy vision",
-      values: "Care\nTrust",
-      theoryOfChange: "Legacy theory",
+      originStory: "<p>Legacy origin</p>",
+      needStatement: "<p>Legacy need</p>",
+      mission: "<p>Legacy mission</p>",
+      vision: "<p>Legacy vision</p>",
+      values: "<p>Care<br>Trust</p>",
+      theoryOfChange: "<p>Legacy theory</p>",
     })
   })
 
@@ -119,7 +119,7 @@ describe("Core Documents publication", () => {
     expect(
       resolvePublicOrganizationProfileNarratives(drafting.nextProfile)
         .needStatement
-    ).toBe("Current public need")
+    ).toBe("<p>Current public need</p>")
 
     const republished = updateRoadmapSection(drafting.nextProfile, "need", {
       status: "complete",
@@ -128,7 +128,7 @@ describe("Core Documents publication", () => {
     expect(
       resolvePublicOrganizationProfileNarratives(republished.nextProfile)
         .needStatement
-    ).toBe("Private replacement")
+    ).toBe("<p>Private replacement</p>")
   })
 
   it("keeps legacy public content stable when publication controls activate", () => {
@@ -146,7 +146,7 @@ describe("Core Documents publication", () => {
     expect(
       resolvePublicOrganizationProfileNarratives(drafting.nextProfile)
         .needStatement
-    ).toBe("Legacy public need")
+    ).toBe("<p>Legacy public need</p>")
   })
 
   it("activates draft privacy when a legacy document is edited", () => {
@@ -173,7 +173,7 @@ describe("Core Documents publication", () => {
     )
     expect(
       resolvePublicOrganizationProfileNarratives(edited.nextProfile).mission
-    ).toBe("Current public mission")
+    ).toBe("<p>Current public mission</p>")
   })
 
   it("routes all six profile and homework narratives through Core Documents", () => {
@@ -237,19 +237,55 @@ describe("Core Documents publication", () => {
         },
       })
     ).toEqual({
-      originStory: "Public origin",
-      needStatement: "Public need",
-      mission: "Public mission",
-      vision: "Public vision",
-      values: "- Care\n- Trust",
-      theoryOfChange: "Public theory",
+      originStory: "<p>Public <strong>origin</strong></p>",
+      needStatement: "<p>Public need</p>",
+      mission: "<p>Public mission</p>",
+      vision: "<p>Public vision</p>",
+      values: "<ul><li>Care</li><li>Trust</li></ul>",
+      theoryOfChange: "<p>Public theory</p>",
     })
+  })
+
+  it("preserves rich text and image-only public Core Documents", () => {
+    const narratives = resolvePublicOrganizationProfileNarratives({
+      roadmap: {
+        sections: [
+          {
+            id: "origin_story",
+            content:
+              '<h2 style="text-align:center">Our beginning</h2><p><em>Built together.</em></p>',
+            status: "complete",
+            lastUpdated: "2026-08-18T18:00:00.000Z",
+            publicProfileStatusControlled: true,
+          },
+          {
+            id: "need",
+            content:
+              '<img src="https://example.org/need.png" alt="Community need map" onerror="alert(1)"><script>alert(1)</script>',
+            status: "complete",
+            lastUpdated: "2026-08-18T18:00:00.000Z",
+            publicProfileStatusControlled: true,
+          },
+        ],
+      },
+    })
+
+    expect(narratives.originStory).toContain("<h2")
+    expect(narratives.originStory).toContain("<em>Built together.</em>")
+    expect(narratives.needStatement).toContain(
+      '<img src="https://example.org/need.png" alt="Community need map">'
+    )
+    expect(narratives.needStatement).not.toContain("onerror")
+    expect(narratives.needStatement).not.toContain("script")
   })
 
   it("uses the new labels, keeps colors, and refreshes the public map", () => {
     const panel = readSource("src/components/roadmap/roadmap-section-panel.tsx")
     const editor = readSource(
       "src/components/roadmap/roadmap-editor/hooks/use-roadmap-editor-state.ts"
+    )
+    const editorShell = readSource(
+      "src/components/roadmap/roadmap-editor/components/roadmap-editor-shell.tsx"
     )
     const action = readSource("src/actions/roadmap.ts")
     const publicMapQuery = readSource("src/lib/queries/public-map-index.ts")
@@ -266,10 +302,29 @@ describe("Core Documents publication", () => {
     )
     expect(editor).toContain("expectedLastUpdated: activeSection.lastUpdated")
     expect(editor).toContain("content: draft.content")
+    expect(editorShell).toContain(
+      "status={controlsPublicProfile ? activeSection.status : status}"
+    )
     expect(action).toContain('revalidateTag("public-map-organizations", "max")')
     expect(action).toContain('revalidatePath("/find")')
     expect(publicMapQuery).toContain(
       "resolvePublicOrganizationProfileNarratives(profile)"
     )
+  })
+
+  it("hydrates organization profile editors with canonical rich HTML", () => {
+    const helpers = readSource(
+      "src/app/(dashboard)/my-organization/_lib/helpers.ts"
+    )
+    const storyEditor = readSource(
+      "src/components/organization/org-profile-card/tabs/company-tab/edit-sections/story.tsx"
+    )
+
+    expect(helpers).not.toContain("organizationNarrativeHtmlToPlainText")
+    expect(helpers).toContain("need: coreDocuments.need")
+    expect(helpers).toContain("originStory: coreDocuments.originStory")
+    expect(storyEditor).toContain("<RichTextEditor")
+    expect(storyEditor).toContain("preserveImages")
+    expect(storyEditor).not.toContain("<Textarea")
   })
 })

--- a/tests/acceptance/mission-vision-values-unification.test.ts
+++ b/tests/acceptance/mission-vision-values-unification.test.ts
@@ -414,7 +414,7 @@ describe("Mission, Vision, and Values integration guardrails", () => {
     expect(route).toContain("organizationId: orgId")
     expect(route).toContain("submissionSaved: true")
     expect(route).not.toContain("organizationId: user.id")
-    expect(sync).toContain("updateOrganizationNarratives")
+    expect(sync).toContain("updateOrganizationCoreDocuments")
     expect(sync).toContain('.eq("updated_at", organizationRow.updated_at)')
   })
 

--- a/tests/acceptance/org-profile-story-contract.test.ts
+++ b/tests/acceptance/org-profile-story-contract.test.ts
@@ -3,12 +3,8 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 
 import { buildInitialOrganizationProfile } from "@/app/(dashboard)/my-organization/_lib/helpers"
-import {
-  resolveOrganizationProfileComplete as resolvePageProfileComplete,
-} from "@/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers"
-import {
-  resolveOrganizationProfileComplete as resolveWorkspaceSeedProfileComplete,
-} from "@/app/(dashboard)/my-organization/_lib/my-organization-workspace-seed-helpers"
+import { resolveOrganizationProfileComplete as resolvePageProfileComplete } from "@/app/(dashboard)/my-organization/_lib/my-organization-page-content-helpers"
+import { resolveOrganizationProfileComplete as resolveWorkspaceSeedProfileComplete } from "@/app/(dashboard)/my-organization/_lib/my-organization-workspace-seed-helpers"
 import { OrgProfilePublicAboutSection } from "@/components/organization/org-profile-card/public-card-sections"
 import { StorySection } from "@/components/organization/org-profile-card/tabs/company-tab/edit-sections/story"
 import { StoryPreview } from "@/components/organization/org-profile-card/tabs/company-tab/display-sections"
@@ -46,10 +42,12 @@ describe("organization profile story contract", () => {
       },
     })
 
-    expect(legacyProfile.originStory).toBe("Legacy origin story")
-    expect(legacyProfile.theoryOfChange).toBe("Legacy theory of change")
-    expect(currentProfile.originStory).toBe("Current origin story")
-    expect(currentProfile.theoryOfChange).toBe("Current theory of change")
+    expect(legacyProfile.originStory).toBe("<p>Legacy origin story</p>")
+    expect(legacyProfile.theoryOfChange).toBe("<p>Legacy theory of change</p>")
+    expect(currentProfile.originStory).toBe("<p>Current origin story</p>")
+    expect(currentProfile.theoryOfChange).toBe(
+      "<p>Current theory of change</p>"
+    )
   })
 
   it("sanitizes and renders the added story fields in the internal and public profile views", () => {
@@ -58,8 +56,12 @@ describe("organization profile story contract", () => {
       theoryOfChange: "<strong>Pair coaching with shared tools.</strong>",
     })
 
-    expect(cleaned.nextProfile.originStory).toBe("Started in a church basement.")
-    expect(cleaned.nextProfile.theoryOfChange).toBe("Pair coaching with shared tools.")
+    expect(cleaned.nextProfile.originStory).toBe(
+      "Started in a church basement."
+    )
+    expect(cleaned.nextProfile.theoryOfChange).toBe(
+      "Pair coaching with shared tools."
+    )
 
     const company = {
       name: "Atlas Org",
@@ -114,7 +116,7 @@ describe("organization profile story contract", () => {
         company,
         addressLines: [],
         hasAnyBrandLink: false,
-      }),
+      })
     )
     const publicMarkup = renderToStaticMarkup(
       createElement(OrgProfilePublicAboutSection, {
@@ -125,7 +127,7 @@ describe("organization profile story contract", () => {
         vision: company.vision ?? "",
         values: company.values ?? "",
         theoryOfChange: company.theoryOfChange ?? "",
-      }),
+      })
     )
 
     expect(previewMarkup).toContain("Origin story")
@@ -157,7 +159,7 @@ describe("organization profile story contract", () => {
     expect(resolveWorkspaceSeedProfileComplete(profile)).toBe(true)
   })
 
-  it("shows story field limits and inline errors in edit mode", () => {
+  it("shows rich story fields and inline validation errors in edit mode", () => {
     const company = {
       name: "Atlas Org",
       description: "",
@@ -218,14 +220,11 @@ describe("organization profile story contract", () => {
         onAutoSave: async () => undefined,
         setSlugStatus: () => undefined,
         slugStatus: null,
-      }),
+      })
     )
 
     expect(markup).toContain("Origin story")
-    expect(markup).toContain("maxLength=\"20000\"")
-    expect(markup).toContain(`${company.originStory.length.toLocaleString()} / 20,000`)
     expect(markup).toContain("Origin story must be 20,000 characters or less.")
-    expect(markup).toContain("aria-invalid=\"true\"")
   })
 
   it("allows longer roadmap story fields while keeping a clear maximum", () => {
@@ -251,7 +250,7 @@ describe("organization profile story contract", () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.flatten().fieldErrors.originStory?.[0]).toBe(
-        "Origin story must be 20,000 characters or less.",
+        "Origin story must be 20,000 characters or less."
       )
     }
   })

--- a/tests/acceptance/projects.json
+++ b/tests/acceptance/projects.json
@@ -20,6 +20,7 @@
       "tests/acceptance/billing-checkout-button.test.ts",
       "tests/acceptance/board-reminders-cron-route.test.ts",
       "tests/acceptance/coaching-schedule-route.test.ts",
+      "tests/acceptance/core-documents-publication.test.ts",
       "tests/acceptance/devtools-audience.test.ts",
       "tests/acceptance/documents-banner.test.ts",
       "tests/acceptance/documents-index-sort-state.test.ts",

--- a/tests/acceptance/public-map-index-query.test.ts
+++ b/tests/acceptance/public-map-index-query.test.ts
@@ -209,8 +209,10 @@ describe("fetchPublicMapOrganizations", () => {
       city: "Brooklyn",
       state: "NY",
       country: "United States",
-      originStory: "Atlas began after local caregivers lost support access.",
-      theoryOfChange: "Pair trained neighbors with recurring care circles.",
+      originStory:
+        "<p>Atlas began after local caregivers lost support access.</p>",
+      theoryOfChange:
+        "<p>Pair trained neighbors with recurring care circles.</p>",
       programPreview: {
         activityKind: "Event",
         ctaLabel: "Join",
@@ -234,8 +236,9 @@ describe("fetchPublicMapOrganizations", () => {
       longitude: null,
       isOnlineOnly: true,
       locationUrl: "https://beacon.org/visit",
-      originStory: "Beacon launched from a mutual aid pilot.",
-      theoryOfChange: "Shared onboarding and referrals improve continuity.",
+      originStory: "<p>Beacon launched from a mutual aid pilot.</p>",
+      theoryOfChange:
+        "<p>Shared onboarding and referrals improve continuity.</p>",
       programPreview: {
         activityKind: "Web resource",
         ctaLabel: "Open",

--- a/tests/acceptance/public-map-organization-curation.test.ts
+++ b/tests/acceptance/public-map-organization-curation.test.ts
@@ -17,7 +17,7 @@ describe("public map organization curation", () => {
     expect(organizationAction).toContain(
       'revalidateTag("public-map-organizations", "max")'
     )
-    expect(publicMapQuery).toContain('["public-map-organizations-v7"]')
+    expect(publicMapQuery).toContain('["public-map-organizations-v8"]')
   })
 
   it("uses an admin-gated unpublish action instead of deleting org data", () => {

--- a/tests/acceptance/public-map-organization-curation.test.ts
+++ b/tests/acceptance/public-map-organization-curation.test.ts
@@ -17,7 +17,7 @@ describe("public map organization curation", () => {
     expect(organizationAction).toContain(
       'revalidateTag("public-map-organizations", "max")'
     )
-    expect(publicMapQuery).toContain('["public-map-organizations-v6"]')
+    expect(publicMapQuery).toContain('["public-map-organizations-v7"]')
   })
 
   it("uses an admin-gated unpublish action instead of deleting org data", () => {

--- a/tests/acceptance/public-map-organization-detail-helpers.test.ts
+++ b/tests/acceptance/public-map-organization-detail-helpers.test.ts
@@ -92,17 +92,27 @@ describe("buildStoryFields", () => {
     ])
   })
 
-  it("normalizes empty values to empty strings while preserving label order", () => {
+  it("omits empty story fields", () => {
     const fields = buildStoryFields(buildOrganization())
 
-    expect(fields.map((field) => field.label)).toEqual([
-      "Origin story",
-      "Need statement",
-      "Mission",
-      "Vision",
-      "Values",
-      "Theory of change",
+    expect(fields).toEqual([])
+  })
+
+  it("keeps image-only story fields while omitting empty markup", () => {
+    const fields = buildStoryFields(
+      buildOrganization({
+        originStory: "<p><br></p>",
+        needStatement:
+          '<img src="https://example.org/need.png" alt="Community need map">',
+      })
+    )
+
+    expect(fields).toEqual([
+      {
+        label: "Need statement",
+        value:
+          '<img src="https://example.org/need.png" alt="Community need map">',
+      },
     ])
-    expect(fields.every((field) => field.value === "")).toBe(true)
   })
 })

--- a/tests/acceptance/public-map-organization-detail-sections.test.ts
+++ b/tests/acceptance/public-map-organization-detail-sections.test.ts
@@ -6,6 +6,7 @@ import {
   OrganizationDetailActivitiesSection,
   OrganizationDetailBrandKitSection,
   OrganizationDetailOriginSection,
+  OrganizationDetailStoryContent,
 } from "@/components/public/public-map-index/organization-detail-sections"
 import { PublicMapOrganizationDetail } from "@/components/public/public-map-index/organization-detail"
 import { OrganizationDetailResourceLinksSection } from "@/components/public/public-map-index/organization-detail-resource-links-section"
@@ -151,17 +152,40 @@ describe("OrganizationDetailOriginSection", () => {
         storyFields: [
           {
             label: "Origin story",
-            value: "Started after repeated service gaps.",
+            value:
+              '<h2 style="text-align:center">Our beginning</h2><p><strong>Started</strong> after repeated service gaps.</p><img src="https://example.org/story.png" alt="Founding team">',
           },
         ],
-        expandedStoryFields: {},
-        onToggleField: () => {},
       })
     )
 
     expect(markup).toContain(">Organization story<")
     expect(markup).not.toContain(">Origin<")
     expect(markup).toContain("Origin story")
+  })
+
+  it("preserves sanitized rich layout and images after expansion", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(OrganizationDetailStoryContent, {
+        value:
+          '<h2 style="text-align:center">Our beginning</h2><p><strong>Started</strong> together.</p><img src="https://example.org/story.png" alt="Founding team">',
+      })
+    )
+
+    expect(markup).toContain('<h2 style="text-align:center">')
+    expect(markup).toContain("<strong>Started</strong>")
+    expect(markup).toContain('alt="Founding team"')
+  })
+
+  it("renders nothing when no public story fields have content", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(OrganizationDetailOriginSection, {
+        storyFields: [],
+      })
+    )
+
+    expect(markup).toBe("")
+    expect(markup).not.toContain("Not provided yet.")
   })
 })
 


### PR DESCRIPTION
## Summary
- rename the six public-profile Core Document statuses to Not started, Draft, and Public without changing their colors
- make Public project the saved document into `/find`, retain the last public version while a replacement is drafted, and preserve legacy public content without a data migration
- route organization-profile and mapped-homework narrative writes through the same Core Document records and invalidate the public map cache

## Safety
- isolated branch and worktree; original dirty worktree preserved
- no database migration or production-data write
- final rebased pre-push gate passed all guardrails, snapshots, and 2,163 acceptance tests with one intentional skip
- full-gate acceptance, focused RLS, 112-route build, and performance budgets passed; one unrelated visual stability timeout passed alone

## Release gates
- hosted parallel CI and Vercel preview
- non-author review
- preview QA: Draft stays private, Public appears on `/find`, Public to Draft retains the last public version
- production verification after merge before notifying the user that it is live