### PR TITLE
[STEP S86] Restrict Find claims to imported listings

### DIFF
--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -4452,5 +4452,7 @@ creating new user`; no migration or policy changed. No remote, production,
   writes. Lint, snapshots, all 2,208 acceptance cases, claim-specific RLS, build,
   performance budgets, and all 34 visual tests passed. The shared connected RLS
   runner alone stopped at the existing external user-fixture creation 500.
-- Graphify refreshed to 16,793 nodes and 47,420 edges. No commit, push, migration,
-  production submission, or deployment occurred.
+- Graphify refreshed to 16,793 nodes and 47,420 edges. Committed the isolated
+  change as `b9d9b92b`, pushed `fix/find-claimable-listings`, and opened draft
+  PR #213; hosted checks were pending at handoff. No migration, production
+  submission, or deployment occurred.

--- a/docs/runlog/2026-08.md
+++ b/docs/runlog/2026-08.md
@@ -4433,3 +4433,24 @@ creating new user`; no migration or policy changed. No remote, production,
   public resource index with one fixed published food resource, preserving the
   real UI path while making search-row assertions deterministic. The focused
   Playwright case and lint passed.
+
+2026-08-21 15:41 EDT - narrowed Find claims to unowned imported listings.
+
+- Created `fix/find-claimable-listings` from merged `origin/main`. Replaced the
+  map-page progressive-list scan with a dedicated debounced organization search
+  over the sanitized public resource view.
+- Claim search now returns deduplicated organization names only when the imported
+  listing has source evidence and no linked Coach House organization. Submission
+  revalidates the same conditions server-side and uses the canonical organization
+  name, so crafted requests cannot target user-created or already-linked profiles.
+- Removed the missing-nonprofit message intake. An unmatched search now links to
+  builder signup at `/sign-up?intent=build&source=find_claim`; existing historical
+  queue types remain readable, but the public submission schema accepts imported
+  resource organizations only.
+- Browser QA confirmed the mobile claim dialog, unique search results, and absence
+  of the removed intake. Invalid platform/new requests returned 400 without data
+  writes. Lint, snapshots, all 2,208 acceptance cases, claim-specific RLS, build,
+  performance budgets, and all 34 visual tests passed. The shared connected RLS
+  runner alone stopped at the existing external user-fixture creation 500.
+- Graphify refreshed to 16,793 nodes and 47,420 edges. No commit, push, migration,
+  production submission, or deployment occurred.

--- a/src/app/api/public/organization-claims/route.ts
+++ b/src/app/api/public/organization-claims/route.ts
@@ -2,10 +2,25 @@ import { NextResponse } from "next/server"
 
 import {
   isSameOriginRequest,
+  searchPublicMapClaimListings,
   submitPublicMapClaimRequest,
 } from "@/features/public-map-claims"
 
 const MAX_BODY_BYTES = 16_384
