### PR TITLE
[STEP S81] Keep Find active total stable

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -3969,3 +3969,20 @@ creating new user`; no migration or policy changed. No remote, production,
   checks initially stopped behind the existing location-consent dialog and
   passed immediately when rerun alone. `/find` measured `1873.3KB` against its
   `1900KB` budget. No database, customer, or production data changed.
+
+2026-08-20 15:31 EDT - stabilized the public Find Active count.
+
+- Reproduced the count shrinking during cursor loading because the location
+  control derived it from currently loaded or filtered resources. The loader
+  now retains the first valid API `totalCount`, and the control displays that
+  complete public-resource total plus public organizations independently of
+  progressive loading, search, category, guide, or location filters.
+- Added a production-sized cursor regression proving later decreasing page
+  totals cannot replace the complete total. Five focused acceptance files
+  passed `68/68`; the full quality gate passed all guardrails, snapshots,
+  `2,175` acceptance tests with one intentional skip, focused RLS, the
+  112-route build, `30/30` visuals, and performance budgets. The optional
+  generic RLS fixture skipped without Supabase credentials.
+- No visual baseline, database, customer data, remote branch, main, deployment,
+  or production state changed. Continue from
+  `fix/find-stable-active-count-20260820` for commit, review, and release.

--- a/src/components/public/public-map-index.tsx
+++ b/src/components/public/public-map-index.tsx
@@ -128,7 +128,6 @@ export function PublicMapIndex({
     resolveInitialCameraTarget(initialOrganization)
   )
   const [authSheetOpen, setAuthSheetOpen] = useState(false)
-  const pendingAuthOrgId: string | null = null
   const [sidebarInsetLeft, setSidebarInsetLeft] = useState(0)
   const [initialViewportResolved, setInitialViewportResolved] = useState(false)
   const [mapLoadVersion, setMapLoadVersion] = useState(0)
@@ -153,9 +152,9 @@ export function PublicMapIndex({
     resourceItems,
     retry: retryResourceItems,
     status: resourceItemsLoadStatus,
+    totalResourceCount,
   } = usePublicMapResourceItems({ initialResourceItems, resourceItemsEndpoint })
   const deferredQuery = useDeferredValue(query)
-  const searchPending = deferredQuery !== query
   const {
     collectedResourceIds,
     favorites,
@@ -295,7 +294,7 @@ export function PublicMapIndex({
       searchParams,
       initialPublicSlug,
       selectedOrganization,
-      pendingAuthOrgId,
+      pendingAuthOrgId: null,
       setSelectedOrgId,
       setSidebarMode,
       setCameraTargetOrgId: handleSetCameraTargetOrgId,
@@ -394,13 +393,13 @@ export function PublicMapIndex({
   })
 
   useFocusPublicMapCameraTarget(mapRef, cameraTarget, organizationById)
-
   const directoryListItems =
     activeSearchContext?.items ?? filteredDirectoryListItems
   const mapSurface = (
     <PublicMapSurface
       containerRef={containerRef}
       sidebarMode={sidebarMode}
+      directoryCount={organizations.length + totalResourceCount}
       filteredItems={directoryListItems}
       filteredOrganizations={filteredOrganizations}
       selectedItemId={selectedListItemId}
@@ -420,7 +419,7 @@ export function PublicMapIndex({
       groupCounts={groupCounts}
       resourceItemsLoadStatus={resourceItemsLoadStatus}
       resourceItemsLoadError={resourceItemsLoadError}
-      searchPending={searchPending}
+      searchPending={deferredQuery !== query}
       searchContext={activeSearchContext}
       tokenAvailable={tokenAvailable}
       mapError={mapError}
@@ -444,6 +443,5 @@ export function PublicMapIndex({
       mapOverlay={memberOnboardingMapOverlay}
     />
   )
-
   return <PublicMapIndexChrome mapSurface={mapSurface} />
 }

--- a/src/components/public/public-map-index/map-surface.tsx
+++ b/src/components/public/public-map-index/map-surface.tsx
@@ -43,6 +43,7 @@ const PublicMapAuthSheet = dynamic(() =>
 type PublicMapSurfaceProps = {
   containerRef: RefObject<HTMLDivElement | null>
   sidebarMode: SidebarMode
+  directoryCount: number
   filteredItems: PublicMapListItem[]
   filteredOrganizations: PublicMapOrganization[]
   selectedItemId: string | null
@@ -97,6 +98,7 @@ type PublicMapSurfaceProps = {
 export function PublicMapSurface({
   containerRef,
   sidebarMode,
+  directoryCount,
   filteredItems,
   filteredOrganizations,
   selectedItemId,
@@ -274,7 +276,7 @@ export function PublicMapSurface({
           <div className="pointer-events-none absolute inset-0 hidden dark:block dark:bg-[linear-gradient(180deg,rgba(250,250,250,0.08),rgba(250,250,250,0.025)_28%,rgba(24,24,27,0.015)_58%,rgba(9,9,11,0.06))]" />
           <PublicMapLocationControl
             {...locationControl}
-            directoryCount={filteredItems.length}
+            directoryCount={directoryCount}
           />
 
           <div className="pointer-events-none absolute top-4 right-4 z-20 flex max-w-[min(24rem,calc(100vw-2rem))] flex-col items-end gap-2">

--- a/src/components/public/public-map-index/use-resource-map-items.ts
+++ b/src/components/public/public-map-index/use-resource-map-items.ts
@@ -15,7 +15,9 @@ export const PUBLIC_MAP_RESOURCE_ITEMS_UNAVAILABLE_ERROR =
 export type PublicMapResourceItemsLoadStatus = "loading" | "ready" | "error"
 
 type ResourceItemsLoad = {
-  listeners: Set<(items: ExternalResourceMapItem[]) => void>
+  listeners: Set<
+    (items: ExternalResourceMapItem[], totalCount: number | null) => void
+  >
   promise: Promise<ExternalResourceMapItem[]>
 }
 
@@ -25,6 +27,13 @@ const RESOURCE_ITEMS_PROGRESS_BATCH_SIZE = 1_000
 type FindResourceIndexPage = {
   hasMore?: unknown
   nextCursor?: unknown
+  totalCount?: unknown
+}
+
+function resolveFindResourceIndexTotalCount(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : null
 }
 
 function isFindResourceIndexItem(
@@ -106,7 +115,10 @@ export function clearPublicMapResourceItemsCache(endpoint?: string) {
 
 export function loadPublicMapResourceItems(
   endpoint: string,
-  onProgress?: (items: ExternalResourceMapItem[]) => void
+  onProgress?: (
+    items: ExternalResourceMapItem[],
+    totalCount: number | null
+  ) => void
 ) {
   const cached = resourceItemsLoadByEndpoint.get(endpoint)
   if (cached) {
@@ -114,13 +126,16 @@ export function loadPublicMapResourceItems(
     return cached.promise
   }
 
-  const listeners = new Set<(items: ExternalResourceMapItem[]) => void>()
+  const listeners = new Set<
+    (items: ExternalResourceMapItem[], totalCount: number | null) => void
+  >()
   if (onProgress) listeners.add(onProgress)
 
   const promise = (async () => {
     const resourceItems: ExternalResourceMapItem[] = []
     let pageEndpoint: string | null = endpoint
     let pageCount = 0
+    let totalCount: number | null = null
 
     while (pageEndpoint) {
       const response = await fetch(pageEndpoint, {
@@ -140,6 +155,9 @@ export function loadPublicMapResourceItems(
           ...payload.resourceItems.map(normalizeLoadedResourceItem)
         )
       }
+      totalCount ??= resolveFindResourceIndexTotalCount(
+        payload.page?.totalCount
+      )
 
       const nextCursor = payload.page?.nextCursor
       pageEndpoint =
@@ -156,7 +174,9 @@ export function loadPublicMapResourceItems(
         pageEndpoint === null ||
         resourceItems.length % RESOURCE_ITEMS_PROGRESS_BATCH_SIZE === 0
       if (shouldPublishProgress) {
-        for (const listener of listeners) listener([...resourceItems])
+        for (const listener of listeners) {
+          listener([...resourceItems], totalCount)
+        }
       }
     }
 
@@ -183,6 +203,9 @@ export function usePublicMapResourceItems({
   resourceItemsEndpoint?: string
 }) {
   const [resourceItems, setResourceItems] = useState(initialResourceItems)
+  const [totalResourceCount, setTotalResourceCount] = useState(
+    initialResourceItems.length
+  )
   const [status, setStatus] = useState<PublicMapResourceItemsLoadStatus>(
     resourceItemsEndpoint ? "loading" : "ready"
   )
@@ -192,6 +215,7 @@ export function usePublicMapResourceItems({
   useEffect(() => {
     if (resourceItemsEndpoint) return
     setResourceItems(initialResourceItems)
+    setTotalResourceCount(initialResourceItems.length)
     setStatus("ready")
     setError(null)
   }, [initialResourceItems, resourceItemsEndpoint])
@@ -206,13 +230,17 @@ export function usePublicMapResourceItems({
       setStatus("loading")
       setError(null)
       try {
-        const payload = await loadPublicMapResourceItems(endpoint, (items) => {
-          if (!cancelled) {
-            setResourceItems((currentItems) =>
-              mergeProgressiveResourceItems(currentItems, items)
-            )
+        const payload = await loadPublicMapResourceItems(
+          endpoint,
+          (items, totalCount) => {
+            if (!cancelled) {
+              setResourceItems((currentItems) =>
+                mergeProgressiveResourceItems(currentItems, items)
+              )
+              setTotalResourceCount(totalCount ?? items.length)
+            }
           }
-        })
+        )
         if (cancelled) return
         setResourceItems((currentItems) => {
           const alreadyPublished =
@@ -281,5 +309,5 @@ export function usePublicMapResourceItems({
     setLoadRequestId((current) => current + 1)
   }, [resourceItemsEndpoint])
 
-  return { error, resourceItems, retry, status }
+  return { error, resourceItems, retry, status, totalResourceCount }
 }

--- a/tests/acceptance/public-map-resource-items-client.test.ts
+++ b/tests/acceptance/public-map-resource-items-client.test.ts
@@ -165,19 +165,46 @@ describe("public map resource items client", () => {
             nextCursor: isFinalPage
               ? null
               : resourceItems[resourceItems.length - 1]?.id,
+            totalCount: 856 - page * pageSize,
           },
         })
       )
     }
 
     const progressCounts: number[] = []
+    const reportedTotalCounts: Array<number | null> = []
     const items = await loadPublicMapResourceItems(
       "/api/public/resource-map/index?limit=50&test=bounded-progress",
-      (loadedItems) => progressCounts.push(loadedItems.length)
+      (loadedItems, totalCount) => {
+        progressCounts.push(loadedItems.length)
+        reportedTotalCounts.push(totalCount)
+      }
     )
 
     expect(items).toHaveLength(856)
     expect(progressCounts).toEqual([50, 856])
+    expect(reportedTotalCounts).toEqual([856, 856])
+  })
+
+  it("keeps the map inventory total separate from filtered result lists", () => {
+    const indexSource = readFileSync(
+      join(process.cwd(), "src/components/public/public-map-index.tsx"),
+      "utf8"
+    )
+    const surfaceSource = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/public/public-map-index/map-surface.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(indexSource).toContain(
+      "directoryCount={organizations.length + totalResourceCount}"
+    )
+    expect(indexSource).toContain("filteredItems={directoryListItems}")
+    expect(surfaceSource).toContain("directoryCount={directoryCount}")
+    expect(surfaceSource).not.toContain("directoryCount={filteredItems.length}")
   })
 
   it("deduplicates selected resource detail loads", async () => {


### PR DESCRIPTION
## Summary

- retain the first valid resource API `totalCount` while cursor pages load
- show the complete public organization plus resource inventory independently of search, category, guide, and location filters
- replace the stale implementation from closed PR #199 with a narrow current-main diff

## Validation

- `pnpm check:quality`
- 2,175 acceptance tests passed with one intentional skip
- focused RLS and 112-route production build passed
- 30/30 visual tests and performance budgets passed
- mandatory pre-push gate passed again

## Release boundary

No database, customer data, visual baseline, deployment, production, or hCaptcha changes.