+
+export async function GET(request: Request) {
+  try {
+    const query = new URL(request.url).searchParams.get("query") ?? ""
+    const listingOptions = await searchPublicMapClaimListings(query)
+    return NextResponse.json({ listingOptions })
+  } catch (error) {
+    console.error("[public-map-claims] Search failed.", error)
+    return NextResponse.json(
+      { error: "Listing search is temporarily unavailable." },
+      { status: 503 }
+    )
+  }
+}
 
 export async function POST(request: Request) {
   if (!isSameOriginRequest(request)) {

--- a/src/components/public/public-map-index/directory-home.tsx
+++ b/src/components/public/public-map-index/directory-home.tsx
@@ -13,7 +13,6 @@ import {
   PublicMapResourceGuides,
   type PublicMapResourceGuide,
 } from "./resource-guides"
-import type { PublicMapListItem } from "./map-items-state"
 
 const PublicMapClaimDialog = lazy(() =>
   import("@/features/public-map-claims").then((module) => ({
@@ -21,38 +20,9 @@ const PublicMapClaimDialog = lazy(() =>
   }))
 )
 
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-function buildClaimListingOptions(items: PublicMapListItem[]) {
-  const options = items.flatMap((item) => {
-    const id =
-      item.itemType === "platform_organization"
-        ? item.organization.id
-        : item.resourceOrganizationId
-    if (!id || !UUID_PATTERN.test(id)) return []
-    return [
-      {
-        id,
-        name: item.title,
-        targetKind:
-          item.itemType === "platform_organization"
-            ? ("platform_organization" as const)
-            : ("resource_map_organization" as const),
-      },
-    ]
-  })
-  return [
-    ...new Map(
-      options.map((option) => [`${option.targetKind}:${option.id}`, option])
-    ).values(),
-  ]
-}
-
 export function PublicMapDirectoryHome({
   counts,
   featuredGuides,
-  items,
   onCategorySelect,
   onGuideSelect,
   onToggleSavedGuide,
@@ -61,7 +31,6 @@ export function PublicMapDirectoryHome({
 }: {
   counts: PublicMapGroupFilterCounts
   featuredGuides: PublicMapResourceGuide[]
-  items: PublicMapListItem[]
   onCategorySelect: (category: PublicMapGroupFilterKey) => void
   onGuideSelect: (guideId: string) => void
   onToggleSavedGuide?: (guideId: PublicMapResourceGuideId) => void
@@ -96,9 +65,7 @@ export function PublicMapDirectoryHome({
       ) : null}
       <div className="pt-1">
         <Suspense fallback={<div className="h-[76px]" aria-hidden />}>
-          <PublicMapClaimDialog
-            listingOptions={buildClaimListingOptions(items)}
-          />
+          <PublicMapClaimDialog />
         </Suspense>
       </div>
     </div>

--- a/src/components/public/public-map-index/sidebar-panels.tsx
+++ b/src/components/public/public-map-index/sidebar-panels.tsx
@@ -271,7 +271,6 @@ export function PublicMapDrawerSearchPanel({
         <PublicMapDirectoryHome
           counts={discoveryGroupCounts}
           featuredGuides={featuredGuides}
-          items={items}
           onCategorySelect={onActiveGroupChange}
           onGuideSelect={onGuideSelect ?? noopPublicMapSearchAction}
           onToggleSavedGuide={onToggleSavedGuide}

--- a/src/features/public-map-claims/actions.ts
+++ b/src/features/public-map-claims/actions.ts
@@ -6,6 +6,7 @@ import {
 } from "./server/actions"
 import { loadPublicMapClaimQueue as loadQueue } from "./server/loaders"
 import { submitPublicMapClaimRequest as submitClaim } from "./server/submission"
+import { searchPublicMapClaimListings as searchListings } from "./server/search"
 
 export async function loadPublicMapClaimQueue(options?: {
   limit?: number
@@ -19,6 +20,10 @@ export async function submitPublicMapClaimRequest(input: {
   value: unknown
 }) {
   return submitClaim(input)
+}
+
+export async function searchPublicMapClaimListings(query: string) {
+  return searchListings(query)
 }
 
 export async function retryPublicMapClaimDeliveryFormAction(

--- a/src/features/public-map-claims/components/index.ts
+++ b/src/features/public-map-claims/components/index.ts
@@ -1,4 +1,1 @@
-export {
-  PublicMapClaimDialog,
-  type PublicMapClaimListingOption,
-} from "./public-map-claim-dialog"
+export { PublicMapClaimDialog } from "./public-map-claim-dialog"

--- a/src/features/public-map-claims/components/public-map-claim-dialog.tsx
+++ b/src/features/public-map-claims/components/public-map-claim-dialog.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { useMemo, useRef, useState, type FormEvent } from "react"
+import Link from "next/link"
+import { useEffect, useRef, useState, type FormEvent } from "react"
 import ArrowUpRightIcon from "lucide-react/dist/esm/icons/arrow-up-right"
-import BuildingIcon from "lucide-react/dist/esm/icons/building-2"
-import PlusIcon from "lucide-react/dist/esm/icons/plus"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -14,56 +13,69 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/lib/toast"
 
-import type { PublicMapClaimTargetKind } from "../types"
+import type { PublicMapClaimListingOption } from "../types"
 
-export type PublicMapClaimListingOption = {
-  id: string
-  name: string
-  targetKind: Exclude<PublicMapClaimTargetKind, "new">
-}
-
-type ClaimMode = "claim" | "new"
+type ClaimListingSearchStatus = "idle" | "loading" | "ready" | "error"
 
 function createSubmissionKey() {
   return crypto.randomUUID()
 }
 
-export function PublicMapClaimDialog({
-  listingOptions,
-}: {
-  listingOptions: PublicMapClaimListingOption[]
-}) {
+export function PublicMapClaimDialog() {
   const [open, setOpen] = useState(false)
-  const [mode, setMode] = useState<ClaimMode>("claim")
   const [listingQuery, setListingQuery] = useState("")
+  const [listingOptions, setListingOptions] = useState<
+    PublicMapClaimListingOption[]
+  >([])
+  const [searchStatus, setSearchStatus] =
+    useState<ClaimListingSearchStatus>("idle")
   const [selectedListing, setSelectedListing] =
     useState<PublicMapClaimListingOption | null>(null)
   const [dirty, setDirty] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const submissionKeyRef = useRef(createSubmissionKey())
 
-  const filteredListings = useMemo(() => {
+  useEffect(() => {
     const query = listingQuery.trim().toLocaleLowerCase()
-    if (!query) return []
-    return listingOptions
-      .filter((listing) => listing.name.toLocaleLowerCase().includes(query))
-      .slice(0, 8)
-  }, [listingOptions, listingQuery])
+    if (query.length < 2 || selectedListing) return
 
-  function begin(nextMode: ClaimMode) {
-    setMode(nextMode)
+    const controller = new AbortController()
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = await fetch(
+          `/api/public/organization-claims?query=${encodeURIComponent(query)}`,
+          { signal: controller.signal }
+        )
+        const result = (await response.json().catch(() => null)) as {
+          listingOptions?: PublicMapClaimListingOption[]
+        } | null
+        if (!response.ok) throw new Error("Listing search failed.")
+        setListingOptions(
+          Array.isArray(result?.listingOptions) ? result.listingOptions : []
+        )
+        setSearchStatus("ready")
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return
+        setListingOptions([])
+        setSearchStatus("error")
+      }
+    }, 200)
+
+    return () => {
+      window.clearTimeout(timer)
+      controller.abort()
+    }
+  }, [listingQuery, selectedListing])
+
+  function begin() {
     setListingQuery("")
+    setListingOptions([])
+    setSearchStatus("idle")
     setSelectedListing(null)
     setDirty(false)
     submissionKeyRef.current = createSubmissionKey()
@@ -79,7 +91,7 @@ export function PublicMapClaimDialog({
     event.preventDefault()
     const form = event.currentTarget
     if (!form.reportValidity()) return
-    if (mode === "claim" && !selectedListing) {
+    if (!selectedListing) {
       form.querySelector<HTMLInputElement>("#claim-listing-search")?.focus()
       return
     }
@@ -91,12 +103,11 @@ export function PublicMapClaimDialog({
         body: JSON.stringify({
           claimantEmail: formData.get("claimantEmail"),
           claimantName: formData.get("claimantName"),
-          listingName:
-            selectedListing?.name ?? formData.get("listingName") ?? "",
+          listingName: selectedListing.name,
           message: formData.get("message"),
           submissionKey: submissionKeyRef.current,
-          targetId: selectedListing?.id ?? null,
-          targetKind: selectedListing?.targetKind ?? "new",
+          targetId: selectedListing.id,
+          targetKind: "resource_map_organization",
           website: formData.get("website"),
         }),
         headers: { "Content-Type": "application/json" },
@@ -131,48 +142,34 @@ export function PublicMapClaimDialog({
     }
   }
 
+  const showSearchStatus = listingQuery.trim().length >= 2 && !selectedListing
+  const noSearchResults =
+    searchStatus === "ready" && listingOptions.length === 0
+
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-auto w-full flex-col gap-0.5 rounded-xl py-4 text-center"
-          >
-            <span className="text-muted-foreground text-sm">
-              Have an NFP on Coach House?
-            </span>
-            <span className="flex items-center gap-1 text-sm font-medium">
-              Claim or manage it
-              <ArrowUpRightIcon aria-hidden className="size-3.5" />
-            </span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="center" className="w-64">
-          <DropdownMenuItem
-            className="min-h-11"
-            onSelect={() => begin("claim")}
-          >
-            <BuildingIcon aria-hidden />
-            Claim an existing listing
-          </DropdownMenuItem>
-          <DropdownMenuItem className="min-h-11" onSelect={() => begin("new")}>
-            <PlusIcon aria-hidden />
-            Add a missing nonprofit
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-auto w-full flex-col gap-0.5 rounded-xl py-4 text-center"
+        onClick={begin}
+      >
+        <span className="text-muted-foreground text-sm">
+          Have an NFP listed on Coach House?
+        </span>
+        <span className="flex items-center gap-1 text-sm font-medium">
+          Claim or manage it
+          <ArrowUpRightIcon aria-hidden className="size-3.5" />
+        </span>
+      </Button>
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-h-[min(44rem,calc(100dvh-2rem))] overflow-y-auto sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>
-              {mode === "claim" ? "Claim a listing" : "Add a nonprofit"}
-            </DialogTitle>
+            <DialogTitle>Claim a listing</DialogTitle>
             <DialogDescription>
-              Send a request for Coach House to review. This does not change
-              ownership or public access automatically.
+              Request access to an imported public listing. Coach House verifies
+              each request before changing ownership.
             </DialogDescription>
           </DialogHeader>
           <form
@@ -180,57 +177,65 @@ export function PublicMapClaimDialog({
             onChange={() => setDirty(true)}
             onSubmit={handleSubmit}
           >
-            {mode === "claim" ? (
-              <div className="grid gap-2">
-                <Label htmlFor="claim-listing-search">Nonprofit</Label>
-                <Input
-                  id="claim-listing-search"
-                  value={selectedListing?.name ?? listingQuery}
-                  onChange={(event) => {
-                    setSelectedListing(null)
-                    setListingQuery(event.target.value)
-                  }}
-                  autoComplete="off"
-                  placeholder="Search listings"
-                  required
-                />
-                {filteredListings.length > 0 && !selectedListing ? (
-                  <div className="bg-popover grid max-h-48 overflow-y-auto rounded-md border p-1 shadow-sm">
-                    {filteredListings.map((listing) => (
-                      <button
-                        key={`${listing.targetKind}:${listing.id}`}
-                        type="button"
-                        className="hover:bg-accent focus-visible:bg-accent min-h-10 truncate rounded-sm px-2 text-left text-sm outline-none"
-                        onClick={() => {
-                          setSelectedListing(listing)
-                          setListingQuery(listing.name)
-                        }}
-                      >
-                        {listing.name}
-                      </button>
-                    ))}
-                  </div>
-                ) : null}
-                {listingQuery.trim() && filteredListings.length === 0 ? (
+            <div className="grid gap-2">
+              <Label htmlFor="claim-listing-search">Nonprofit</Label>
+              <Input
+                id="claim-listing-search"
+                value={selectedListing?.name ?? listingQuery}
+                onChange={(event) => {
+                  const query = event.target.value
+                  setSelectedListing(null)
+                  setListingOptions([])
+                  setListingQuery(query)
+                  setSearchStatus(query.trim().length >= 2 ? "loading" : "idle")
+                }}
+                autoComplete="off"
+                maxLength={80}
+                placeholder="Search listings…"
+                required
+              />
+              {listingOptions.length > 0 && !selectedListing ? (
+                <div className="bg-popover grid max-h-48 overflow-y-auto rounded-md border p-1 shadow-sm">
+                  {listingOptions.map((listing) => (
+                    <button
+                      key={listing.id}
+                      type="button"
+                      className="hover:bg-accent focus-visible:bg-accent min-h-11 truncate rounded-sm px-2 text-left text-sm outline-none"
+                      onClick={() => {
+                        setSelectedListing(listing)
+                        setListingQuery(listing.name)
+                        setSearchStatus("idle")
+                      }}
+                    >
+                      {listing.name}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              {showSearchStatus &&
+              (searchStatus === "loading" ||
+                searchStatus === "error" ||
+                noSearchResults) ? (
+                <div className="grid gap-1" role="status">
                   <p className="text-muted-foreground text-xs">
-                    No listing found. Close this form and choose Add a missing
-                    nonprofit.
+                    {searchStatus === "loading"
+                      ? "Searching imported listings…"
+                      : searchStatus === "error"
+                        ? "Unable to search listings. Try again."
+                        : "No claimable listing found."}
                   </p>
-                ) : null}
-              </div>
-            ) : (
-              <div className="grid gap-2">
-                <Label htmlFor="claim-listing-name">Nonprofit name</Label>
-                <Input
-                  id="claim-listing-name"
-                  name="listingName"
-                  minLength={2}
-                  maxLength={160}
-                  autoComplete="organization"
-                  required
-                />
-              </div>
-            )}
+                  {noSearchResults ? (
+                    <Link
+                      href="/sign-up?intent=build&source=find_claim"
+                      className="text-foreground focus-visible:ring-ring inline-flex min-h-11 items-center rounded-sm text-sm font-medium underline underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+                      onClick={() => setDirty(false)}
+                    >
+                      Create your nonprofit on Coach House
+                    </Link>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
             <div className="grid gap-2">
               <Label htmlFor="claim-name">Your name</Label>
               <Input

--- a/src/features/public-map-claims/index.ts
+++ b/src/features/public-map-claims/index.ts
@@ -3,11 +3,13 @@ export { PublicMapClaimDialog } from "./components"
 export {
   loadPublicMapClaimQueue,
   retryPublicMapClaimDeliveryFormAction,
+  searchPublicMapClaimListings,
   submitPublicMapClaimRequest,
   updatePublicMapClaimStatusFormAction,
 } from "./actions"
 export { isSameOriginRequest, parsePublicMapClaimInput } from "./lib"
 export type {
+  PublicMapClaimListingOption,
   PublicMapClaimQueue,
   PublicMapClaimRequest,
   PublicMapClaimStatus,

--- a/src/features/public-map-claims/lib/index.ts
+++ b/src/features/public-map-claims/lib/index.ts
@@ -1,35 +1,22 @@
 import { z } from "zod"
 
-export const publicMapClaimTargetKindSchema = z.enum([
-  "platform_organization",
-  "resource_map_organization",
-  "new",
-])
+export const publicMapClaimTargetKindSchema = z.literal(
+  "resource_map_organization"
+)
 
 const trimmedString = (minimum: number, maximum: number) =>
   z.string().trim().min(minimum).max(maximum)
 
-export const publicMapClaimInputSchema = z
-  .object({
-    targetKind: publicMapClaimTargetKindSchema,
-    targetId: z.string().uuid().nullable().optional(),
-    listingName: trimmedString(2, 160),
-    claimantName: trimmedString(2, 120),
-    claimantEmail: z.string().trim().email().max(254),
-    message: z.string().trim().max(2000).optional().default(""),
-    submissionKey: z.string().uuid(),
-    website: z.string().max(0).optional().default(""),
-  })
-  .superRefine((value, context) => {
-    const needsTarget = value.targetKind !== "new"
-    if (needsTarget !== Boolean(value.targetId)) {
-      context.addIssue({
-        code: "custom",
-        message: "Choose a valid listing.",
-        path: ["targetId"],
-      })
-    }
-  })
+export const publicMapClaimInputSchema = z.object({
+  targetKind: publicMapClaimTargetKindSchema,
+  targetId: z.string().uuid(),
+  listingName: trimmedString(2, 160),
+  claimantName: trimmedString(2, 120),
+  claimantEmail: z.string().trim().email().max(254),
+  message: z.string().trim().max(2000).optional().default(""),
+  submissionKey: z.string().uuid(),
+  website: z.string().max(0).optional().default(""),
+})
 
 export type PublicMapClaimInput = z.infer<typeof publicMapClaimInputSchema>
 

--- a/src/features/public-map-claims/server/search.ts
+++ b/src/features/public-map-claims/server/search.ts
@@ -1,0 +1,57 @@
+import { createSupabaseAdminClient } from "@/lib/supabase/admin"
+
+import type { PublicMapClaimListingOption } from "../types"
+
+const CLAIM_LISTING_SEARCH_LIMIT = 8
+const CLAIM_LISTING_CANDIDATE_LIMIT = 80
+
+function normalizeQuery(value: string) {
+  return value.trim().replace(/\s+/g, " ").slice(0, 80)
+}
+
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, "\\$&")
+}
+
+export async function searchPublicMapClaimListings(
+  value: string
+): Promise<PublicMapClaimListingOption[]> {
+  const query = normalizeQuery(value)
+  if (query.length < 2) return []
+
+  const admin = createSupabaseAdminClient()
+  const { data, error } = await admin
+    .from("resource_map_public_items")
+    .select("organization_id, organization_name, platform_org_id, source_label")
+    .is("platform_org_id", null)
+    .not("source_label", "is", null)
+    .ilike("organization_name", `%${escapeLikePattern(query)}%`)
+    .order("organization_name", { ascending: true })
+    .order("organization_id", { ascending: true })
+    .limit(CLAIM_LISTING_CANDIDATE_LIMIT)
+
+  if (error) throw new Error("Unable to search claimable listings.")
+
+  const options = new Map<string, PublicMapClaimListingOption>()
+  for (const row of data ?? []) {
+    const id = row.organization_id?.trim()
+    const name = row.organization_name?.trim()
+    if (!id || !name || row.platform_org_id || !row.source_label) continue
+    const nameKey = name.toLocaleLowerCase()
+    if (!options.has(nameKey)) options.set(nameKey, { id, name })
+  }
+
+  const normalizedQuery = query.toLocaleLowerCase()
+  return [...options.values()]
+    .sort((left, right) => {
+      const leftStarts = left.name
+        .toLocaleLowerCase()
+        .startsWith(normalizedQuery)
+      const rightStarts = right.name
+        .toLocaleLowerCase()
+        .startsWith(normalizedQuery)
+      if (leftStarts !== rightStarts) return leftStarts ? -1 : 1
+      return left.name.localeCompare(right.name)
+    })
+    .slice(0, CLAIM_LISTING_SEARCH_LIMIT)
+}

--- a/src/features/public-map-claims/server/submission.ts
+++ b/src/features/public-map-claims/server/submission.ts
@@ -14,6 +14,21 @@ type SubmitRpcResult = {
   status?: unknown
 }
 
+async function resolveClaimableListing(targetId: string) {
+  const admin = createSupabaseAdminClient()
+  const { data, error } = await admin
+    .from("resource_map_public_items")
+    .select("organization_id, organization_name, platform_org_id, source_label")
+    .eq("organization_id", targetId)
+    .is("platform_org_id", null)
+    .not("source_label", "is", null)
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data?.organization_name || !data.source_label) return null
+  return { id: data.organization_id, name: data.organization_name }
+}
+
 function asRecord(value: unknown) {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -67,12 +82,15 @@ export async function submitPublicMapClaimRequest({
     return { code: "invalid", ok: false }
   }
 
-  const input = parsed.data
+  const listing = await resolveClaimableListing(parsed.data.targetId)
+  if (!listing) return { code: "invalid", ok: false }
+
+  const input = { ...parsed.data, listingName: listing.name }
   const riskKey = hashPublicMapClaimRisk(
     `risk:${readPublicMapClaimRiskIdentity(request)}`
   )
   const emailTargetKey = hashPublicMapClaimRisk(
-    `email-target:${input.claimantEmail.toLowerCase()}:${input.targetKind}:${input.targetId ?? input.listingName.toLowerCase()}`
+    `email-target:${input.claimantEmail.toLowerCase()}:${input.targetKind}:${listing.id}`
   )
   if (!riskKey || !emailTargetKey) {
     return { code: "unavailable", ok: false }
@@ -81,7 +99,7 @@ export async function submitPublicMapClaimRequest({
   const admin = createSupabaseAdminClient()
   const { data, error } = await admin.rpc("submit_public_map_claim_request", {
     p_target_kind: input.targetKind,
-    p_target_id: input.targetId ?? null,
+    p_target_id: listing.id,
     p_listing_name: input.listingName,
     p_claimant_name: input.claimantName,
     p_claimant_email: input.claimantEmail,

--- a/src/features/public-map-claims/types.ts
+++ b/src/features/public-map-claims/types.ts
@@ -3,6 +3,11 @@ export type PublicMapClaimTargetKind =
   | "resource_map_organization"
   | "new"
 
+export type PublicMapClaimListingOption = {
+  id: string
+  name: string
+}
+
 export type PublicMapClaimStatus =
   | "new"
   | "reviewing"

--- a/tests/acceptance/public-map-claims.test.ts
+++ b/tests/acceptance/public-map-claims.test.ts
@@ -20,8 +20,8 @@ describe("public-map-claims feature contract", () => {
       listingName: "Neighborhood Pantry",
       message: "I founded this nonprofit.",
       submissionKey: "f9ff4f91-a252-46aa-b19d-c7b8b8bf2021",
-      targetKind: "new",
-      targetId: null,
+      targetKind: "resource_map_organization",
+      targetId: "a74bfebe-7af2-4980-a371-0a7967eda380",
       website: "",
     })
 
@@ -33,7 +33,18 @@ describe("public-map-claims feature contract", () => {
         listingName: "N",
         message: "x".repeat(2_001),
         submissionKey: "invalid",
+        targetKind: "resource_map_organization",
+        targetId: "not-a-uuid",
+      }).success
+    ).toBe(false)
+    expect(
+      parsePublicMapClaimInput({
+        claimantEmail: "person@example.org",
+        claimantName: "Casey Founder",
+        listingName: "Neighborhood Pantry",
+        submissionKey: "f9ff4f91-a252-46aa-b19d-c7b8b8bf2021",
         targetKind: "new",
+        targetId: null,
       }).success
     ).toBe(false)
   })
@@ -104,11 +115,23 @@ describe("public-map-claims feature contract", () => {
       "src/features/public-map-claims/server/loaders.ts"
     )
     const route = readSource("src/app/api/public/organization-claims/route.ts")
+    const search = readSource("src/features/public-map-claims/server/search.ts")
+    const submission = readSource(
+      "src/features/public-map-claims/server/submission.ts"
+    )
 
     expect(dialog).toContain("closeButton: true")
     expect(dialog).toContain("Discard this request?")
-    expect(dialog).toContain("Claim an existing listing")
-    expect(dialog).toContain("Add a missing nonprofit")
+    expect(dialog).toContain("Claim a listing")
+    expect(dialog).toContain('href="/sign-up?intent=build&source=find_claim"')
+    expect(dialog).toContain("?query=${encodeURIComponent(query)}")
+    expect(dialog).not.toContain("Add a missing nonprofit")
+    expect(search).toContain('.from("resource_map_public_items")')
+    expect(search).toContain('.is("platform_org_id", null)')
+    expect(search).toContain('.not("source_label", "is", null)')
+    expect(submission).toContain('.from("resource_map_public_items")')
+    expect(submission).toContain('.is("platform_org_id", null)')
+    expect(submission).toContain('.not("source_label", "is", null)')
     expect(loader).toContain("await requireAdmin()")
     expect(route).toContain("MAX_BODY_BYTES = 16_384")
     expect(route).toContain('"Retry-After"')


### PR DESCRIPTION
## Summary

- search only sourced public resource-map organizations without a linked Coach House organization
- deduplicate nonprofit names and revalidate ownership/source eligibility server-side before intake
- remove the missing-nonprofit message path and route unmatched organizations to builder signup
- keep historical claim queue rows readable while rejecting new public `platform_organization` and `new` targets

## Validation

- `pnpm lint`
- `pnpm test:snapshots`
- `pnpm test:acceptance` — 2,207 passed, 1 existing skip
- `pnpm test:rls:claims`
- `pnpm check:quality:build`
- `pnpm check:quality:visual` — 34 passed
- mobile browser QA for claim search, deduplication, removed intake, and signup fallback
- invalid platform/new POST smoke tests returned 400 without writes

## Known external limitation

The aggregate local quality command reached the shared connected RLS runner after claim-specific RLS passed, then the connected Supabase fixture service returned its existing 500 while creating a test user. Hosted RLS remains the authoritative retry.

## Data and deployment

- no migration
- no production claim submission
- no automatic ownership grant
- no deployment performed